### PR TITLE
feat(metrics): add Metric protocol, engine, and operational metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,4 +44,5 @@ python-version = "3.14"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["tests"]
 markers = ["slow: marks tests requiring LLM calls"]

--- a/src/raki/metrics/__init__.py
+++ b/src/raki/metrics/__init__.py
@@ -1,0 +1,4 @@
+from raki.metrics.engine import MetricsEngine
+from raki.metrics.protocol import Metric, MetricConfig
+
+__all__ = ["Metric", "MetricConfig", "MetricsEngine"]

--- a/src/raki/metrics/engine.py
+++ b/src/raki/metrics/engine.py
@@ -1,0 +1,45 @@
+import uuid
+from collections.abc import Sequence
+
+from raki.metrics.protocol import Metric, MetricConfig
+from raki.model import EvalDataset
+from raki.model.report import EvalReport, MetricResult
+
+
+class MetricsEngine:
+    def __init__(self, metrics: Sequence[Metric], config: MetricConfig | None = None) -> None:
+        self._metrics = metrics
+        self._config = config or MetricConfig()
+
+    def run(
+        self,
+        dataset: EvalDataset,
+        skip_llm: bool = False,
+        skip_ground_truth: bool = False,
+    ) -> EvalReport:
+        results: list[MetricResult] = []
+        for metric in self._metrics:
+            if skip_llm and metric.requires_llm:
+                continue
+            if skip_ground_truth and metric.requires_ground_truth:
+                continue
+            result = metric.compute(dataset, self._config)
+            results.append(result)
+        aggregate = {result.name: result.score for result in results}
+        return EvalReport(
+            run_id=f"eval-{uuid.uuid4().hex[:8]}",
+            config={
+                "llm_model": self._config.llm_model,
+                "metrics": [metric.name for metric in self._metrics],
+                "skip_llm": skip_llm,
+            },
+            aggregate_scores=aggregate,
+            sample_results=[],
+            manifest_hash=dataset.manifest_hash,
+        )
+
+    def run_single(self, metric_name: str, dataset: EvalDataset) -> MetricResult:
+        for metric in self._metrics:
+            if metric.name == metric_name:
+                return metric.compute(dataset, self._config)
+        raise ValueError(f"Unknown metric: {metric_name}")

--- a/src/raki/metrics/operational/__init__.py
+++ b/src/raki/metrics/operational/__init__.py
@@ -1,0 +1,19 @@
+from raki.metrics.operational.cost import CostEfficiency
+from raki.metrics.operational.rework import ReworkCycles
+from raki.metrics.operational.severity import ReviewSeverityDistribution
+from raki.metrics.operational.verify_rate import FirstPassVerifyRate
+
+ALL_OPERATIONAL = [
+    FirstPassVerifyRate(),
+    ReworkCycles(),
+    ReviewSeverityDistribution(),
+    CostEfficiency(),
+]
+
+__all__ = [
+    "ALL_OPERATIONAL",
+    "CostEfficiency",
+    "FirstPassVerifyRate",
+    "ReviewSeverityDistribution",
+    "ReworkCycles",
+]

--- a/src/raki/metrics/operational/cost.py
+++ b/src/raki/metrics/operational/cost.py
@@ -1,0 +1,32 @@
+from raki.metrics.protocol import MetricConfig
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+
+class CostEfficiency:
+    name: str = "cost_efficiency"
+    requires_ground_truth: bool = False
+    requires_llm: bool = False
+    higher_is_better: bool = False
+    display_format: str = "currency"
+    display_name: str = "Cost / session"
+
+    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:
+        sample_scores: dict[str, float] = {}
+        costs: list[float] = []
+        for sample in dataset.samples:
+            if sample.session.total_cost_usd is not None:
+                costs.append(sample.session.total_cost_usd)
+                sample_scores[sample.session.session_id] = sample.session.total_cost_usd
+        mean = sum(costs) / len(costs) if costs else 0.0
+        return MetricResult(
+            name=self.name,
+            score=mean,
+            details={
+                "mean_cost": mean,
+                "min_cost": min(costs) if costs else 0.0,
+                "max_cost": max(costs) if costs else 0.0,
+                "sessions_with_cost": len(costs),
+            },
+            sample_scores=sample_scores,
+        )

--- a/src/raki/metrics/operational/rework.py
+++ b/src/raki/metrics/operational/rework.py
@@ -1,0 +1,28 @@
+from raki.metrics.protocol import MetricConfig
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+
+class ReworkCycles:
+    name: str = "rework_cycles"
+    requires_ground_truth: bool = False
+    requires_llm: bool = False
+    higher_is_better: bool = False
+    display_format: str = "count"
+    display_name: str = "Rework cycles"
+
+    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:
+        sample_scores: dict[str, float] = {}
+        total_rework = 0
+        count = len(dataset.samples)
+        for sample in dataset.samples:
+            cycles = sample.session.rework_cycles
+            sample_scores[sample.session.session_id] = float(cycles)
+            total_rework += cycles
+        mean = total_rework / count if count > 0 else 0.0
+        return MetricResult(
+            name=self.name,
+            score=mean,
+            details={"total_rework": total_rework, "sessions": count},
+            sample_scores=sample_scores,
+        )

--- a/src/raki/metrics/operational/severity.py
+++ b/src/raki/metrics/operational/severity.py
@@ -1,0 +1,33 @@
+from raki.metrics.protocol import MetricConfig
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+
+class ReviewSeverityDistribution:
+    name: str = "review_severity_distribution"
+    requires_ground_truth: bool = False
+    requires_llm: bool = False
+    higher_is_better: bool = True
+    display_format: str = "score"
+    display_name: str = "Severity score"
+
+    WEIGHTS: dict[str, int] = {"critical": 3, "major": 2, "minor": 1}
+
+    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:
+        counts: dict[str, int] = {"critical": 0, "major": 0, "minor": 0}
+        for sample in dataset.samples:
+            for finding in sample.findings:
+                if finding.severity in counts:
+                    counts[finding.severity] += 1
+        total = sum(counts.values())
+        if total > 0:
+            weighted = sum(self.WEIGHTS[sev] * count for sev, count in counts.items())
+            max_weighted = self.WEIGHTS["critical"] * total
+            score = 1.0 - (weighted / max_weighted)
+        else:
+            score = 1.0
+        return MetricResult(
+            name=self.name,
+            score=score,
+            details={**counts, "total": total},
+        )

--- a/src/raki/metrics/operational/verify_rate.py
+++ b/src/raki/metrics/operational/verify_rate.py
@@ -1,0 +1,38 @@
+from raki.metrics.protocol import MetricConfig
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+
+class FirstPassVerifyRate:
+    name: str = "first_pass_verify_rate"
+    requires_ground_truth: bool = False
+    requires_llm: bool = False
+    higher_is_better: bool = True
+    display_format: str = "percent"
+    display_name: str = "Verify rate"
+
+    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:
+        sample_scores: dict[str, float] = {}
+        passed = 0
+        total = 0
+        for sample in dataset.samples:
+            verify_phases = [phase for phase in sample.phases if phase.name == "verify"]
+            if not verify_phases:
+                continue
+            min_gen = min(phase.generation for phase in verify_phases)
+            first_pass = min_gen == 1 and any(
+                phase.generation == 1 and phase.status == "completed" for phase in verify_phases
+            )
+            total += 1
+            if first_pass:
+                passed += 1
+                sample_scores[sample.session.session_id] = 1.0
+            else:
+                sample_scores[sample.session.session_id] = 0.0
+        score = passed / total if total > 0 else 0.0
+        return MetricResult(
+            name=self.name,
+            score=score,
+            details={"passed": passed, "total": total},
+            sample_scores=sample_scores,
+        )

--- a/src/raki/metrics/protocol.py
+++ b/src/raki/metrics/protocol.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel
+
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+
+class MetricConfig(BaseModel):
+    llm_provider: str = "vertex-anthropic"
+    llm_model: str = "claude-sonnet-4-6"
+    temperature: float = 0.0
+    batch_size: int = 4
+    judge_log_path: Path | None = None  # path to judge_log.jsonl for audit logging
+
+
+@runtime_checkable
+class Metric(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def requires_ground_truth(self) -> bool: ...
+
+    @property
+    def requires_llm(self) -> bool: ...
+
+    @property
+    def higher_is_better(self) -> bool: ...
+
+    @property
+    def display_format(self) -> str: ...
+
+    @property
+    def display_name(self) -> str: ...
+
+    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,57 @@
 Factory fixtures live here and are never duplicated across test files.
 """
 
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 import pytest
+
+from raki.model import (
+    EvalDataset,
+    EvalSample,
+    PhaseResult,
+    ReviewFinding,
+    SessionMeta,
+)
+
+
+def make_sample(
+    session_id: str,
+    rework_cycles: int = 0,
+    cost: float = 10.0,
+    verify_gen: int = 1,
+    verify_status: Literal["completed", "failed", "skipped"] = "completed",
+    findings: list[ReviewFinding] | None = None,
+) -> EvalSample:
+    meta = SessionMeta(
+        session_id=session_id,
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=3,
+        rework_cycles=rework_cycles,
+        total_cost_usd=cost,
+    )
+    verify_output = "PASS" if verify_status == "completed" else "FAIL"
+    phases = [
+        PhaseResult(name="implement", generation=1, status="completed", output="done"),
+        PhaseResult(
+            name="verify",
+            generation=verify_gen,
+            status=verify_status,
+            output=verify_output,
+            output_structured={"verdict": verify_output},
+        ),
+    ]
+    return EvalSample(
+        session=meta,
+        phases=phases,
+        findings=findings or [],
+        events=[],
+    )
+
+
+def make_dataset(*samples: EvalSample) -> EvalDataset:
+    return EvalDataset(samples=list(samples))
 
 
 @pytest.fixture

--- a/tests/test_metrics_operational.py
+++ b/tests/test_metrics_operational.py
@@ -1,0 +1,234 @@
+"""Tests for operational metrics: verify rate, rework cycles, severity, cost."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from conftest import make_dataset, make_sample
+from raki.metrics.operational.cost import CostEfficiency
+from raki.metrics.operational.rework import ReworkCycles
+from raki.metrics.operational.severity import ReviewSeverityDistribution
+from raki.metrics.operational.verify_rate import FirstPassVerifyRate
+from raki.metrics.protocol import MetricConfig
+from raki.model import (
+    EvalDataset,
+    EvalSample,
+    PhaseResult,
+    ReviewFinding,
+    SessionMeta,
+)
+
+
+# --- FirstPassVerifyRate ---
+
+
+def test_first_pass_verify_rate_all_pass():
+    dataset = make_dataset(
+        make_sample("1", verify_gen=1),
+        make_sample("2", verify_gen=1),
+    )
+    result = FirstPassVerifyRate().compute(dataset, MetricConfig())
+    assert result.score == 1.0
+    assert result.details["passed"] == 2
+    assert result.details["total"] == 2
+
+
+def test_first_pass_verify_rate_mixed():
+    dataset = make_dataset(
+        make_sample("1", verify_gen=1),
+        make_sample("2", verify_gen=3),
+        make_sample("3", verify_gen=1),
+    )
+    result = FirstPassVerifyRate().compute(dataset, MetricConfig())
+    assert abs(result.score - 2 / 3) < 0.01
+    assert result.sample_scores["2"] == 0.0
+
+
+def test_first_pass_verify_rate_no_verify_phase():
+    meta = SessionMeta(
+        session_id="x",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=1,
+        rework_cycles=0,
+    )
+    sample = EvalSample(
+        session=meta,
+        phases=[PhaseResult(name="triage", generation=1, status="completed", output="ok")],
+        findings=[],
+        events=[],
+    )
+    dataset = make_dataset(sample)
+    result = FirstPassVerifyRate().compute(dataset, MetricConfig())
+    assert result.details["total"] == 0
+    assert result.score == 0.0
+
+
+def test_first_pass_verify_rate_gen1_failed():
+    """Verify gen=1, status='failed' should score 0.0."""
+    dataset = make_dataset(
+        make_sample("1", verify_gen=1, verify_status="failed"),
+    )
+    result = FirstPassVerifyRate().compute(dataset, MetricConfig())
+    assert result.score == 0.0
+    assert result.sample_scores["1"] == 0.0
+
+
+def test_first_pass_verify_rate_properties():
+    metric = FirstPassVerifyRate()
+    assert metric.name == "first_pass_verify_rate"
+    assert metric.requires_ground_truth is False
+    assert metric.requires_llm is False
+    assert metric.higher_is_better is True
+    assert metric.display_format == "percent"
+    assert metric.display_name == "Verify rate"
+
+
+# --- ReworkCycles ---
+
+
+def test_rework_cycles():
+    dataset = make_dataset(
+        make_sample("1", rework_cycles=0),
+        make_sample("2", rework_cycles=2),
+        make_sample("3", rework_cycles=1),
+    )
+    result = ReworkCycles().compute(dataset, MetricConfig())
+    assert abs(result.score - 1.0) < 0.01
+    assert result.sample_scores["2"] == 2.0
+
+
+def test_rework_cycles_empty_dataset():
+    """ReworkCycles with empty dataset should score 0.0."""
+    dataset = EvalDataset(samples=[])
+    result = ReworkCycles().compute(dataset, MetricConfig())
+    assert result.score == 0.0
+
+
+def test_rework_cycles_properties():
+    metric = ReworkCycles()
+    assert metric.name == "rework_cycles"
+    assert metric.requires_ground_truth is False
+    assert metric.requires_llm is False
+    assert metric.higher_is_better is False
+    assert metric.display_format == "count"
+    assert metric.display_name == "Rework cycles"
+
+
+# --- ReviewSeverityDistribution ---
+
+
+def test_review_severity_distribution():
+    findings = [
+        ReviewFinding(reviewer="go", severity="critical", issue="panic"),
+        ReviewFinding(reviewer="go", severity="major", issue="leak"),
+        ReviewFinding(reviewer="ai", severity="minor", issue="nit"),
+        ReviewFinding(reviewer="ai", severity="minor", issue="style"),
+    ]
+    dataset = make_dataset(make_sample("1", findings=findings))
+    result = ReviewSeverityDistribution().compute(dataset, MetricConfig())
+    assert result.details["critical"] == 1
+    assert result.details["major"] == 1
+    assert result.details["minor"] == 2
+    assert result.details["total"] == 4
+    # weighted: (3*1 + 2*1 + 1*2) / (3*4) = 7/12 ~ 0.583
+    # score = 1.0 - 0.583 ~ 0.417
+    assert 0.4 < result.score < 0.45
+
+
+def test_review_severity_distribution_no_findings():
+    dataset = make_dataset(make_sample("1", findings=[]))
+    result = ReviewSeverityDistribution().compute(dataset, MetricConfig())
+    assert result.score == 1.0
+    assert result.details["total"] == 0
+
+
+def test_review_severity_distribution_properties():
+    metric = ReviewSeverityDistribution()
+    assert metric.name == "review_severity_distribution"
+    assert metric.requires_ground_truth is False
+    assert metric.requires_llm is False
+    assert metric.higher_is_better is True
+    assert metric.display_format == "score"
+    assert metric.display_name == "Severity score"
+
+
+# --- CostEfficiency ---
+
+
+def test_cost_efficiency():
+    dataset = make_dataset(
+        make_sample("1", cost=10.0),
+        make_sample("2", cost=20.0),
+        make_sample("3", cost=15.0),
+    )
+    result = CostEfficiency().compute(dataset, MetricConfig())
+    assert abs(result.score - 15.0) < 0.01
+    assert result.sample_scores["2"] == 20.0
+
+
+def test_cost_efficiency_handles_missing_cost():
+    meta = SessionMeta(
+        session_id="x",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=1,
+        rework_cycles=0,
+        total_cost_usd=None,
+    )
+    sample = EvalSample(session=meta, phases=[], findings=[], events=[])
+    dataset = make_dataset(sample)
+    result = CostEfficiency().compute(dataset, MetricConfig())
+    assert result.details["sessions_with_cost"] == 0
+    assert result.score == 0.0
+
+
+def test_cost_efficiency_properties():
+    metric = CostEfficiency()
+    assert metric.name == "cost_efficiency"
+    assert metric.requires_ground_truth is False
+    assert metric.requires_llm is False
+    assert metric.higher_is_better is False
+    assert metric.display_format == "currency"
+    assert metric.display_name == "Cost / session"
+
+
+# --- MetricsEngine ---
+
+
+def test_engine_skips_llm_metrics():
+    """MetricsEngine.run() with skip_llm=True should skip metrics requiring LLM."""
+    from raki.metrics.engine import MetricsEngine
+
+    metrics = [FirstPassVerifyRate(), ReworkCycles()]
+    engine = MetricsEngine(metrics=metrics)
+    dataset = make_dataset(make_sample("1"))
+    report = engine.run(dataset, skip_llm=True)
+    # Both operational metrics should be included (neither requires LLM)
+    assert "first_pass_verify_rate" in report.aggregate_scores
+    assert "rework_cycles" in report.aggregate_scores
+
+
+def test_engine_skips_ground_truth_metrics():
+    """MetricsEngine.run() with skip_ground_truth=True should skip metrics requiring ground truth."""
+    from raki.metrics.engine import MetricsEngine
+
+    metrics = [FirstPassVerifyRate(), CostEfficiency()]
+    engine = MetricsEngine(metrics=metrics)
+    dataset = make_dataset(make_sample("1"))
+    report = engine.run(dataset, skip_ground_truth=True)
+    # Both operational metrics should be included (neither requires ground truth)
+    assert "first_pass_verify_rate" in report.aggregate_scores
+    assert "cost_efficiency" in report.aggregate_scores
+
+
+def test_engine_run_single():
+    """MetricsEngine.run_single() runs only the named metric."""
+    from raki.metrics.engine import MetricsEngine
+
+    metrics = [FirstPassVerifyRate(), ReworkCycles()]
+    engine = MetricsEngine(metrics=metrics)
+    dataset = make_dataset(make_sample("1"))
+    result = engine.run_single("rework_cycles", dataset)
+    assert result.name == "rework_cycles"
+
+    with pytest.raises(ValueError, match="Unknown metric"):
+        engine.run_single("nonexistent_metric", dataset)


### PR DESCRIPTION
## Summary
- `Metric` protocol with @property declarations (name, requires_ground_truth, requires_llm, etc.)
- `MetricConfig` Pydantic model with LLM provider settings
- `MetricsEngine.run()` with prerequisite-based metric skip logic
- Four operational metrics: FirstPassVerifyRate, ReworkCycles, ReviewSeverityDistribution, CostEfficiency
- 17 tests with edge cases (no verify phase, empty dataset, missing cost, failed first pass)

Refs #5

## Review
- Python Specialist: 2 CRITICAL (type safety) + 5 IMPORTANT findings fixed, clean on re-review
- Security Specialist: not applicable
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko