### PR TITLE
feat(adapters): add Alcove adapter and implement redact_sensitive

### DIFF
--- a/src/raki/adapters/__init__.py
+++ b/src/raki/adapters/__init__.py
@@ -1,3 +1,4 @@
+from raki.adapters.alcove import AlcoveAdapter
 from raki.adapters.loader import DatasetLoader, LoadError
 from raki.adapters.protocol import SessionAdapter
 from raki.adapters.redact import redact_sensitive
@@ -6,6 +7,7 @@ from raki.adapters.session_schema import SessionSchemaAdapter
 
 __all__ = [
     "AdapterRegistry",
+    "AlcoveAdapter",
     "DatasetLoader",
     "LoadError",
     "SessionAdapter",

--- a/src/raki/adapters/alcove.py
+++ b/src/raki/adapters/alcove.py
@@ -1,0 +1,115 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from raki.adapters.redact import redact_dict, redact_sensitive
+from raki.model import EvalSample, PhaseResult, SessionMeta, ToolCall
+
+MAX_ALCOVE_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+DETECT_READ_SIZE = 4096  # Only read first 4KB for format detection
+
+
+class AlcoveAdapter:
+    name: str = "alcove"
+
+    def detect(self, source: Path) -> bool:
+        """Detect Alcove format via substring search of first 4KB."""
+        if not source.is_file() or source.suffix != ".json":
+            return False
+        try:
+            with source.open(errors="replace") as file_handle:
+                header = file_handle.read(DETECT_READ_SIZE)
+            return '"session_id"' in header and '"transcript"' in header
+        except OSError:
+            return False
+
+    def load(self, source: Path) -> EvalSample:
+        """Parse an Alcove single-file transcript into an EvalSample."""
+        if source.is_symlink():
+            raise ValueError(f"Source must be a regular file (no symlinks): {source}")
+        resolved = source.resolve()
+        if not resolved.is_file():
+            raise ValueError(f"Source must be a regular file: {source}")
+        file_size = resolved.stat().st_size
+        if file_size > MAX_ALCOVE_FILE_SIZE:
+            raise ValueError(
+                f"File exceeds {MAX_ALCOVE_FILE_SIZE // (1024 * 1024)}MB limit: {source}"
+            )
+        raw = json.loads(resolved.read_text(encoding="utf-8"))
+        session_id = raw["session_id"]
+        transcript = raw["transcript"]
+
+        model_id: str | None = None
+        tool_calls: list[ToolCall] = []
+        output_parts: list[str] = []
+        total_cost_usd: float | None = None
+        duration_ms: int | None = None
+        started_at: datetime | None = None
+        tokens_in = 0
+        tokens_out = 0
+
+        for entry in transcript:
+            entry_type = entry.get("type")
+
+            if entry_type == "system":
+                model_id = entry.get("model")
+
+            elif entry_type == "assistant":
+                message = entry.get("message", {})
+                usage = message.get("usage", {})
+                tokens_in += usage.get("input_tokens", 0)
+                tokens_out += usage.get("output_tokens", 0)
+                for content_block in message.get("content", []):
+                    if content_block.get("type") == "tool_use":
+                        raw_args = content_block.get("input")
+                        tool_calls.append(
+                            ToolCall(
+                                name=content_block["name"],
+                                arguments=redact_dict(raw_args)
+                                if isinstance(raw_args, dict)
+                                else raw_args,
+                            )
+                        )
+                    elif content_block.get("type") == "text":
+                        output_parts.append(content_block["text"])
+
+            elif entry_type == "user":
+                timestamp_str = entry.get("timestamp")
+                if timestamp_str and started_at is None:
+                    started_at = datetime.fromisoformat(timestamp_str)
+
+            elif entry_type == "result":
+                total_cost_usd = entry.get("total_cost_usd")
+                duration_ms = entry.get("duration_ms")
+                model_usage = entry.get("modelUsage", {})
+                if not model_id and model_usage:
+                    model_id = next(iter(model_usage), None)
+
+        meta = SessionMeta(
+            session_id=session_id,
+            started_at=started_at or datetime.now(timezone.utc),
+            total_cost_usd=total_cost_usd,
+            total_phases=1,
+            rework_cycles=0,
+            model_id=model_id,
+        )
+
+        output = redact_sensitive("\n".join(output_parts))
+        phase = PhaseResult(
+            name="session",
+            generation=1,
+            status="completed",
+            cost_usd=total_cost_usd,
+            duration_ms=duration_ms,
+            tokens_in=tokens_in or None,
+            tokens_out=tokens_out or None,
+            output=output,
+            tool_calls=tool_calls,
+        )
+
+        return EvalSample(
+            session=meta,
+            phases=[phase],
+            findings=[],
+            events=[],
+        )

--- a/src/raki/adapters/loader.py
+++ b/src/raki/adapters/loader.py
@@ -26,8 +26,6 @@ class DatasetLoader:
         self.errors = []
         self.skipped = []
         for child in sorted(root.iterdir()):
-            if not child.is_dir():
-                continue
             adapter = self._detect_adapter(child)
             if adapter is None:
                 self.skipped.append(child)

--- a/src/raki/adapters/redact.py
+++ b/src/raki/adapters/redact.py
@@ -1,3 +1,44 @@
+import re
+from typing import Any
+
+PATTERNS = [
+    re.compile(r'(?i)(bearer\s+)(?:[^\s"]+|"[^"]+")'),
+    re.compile(r'(?i)(token[=:]\s*)(?:[^\s"]+|"[^"]+")'),
+    re.compile(r'(?i)(password[=:]\s*)(?:[^\s"]+|"[^"]+")'),
+    re.compile(r'(?i)(api[_-]?key[=:]\s*)(?:[^\s"]+|"[^"]+")'),
+    re.compile(r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"),  # JWT
+    re.compile(r"AKIA[0-9A-Z]{16}"),  # AWS access keys
+    re.compile(r"(?:ghp|gho|ghs|ghr|glpat)_[A-Za-z0-9_]{20,}"),  # GitHub/GitLab tokens
+    re.compile(r'(?i)(secret[=:]\s*)(?:[^\s"]+|"[^"]+")'),  # Generic secret keyword
+    re.compile(
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----"
+    ),  # Private key blocks
+]
+
+
 def redact_sensitive(text: str) -> str:
-    """Stub -- full implementation in Task 3b (Issue #4)."""
+    """Strip common secret patterns from text before it enters EvalSample."""
+    for pattern in PATTERNS:
+        text = pattern.sub(
+            lambda match: (
+                match.group(1) + "***REDACTED***" if match.lastindex else "***REDACTED***"
+            ),
+            text,
+        )
     return text
+
+
+def redact_dict(data: dict[str, Any]) -> dict[str, Any]:
+    """Recursively redact sensitive string values in a dict/list structure."""
+    return {key: _redact_value(value) for key, value in data.items()}
+
+
+def _redact_value(value: Any) -> Any:
+    """Redact a single value, recursing into dicts and lists."""
+    if isinstance(value, str):
+        return redact_sensitive(value)
+    if isinstance(value, dict):
+        return {key: _redact_value(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    return value

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from raki.adapters.redact import redact_sensitive
+from raki.adapters.redact import redact_dict, redact_sensitive
 from raki.model import EvalSample, PhaseResult, ReviewFinding, SessionEvent, SessionMeta
 
 PHASE_NAMES = ["triage", "plan", "implement", "verify"]
@@ -93,7 +93,7 @@ class SessionSchemaAdapter:
                     cost_usd=phase_meta.get("cost"),
                     duration_ms=phase_meta.get("duration_ms"),
                     output=output_text,
-                    output_structured=raw,
+                    output_structured=redact_dict(raw),
                 )
             )
         return results
@@ -146,10 +146,7 @@ class SessionSchemaAdapter:
                         timestamp=raw["timestamp"],
                         phase=raw.get("phase") or None,
                         kind=raw["kind"],
-                        data={
-                            k: redact_sensitive(v) if isinstance(v, str) else v
-                            for k, v in raw.get("data", {}).items()
-                        },
+                        data=redact_dict(raw.get("data", {})),
                     )
                 )
             except KeyError, ValueError, ValidationError:

--- a/tests/fixtures/sessions/alcove-simple.json
+++ b/tests/fixtures/sessions/alcove-simple.json
@@ -1,0 +1,77 @@
+{
+    "session_id": "ae7d2bf4-2f77-4ea6-8e3c-5442fe3d9fa7",
+    "transcript": [
+        {
+            "type": "system",
+            "model": "claude-sonnet-4-20250514",
+            "tools": ["Bash", "Edit", "Read"],
+            "subtype": "init",
+            "session_id": "08b5c518-551f-4e38-89bf-5bd17f68f74c",
+            "permissionMode": "bypassPermissions",
+            "claude_code_version": "2.1.110"
+        },
+        {
+            "type": "assistant",
+            "uuid": "8baf420d-ac6b-4f95-94d9-500d7bad6f6c",
+            "message": {
+                "id": "msg_01",
+                "role": "assistant",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {"input_tokens": 10, "output_tokens": 8},
+                "content": [{"type": "text", "text": "I'll check the environment variable."}]
+            },
+            "session_id": "08b5c518-551f-4e38-89bf-5bd17f68f74c"
+        },
+        {
+            "type": "assistant",
+            "uuid": "91c14589-e5ac-444f-beac-b3674b643494",
+            "message": {
+                "id": "msg_01",
+                "role": "assistant",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {"input_tokens": 10, "output_tokens": 8},
+                "content": [{"id": "toolu_01", "name": "Bash", "type": "tool_use", "input": {"command": "echo $TOKEN", "description": "Check token"}}]
+            },
+            "session_id": "08b5c518-551f-4e38-89bf-5bd17f68f74c"
+        },
+        {
+            "type": "user",
+            "uuid": "c77a4515-d208-4b37-89d2-51bba4268964",
+            "message": {"role": "user", "content": [{"type": "tool_result", "content": "my-token-value", "is_error": false, "tool_use_id": "toolu_01"}]},
+            "timestamp": "2026-04-16T12:11:06.161Z",
+            "session_id": "08b5c518-551f-4e38-89bf-5bd17f68f74c",
+            "tool_use_result": {"stdout": "my-token-value", "stderr": ""}
+        },
+        {
+            "type": "assistant",
+            "uuid": "8932acaa-2912-4bd4-b740-fc29a51d2c8a",
+            "message": {
+                "id": "msg_02",
+                "role": "assistant",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {"input_tokens": 5, "output_tokens": 20},
+                "content": [{"text": "The TOKEN is set to my-token-value.", "type": "text"}]
+            },
+            "session_id": "08b5c518-551f-4e38-89bf-5bd17f68f74c"
+        },
+        {
+            "type": "result",
+            "uuid": "bf4c2099-e02f-4132-8e14-cc5befca1ce2",
+            "usage": {"input_tokens": 20, "output_tokens": 396},
+            "result": "The TOKEN is set to my-token-value.",
+            "subtype": "success",
+            "is_error": false,
+            "num_turns": 3,
+            "modelUsage": {
+                "claude-sonnet-4-20250514": {
+                    "costUSD": 0.027,
+                    "inputTokens": 20,
+                    "outputTokens": 396
+                }
+            },
+            "session_id": "08b5c518-551f-4e38-89bf-5bd17f68f74c",
+            "duration_ms": 9316,
+            "total_cost_usd": 0.027
+        }
+    ]
+}

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,11 +1,18 @@
-"""Tests for the adapter layer: protocol, registry, loader, session-schema adapter."""
+"""Tests for the adapter layer: protocol, registry, loader, session-schema adapter, alcove."""
 
 import json
 from pathlib import Path
 
+import pytest
+
+from raki.adapters.alcove import AlcoveAdapter
 from raki.adapters.loader import DatasetLoader
+from raki.adapters.redact import redact_dict, redact_sensitive
 from raki.adapters.registry import AdapterRegistry
 from raki.adapters.session_schema import SessionSchemaAdapter
+
+FIXTURES = Path(__file__).parent / "fixtures" / "sessions"
+ALCOVE_FIXTURE = FIXTURES / "alcove-simple.json"
 
 
 def test_session_schema_adapter_detects_valid_session(
@@ -108,3 +115,229 @@ def test_dataset_loader_skips_undetected_dirs(tmp_path):
     loader = DatasetLoader(registry)
     dataset = loader.load_directory(tmp_path)
     assert len(dataset.samples) == 0
+
+
+# --- Alcove adapter tests ---
+
+
+def test_alcove_adapter_detects_valid_file():
+    adapter = AlcoveAdapter()
+    assert adapter.detect(ALCOVE_FIXTURE)
+
+
+def test_alcove_adapter_rejects_non_alcove_file(tmp_path):
+    adapter = AlcoveAdapter()
+    bad_file = tmp_path / "not-alcove.json"
+    bad_file.write_text('{"not": "alcove"}')
+    assert not adapter.detect(bad_file)
+
+
+def test_alcove_adapter_rejects_directory():
+    adapter = AlcoveAdapter()
+    assert not adapter.detect(FIXTURES / "pass-simple")
+
+
+def test_alcove_adapter_loads_session():
+    adapter = AlcoveAdapter()
+    sample = adapter.load(ALCOVE_FIXTURE)
+    assert sample.session.session_id == "ae7d2bf4-2f77-4ea6-8e3c-5442fe3d9fa7"
+    assert sample.session.total_cost_usd == 0.027
+    assert sample.session.rework_cycles == 0
+    assert len(sample.phases) == 1
+    assert sample.phases[0].name == "session"
+
+
+def test_alcove_adapter_extracts_tool_calls():
+    adapter = AlcoveAdapter()
+    sample = adapter.load(ALCOVE_FIXTURE)
+    assert len(sample.phases[0].tool_calls) == 1
+    assert sample.phases[0].tool_calls[0].name == "Bash"
+
+
+def test_alcove_adapter_extracts_model():
+    adapter = AlcoveAdapter()
+    sample = adapter.load(ALCOVE_FIXTURE)
+    assert sample.session.model_id == "claude-sonnet-4-20250514"
+
+
+def test_alcove_adapter_started_at_from_first_user_timestamp():
+    adapter = AlcoveAdapter()
+    sample = adapter.load(ALCOVE_FIXTURE)
+    assert sample.session.started_at is not None
+    assert sample.session.started_at.year == 2026
+    assert sample.session.started_at.month == 4
+    assert sample.session.started_at.day == 16
+
+
+def test_alcove_adapter_aggregates_tokens():
+    adapter = AlcoveAdapter()
+    sample = adapter.load(ALCOVE_FIXTURE)
+    phase = sample.phases[0]
+    # 10+10+5 = 25 input, 8+8+20 = 36 output
+    assert phase.tokens_in == 25
+    assert phase.tokens_out == 36
+
+
+def test_alcove_adapter_rejects_oversized_file(tmp_path):
+    adapter = AlcoveAdapter()
+    big_file = tmp_path / "big.json"
+    # Write a file just over the 50MB limit
+    big_file.write_text('{"session_id": "x", "transcript": []}' + " " * (50 * 1024 * 1024))
+    with pytest.raises(ValueError, match="exceeds"):
+        adapter.load(big_file)
+
+
+def test_dataset_loader_loads_alcove_files(tmp_path):
+    import shutil
+
+    shutil.copy(ALCOVE_FIXTURE, tmp_path / "alcove-simple.json")
+    registry = AdapterRegistry()
+    registry.register(SessionSchemaAdapter())
+    registry.register(AlcoveAdapter())
+    loader = DatasetLoader(registry)
+    dataset = loader.load_directory(tmp_path)
+    assert len(dataset.samples) == 1
+
+
+# --- Redaction tests ---
+
+
+def test_redact_bearer_token():
+    text = "Authorization: Bearer sk-abc123xyz"
+    result = redact_sensitive(text)
+    assert "sk-abc123xyz" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_api_key():
+    text = "api_key=secret_key_12345"
+    result = redact_sensitive(text)
+    assert "secret_key_12345" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_api_key_with_dash():
+    text = "api-key: my-super-secret"
+    result = redact_sensitive(text)
+    assert "my-super-secret" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_password():
+    text = "password=hunter2"
+    result = redact_sensitive(text)
+    assert "hunter2" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_jwt():
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.abcdef123456"
+    text = f"token is {jwt}"
+    result = redact_sensitive(text)
+    assert jwt not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_preserves_normal_text():
+    text = "This is a normal session output with no secrets."
+    result = redact_sensitive(text)
+    assert result == text
+
+
+def test_redact_token_equals():
+    text = "token=abc123secret"
+    result = redact_sensitive(text)
+    assert "abc123secret" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_multiple_patterns():
+    text = "Bearer sk-abc123 and password=hunter2"
+    result = redact_sensitive(text)
+    assert "sk-abc123" not in result
+    assert "hunter2" not in result
+
+
+def test_redact_quoted_bearer_token():
+    text = 'Authorization: Bearer "sk-abc123xyz"'
+    result = redact_sensitive(text)
+    assert "sk-abc123xyz" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_quoted_password():
+    text = 'password="hunter2"'
+    result = redact_sensitive(text)
+    assert "hunter2" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_aws_access_key():
+    text = "aws_key=AKIAIOSFODNN7EXAMPLE"
+    result = redact_sensitive(text)
+    assert "AKIAIOSFODNN7EXAMPLE" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_github_token():
+    text = "token: ghp_ABCDEFabcdef1234567890"
+    result = redact_sensitive(text)
+    assert "ghp_ABCDEFabcdef1234567890" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_gitlab_token():
+    text = "auth glpat_ABCDEFabcdef1234567890"
+    result = redact_sensitive(text)
+    assert "glpat_ABCDEFabcdef1234567890" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_generic_secret():
+    text = "secret=my_super_secret_value"
+    result = redact_sensitive(text)
+    assert "my_super_secret_value" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_private_key_block():
+    text = "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALRiMLAH\n-----END RSA PRIVATE KEY-----"
+    result = redact_sensitive(text)
+    assert "MIIBogIBAAJBALRiMLAH" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_dict_redacts_string_values():
+    data = {"command": "curl -H 'Bearer sk-secret123'", "count": 42}
+    result = redact_dict(data)
+    assert "sk-secret123" not in result["command"]
+    assert "***REDACTED***" in result["command"]
+    assert result["count"] == 42
+
+
+def test_redact_dict_recurses_into_nested_structures():
+    data = {
+        "outer": {
+            "inner": "password=hunter2",
+            "list_val": ["token=abc123secret", "normal text"],
+        }
+    }
+    result = redact_dict(data)
+    assert "hunter2" not in result["outer"]["inner"]
+    assert "abc123secret" not in result["outer"]["list_val"][0]
+    assert result["outer"]["list_val"][1] == "normal text"
+
+
+def test_redact_dict_handles_empty_dict():
+    assert redact_dict({}) == {}
+
+
+def test_alcove_adapter_rejects_symlink(tmp_path):
+    """Ensure alcove.load() rejects symlinks."""
+    adapter = AlcoveAdapter()
+    real_file = tmp_path / "real.json"
+    real_file.write_text('{"session_id": "x", "transcript": []}')
+    link_file = tmp_path / "link.json"
+    link_file.symlink_to(real_file)
+    with pytest.raises(ValueError, match="symlink"):
+        adapter.load(link_file)


### PR DESCRIPTION
## Summary
- AlcoveAdapter for single-file Claude Code session transcripts (4KB detect, token aggregation, 50MB limit)
- Real `redact_sensitive()` implementation replacing stub: bearer tokens, API keys, passwords, JWTs, AWS keys, GitHub/GitLab tokens, secrets, private key blocks
- Recursive `redact_dict()` for nested dict/list structures
- Redaction wired into both session-schema and Alcove adapters (outputs, tool args, event data, findings)
- Symlink protection in Alcove adapter
- DatasetLoader updated to handle both files and directories

Refs #4

## Review
- Python Specialist: 3 IMPORTANT findings fixed (tool arg redaction, quoted values, missing patterns), clean on re-review (1 false positive: PEP 758 except syntax)
- Security Specialist: 2 CRITICAL + 4 IMPORTANT findings fixed (redaction gaps, symlink, patterns), clean after 2 iterations (1 false positive: PEP 758 except syntax)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko