### PR TITLE
feat(adapters): add adapter protocol, registry, loader, and session-schema adapter

### DIFF
--- a/src/raki/adapters/__init__.py
+++ b/src/raki/adapters/__init__.py
@@ -1,0 +1,14 @@
+from raki.adapters.loader import DatasetLoader, LoadError
+from raki.adapters.protocol import SessionAdapter
+from raki.adapters.redact import redact_sensitive
+from raki.adapters.registry import AdapterRegistry
+from raki.adapters.session_schema import SessionSchemaAdapter
+
+__all__ = [
+    "AdapterRegistry",
+    "DatasetLoader",
+    "LoadError",
+    "SessionAdapter",
+    "SessionSchemaAdapter",
+    "redact_sensitive",
+]

--- a/src/raki/adapters/loader.py
+++ b/src/raki/adapters/loader.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from raki.adapters.protocol import SessionAdapter
+from raki.adapters.registry import AdapterRegistry
+from raki.model import EvalDataset, EvalSample
+
+
+@dataclass
+class LoadError:
+    path: Path
+    error: str
+
+
+class DatasetLoader:
+    def __init__(self, registry: AdapterRegistry) -> None:
+        self._registry = registry
+        self.errors: list[LoadError] = []
+        self.skipped: list[Path] = []
+
+    def load_directory(self, root: Path) -> EvalDataset:
+        # Resolve to an absolute path to prevent trivial path traversal.
+        # Full manifest-level validation is deferred to the CLI/manifest layer (Issues #6/#8).
+        root = root.resolve()
+        samples: list[EvalSample] = []
+        self.errors = []
+        self.skipped = []
+        for child in sorted(root.iterdir()):
+            if not child.is_dir():
+                continue
+            adapter = self._detect_adapter(child)
+            if adapter is None:
+                self.skipped.append(child)
+                continue
+            try:
+                sample = adapter.load(child)
+                samples.append(sample)
+            except Exception as exc:
+                self.errors.append(LoadError(path=child, error=str(exc)))
+        return EvalDataset(samples=samples)
+
+    def load_session(self, path: Path, adapter_name: str | None = None) -> EvalSample:
+        path = path.resolve()
+        if adapter_name:
+            adapter = self._registry.get(adapter_name)
+            if adapter is None:
+                raise ValueError(f"Unknown adapter: {adapter_name}")
+        else:
+            adapter = self._detect_adapter(path)
+            if adapter is None:
+                raise ValueError(f"No adapter detected for {path}")
+        return adapter.load(path)
+
+    def _detect_adapter(self, path: Path) -> SessionAdapter | None:
+        for adapter in self._registry.list_all():
+            if adapter.detect(path):
+                return adapter
+        return None

--- a/src/raki/adapters/protocol.py
+++ b/src/raki/adapters/protocol.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from raki.model import EvalSample
+
+
+@runtime_checkable
+class SessionAdapter(Protocol):
+    name: str
+
+    def detect(self, source: Path) -> bool: ...
+    def load(self, source: Path) -> EvalSample: ...

--- a/src/raki/adapters/redact.py
+++ b/src/raki/adapters/redact.py
@@ -1,0 +1,3 @@
+def redact_sensitive(text: str) -> str:
+    """Stub -- full implementation in Task 3b (Issue #4)."""
+    return text

--- a/src/raki/adapters/registry.py
+++ b/src/raki/adapters/registry.py
@@ -1,0 +1,15 @@
+from raki.adapters.protocol import SessionAdapter
+
+
+class AdapterRegistry:
+    def __init__(self) -> None:
+        self._adapters: dict[str, SessionAdapter] = {}
+
+    def register(self, adapter: SessionAdapter) -> None:
+        self._adapters[adapter.name] = adapter
+
+    def get(self, name: str) -> SessionAdapter | None:
+        return self._adapters.get(name)
+
+    def list_all(self) -> list[SessionAdapter]:
+        return list(self._adapters.values())

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -1,0 +1,157 @@
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from raki.adapters.redact import redact_sensitive
+from raki.model import EvalSample, PhaseResult, ReviewFinding, SessionEvent, SessionMeta
+
+PHASE_NAMES = ["triage", "plan", "implement", "verify"]
+
+MAX_SESSION_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+
+
+def _read_bounded(path: Path) -> str:
+    """Read file contents, raising ValueError if the file exceeds MAX_SESSION_FILE_SIZE."""
+    file_size = path.stat().st_size
+    if file_size > MAX_SESSION_FILE_SIZE:
+        raise ValueError(
+            f"File {path} is {file_size} bytes, exceeding the {MAX_SESSION_FILE_SIZE} byte limit"
+        )
+    return path.read_text()
+
+
+def _validate_path(file_path: Path, session_dir: Path) -> None:
+    """Reject paths that escape the session directory (e.g. via symlinks)."""
+    resolved = file_path.resolve()
+    if not resolved.is_relative_to(session_dir.resolve()):
+        raise ValueError(
+            f"Path {file_path} resolves to {resolved}, which is outside "
+            f"session directory {session_dir.resolve()}"
+        )
+
+
+class SessionSchemaAdapter:
+    name: str = "session-schema"
+
+    def detect(self, source: Path) -> bool:
+        return (source / "meta.json").exists() and (source / "events.jsonl").exists()
+
+    def load(self, source: Path) -> EvalSample:
+        meta_path = source / "meta.json"
+        _validate_path(meta_path, source)
+        meta_raw: dict[str, Any] = json.loads(_read_bounded(meta_path))
+        session_id = str(meta_raw.get("ticket", source.name))
+        meta = SessionMeta(
+            session_id=session_id,
+            ticket=str(meta_raw.get("ticket")),
+            started_at=meta_raw["started_at"],
+            total_cost_usd=meta_raw.get("total_cost"),
+            total_phases=len(meta_raw.get("phases", {})),
+            rework_cycles=meta_raw.get("rework_cycles", 0),
+        )
+        phases = self._load_phases(source, meta_raw)
+        findings = self._load_findings(source)
+        events = self._load_events(source)
+        return EvalSample(session=meta, phases=phases, findings=findings, events=events)
+
+    def _load_phases(self, source: Path, meta_raw: dict[str, Any]) -> list[PhaseResult]:
+        phases: list[PhaseResult] = []
+        for phase_name in PHASE_NAMES:
+            phases.extend(self._load_phase_files(source, phase_name, meta_raw))
+        return phases
+
+    def _load_phase_files(
+        self, source: Path, phase_name: str, meta_raw: dict[str, Any]
+    ) -> list[PhaseResult]:
+        results: list[PhaseResult] = []
+        pattern = re.compile(rf"^{re.escape(phase_name)}\.json(\.\d+)?$")
+        matched_files = sorted(
+            [file_path for file_path in source.iterdir() if pattern.match(file_path.name)],
+            key=lambda file_path: file_path.name,
+        )
+        for file_path in matched_files:
+            _validate_path(file_path, source)
+            suffix_match = re.search(r"\.(\d+)$", file_path.name)
+            phase_meta = meta_raw.get("phases", {}).get(phase_name, {})
+            if suffix_match:
+                generation = int(suffix_match.group(1))
+            else:
+                generation = phase_meta.get("generation", 1)
+            try:
+                raw = json.loads(_read_bounded(file_path))
+            except json.JSONDecodeError:
+                continue
+            output_text = redact_sensitive(json.dumps(raw))
+            results.append(
+                PhaseResult(
+                    name=phase_name,
+                    generation=generation,
+                    status=phase_meta.get("status", "completed"),
+                    cost_usd=phase_meta.get("cost"),
+                    duration_ms=phase_meta.get("duration_ms"),
+                    output=output_text,
+                    output_structured=raw,
+                )
+            )
+        return results
+
+    def _load_findings(self, source: Path) -> list[ReviewFinding]:
+        findings: list[ReviewFinding] = []
+        pattern = re.compile(r"^review\.json(\.\d+)?$")
+        for file_path in sorted(source.iterdir()):
+            if not pattern.match(file_path.name):
+                continue
+            _validate_path(file_path, source)
+            try:
+                raw = json.loads(_read_bounded(file_path))
+            except json.JSONDecodeError:
+                continue
+            for finding_raw in raw.get("findings", []):
+                try:
+                    findings.append(
+                        ReviewFinding(
+                            reviewer=finding_raw.get("source", "unknown"),
+                            severity=finding_raw.get("severity", "minor"),
+                            file=finding_raw.get("file"),
+                            line=finding_raw.get("line"),
+                            issue=redact_sensitive(finding_raw["issue"]),
+                            suggestion=redact_sensitive(s)
+                            if (s := finding_raw.get("suggestion")) is not None
+                            else None,
+                        )
+                    )
+                except KeyError, ValueError:
+                    continue
+        return findings
+
+    def _load_events(self, source: Path) -> list[SessionEvent]:
+        events_file = source / "events.jsonl"
+        if not events_file.exists():
+            return []
+        _validate_path(events_file, source)
+        events: list[SessionEvent] = []
+        for line in _read_bounded(events_file).strip().splitlines():
+            if not line.strip():
+                continue
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            try:
+                events.append(
+                    SessionEvent(
+                        timestamp=raw["timestamp"],
+                        phase=raw.get("phase") or None,
+                        kind=raw["kind"],
+                        data={
+                            k: redact_sensitive(v) if isinstance(v, str) else v
+                            for k, v in raw.get("data", {}).items()
+                        },
+                    )
+                )
+            except KeyError, ValueError, ValidationError:
+                continue
+        return events

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,3 +30,9 @@ def pass_simple_dir(sessions_dir: Path) -> Path:
 def rework_cycle_dir(sessions_dir: Path) -> Path:
     """Return the path to the rework-cycle session fixture."""
     return sessions_dir / "rework-cycle"
+
+
+@pytest.fixture
+def malformed_dir(sessions_dir: Path) -> Path:
+    """Return the path to the malformed session fixture."""
+    return sessions_dir / "malformed"

--- a/tests/fixtures/sessions/malformed/meta.json
+++ b/tests/fixtures/sessions/malformed/meta.json
@@ -1,0 +1,1 @@
+not valid json{{{

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,110 @@
+"""Tests for the adapter layer: protocol, registry, loader, session-schema adapter."""
+
+import json
+from pathlib import Path
+
+from raki.adapters.loader import DatasetLoader
+from raki.adapters.registry import AdapterRegistry
+from raki.adapters.session_schema import SessionSchemaAdapter
+
+
+def test_session_schema_adapter_detects_valid_session(
+    pass_simple_dir: Path, rework_cycle_dir: Path
+):
+    adapter = SessionSchemaAdapter()
+    assert adapter.detect(pass_simple_dir)
+    assert adapter.detect(rework_cycle_dir)
+
+
+def test_session_schema_adapter_rejects_empty_dir(tmp_path):
+    adapter = SessionSchemaAdapter()
+    assert not adapter.detect(tmp_path)
+
+
+def test_session_schema_adapter_loads_pass_simple(pass_simple_dir: Path):
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(pass_simple_dir)
+    assert sample.session.session_id == "101"
+    assert sample.session.ticket == "101"
+    assert sample.session.rework_cycles == 0
+    assert sample.session.total_cost_usd == 12.5
+    assert len(sample.phases) >= 2
+    assert len(sample.findings) == 1
+    assert sample.findings[0].severity == "minor"
+    assert len(sample.events) == 10
+
+
+def test_session_schema_adapter_loads_rework_cycle(rework_cycle_dir: Path):
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(rework_cycle_dir)
+    assert sample.session.session_id == "53"
+    assert sample.session.rework_cycles == 2
+    implement_phases = [phase for phase in sample.phases if phase.name == "implement"]
+    assert len(implement_phases) == 2
+    gen_1 = [phase for phase in implement_phases if phase.generation == 1]
+    assert len(gen_1) == 1
+
+
+def test_session_schema_adapter_extracts_review_findings(rework_cycle_dir: Path):
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(rework_cycle_dir)
+    critical = [finding for finding in sample.findings if finding.severity == "critical"]
+    assert len(critical) == 1
+    assert "closed channel" in critical[0].issue.lower()
+
+
+def test_session_schema_adapter_handles_missing_phase_files(tmp_path):
+    meta = {
+        "ticket": "999",
+        "summary": "test",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 1.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    assert sample.session.session_id == "999"
+    assert len(sample.phases) == 0
+
+
+def test_registry_returns_registered_adapters():
+    registry = AdapterRegistry()
+    adapter = SessionSchemaAdapter()
+    registry.register(adapter)
+    assert registry.get("session-schema") is adapter
+    assert "session-schema" in [registered.name for registered in registry.list_all()]
+
+
+def test_dataset_loader_loads_directory(sessions_dir: Path):
+    registry = AdapterRegistry()
+    registry.register(SessionSchemaAdapter())
+    loader = DatasetLoader(registry)
+    dataset = loader.load_directory(sessions_dir)
+    assert len(dataset.samples) >= 2
+
+
+def test_dataset_loader_skips_malformed(malformed_dir: Path):
+    registry = AdapterRegistry()
+    registry.register(SessionSchemaAdapter())
+    loader = DatasetLoader(registry)
+    dataset = loader.load_directory(malformed_dir.parent)
+    # The malformed session should produce an error, not a valid sample
+    malformed_samples = [
+        sample for sample in dataset.samples if sample.session.session_id == malformed_dir.name
+    ]
+    assert len(malformed_samples) == 0
+    assert len(loader.errors) >= 1
+
+
+def test_dataset_loader_skips_undetected_dirs(tmp_path):
+    unknown = tmp_path / "unknown"
+    unknown.mkdir()
+    (unknown / "transcript.json").write_text("{}")
+    registry = AdapterRegistry()
+    registry.register(SessionSchemaAdapter())
+    loader = DatasetLoader(registry)
+    dataset = loader.load_directory(tmp_path)
+    assert len(dataset.samples) == 0


### PR DESCRIPTION
## Summary
Implement the adapter layer for RAKI's eval pipeline:
- `SessionAdapter` protocol with `detect()`/`load()` methods
- `AdapterRegistry` for registration and lookup
- `DatasetLoader` with auto-detection and skip-and-report error handling
- `SessionSchemaAdapter` for directory-based phase JSONs (meta.json, phase files, events.jsonl)
- Security hardening: 50MB file size bounds, symlink protection, redact_sensitive() call sites (stub for Task 3b), graceful malformed entry handling

Refs #3

## Review
- Python Specialist: 7 findings fixed (Literal types, dict typing, fixture duplication, error handling), clean on re-review
- Security Specialist: 2 CRITICAL + 3 IMPORTANT findings fixed (redact_sensitive, file size, symlink, path traversal, redaction coverage), clean after 2 iterations
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko