### PR TITLE
feat(manifest): add EvalManifest loader with path traversal protection

### DIFF
--- a/src/raki/ground_truth/__init__.py
+++ b/src/raki/ground_truth/__init__.py
@@ -1,0 +1,3 @@
+from raki.ground_truth.manifest import EvalManifest, discover_manifest, load_manifest
+
+__all__ = ["EvalManifest", "discover_manifest", "load_manifest"]

--- a/src/raki/ground_truth/manifest.py
+++ b/src/raki/ground_truth/manifest.py
@@ -1,0 +1,170 @@
+"""Manifest loader for RAKI evaluation configuration.
+
+Loads and validates raki.yaml / eval-manifest.yaml files, resolving
+relative paths and enforcing path traversal guards.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class SessionFilter(BaseModel):
+    """Filter criteria for selecting sessions to evaluate."""
+
+    tickets: list[str] | None = None
+    after: datetime | None = None
+    min_phases: int = 0
+
+
+class SessionsConfig(BaseModel):
+    """Configuration for session data sources."""
+
+    path: Path
+    format: str = "auto"
+    filter: SessionFilter = Field(default_factory=SessionFilter)
+
+
+class SourceDocument(BaseModel):
+    """Reference to a source document used for retrieval evaluation."""
+
+    path: Path
+    repo: str = ""
+    domains: list[str] = Field(default_factory=list)
+
+
+class GroundTruthConfig(BaseModel):
+    """Configuration for ground truth data."""
+
+    path: Path | None = None
+
+
+class SyntheticConfig(BaseModel):
+    """Configuration for synthetic test generation."""
+
+    enabled: bool = False
+    output: Path | None = None
+    count: int = 50
+    seed: int = 42
+
+
+class EvalManifest(BaseModel):
+    """Top-level evaluation manifest model.
+
+    Represents the full contents of a raki.yaml or eval-manifest.yaml file,
+    including session sources, ground truth, and synthetic generation config.
+    """
+
+    sessions: SessionsConfig
+    sources: list[SourceDocument] = Field(default_factory=list)
+    ground_truth: GroundTruthConfig = Field(default_factory=GroundTruthConfig)
+    synthetic: SyntheticConfig = Field(default_factory=SyntheticConfig)
+
+
+def _resolve_and_guard(
+    field_path: Path,
+    manifest_dir: Path,
+    root: Path,
+    *,
+    label: str,
+    must_exist: bool = True,
+) -> Path:
+    """Resolve a manifest path and validate it stays within the project root.
+
+    Args:
+        field_path: The raw path from the manifest field.
+        manifest_dir: Resolved parent directory of the manifest file.
+        root: Resolved project root directory.
+        label: Human-readable label for error messages (e.g. "sessions.path").
+        must_exist: Whether the resolved path must exist on disk.
+
+    Returns:
+        The resolved absolute path.
+
+    Raises:
+        ValueError: If the path does not exist (when must_exist is True)
+            or escapes the project root.
+    """
+    if not field_path.is_absolute():
+        field_path = (manifest_dir / field_path).resolve()
+    resolved = field_path.resolve()
+
+    if must_exist and not resolved.exists():
+        raise ValueError(f"{label} does not exist: {resolved}")
+
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        raise ValueError(f"{label} escapes project root: {resolved} is not under {root}") from None
+
+    return resolved
+
+
+def load_manifest(path: Path, *, project_root: Path | None = None) -> EvalManifest:
+    """Load and validate an evaluation manifest from a YAML file.
+
+    Resolves relative paths against the manifest's parent directory and
+    validates that all referenced paths exist and do not escape the project root.
+
+    Args:
+        path: Path to the manifest YAML file.
+        project_root: Root directory for path traversal validation.
+            Defaults to the manifest file's parent directory.
+
+    Returns:
+        A validated EvalManifest instance.
+
+    Raises:
+        ValueError: If the YAML content is not a mapping, referenced paths
+            do not exist, or paths escape the project root.
+    """
+    raw = yaml.safe_load(path.read_text())
+
+    if not isinstance(raw, dict):
+        raise ValueError("Manifest must contain a YAML mapping")
+
+    manifest = EvalManifest.model_validate(raw)
+    manifest_dir = path.parent.resolve()
+    root = project_root.resolve() if project_root is not None else manifest_dir
+
+    manifest.sessions.path = _resolve_and_guard(
+        manifest.sessions.path, manifest_dir, root, label="Sessions path"
+    )
+
+    for source_index, source in enumerate(manifest.sources):
+        source.path = _resolve_and_guard(
+            source.path, manifest_dir, root, label=f"sources[{source_index}].path"
+        )
+
+    if manifest.ground_truth.path is not None:
+        manifest.ground_truth.path = _resolve_and_guard(
+            manifest.ground_truth.path, manifest_dir, root, label="ground_truth.path"
+        )
+
+    if manifest.synthetic.output is not None:
+        manifest.synthetic.output = _resolve_and_guard(
+            manifest.synthetic.output,
+            manifest_dir,
+            root,
+            label="synthetic.output",
+            must_exist=False,
+        )
+
+    return manifest
+
+
+def discover_manifest() -> Path | None:
+    """Discover a manifest file in the current working directory.
+
+    Checks for raki.yaml first, then eval-manifest.yaml.
+
+    Returns:
+        Path to the discovered manifest file, or None if not found.
+    """
+    for name in ["raki.yaml", "eval-manifest.yaml"]:
+        candidate = Path.cwd() / name
+        if candidate.exists():
+            return candidate
+    return None

--- a/tests/fixtures/manifests/basic.yaml
+++ b/tests/fixtures/manifests/basic.yaml
@@ -1,0 +1,5 @@
+sessions:
+  path: ../sessions
+  format: auto
+  filter:
+    min_phases: 2

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,285 @@
+"""Tests for EvalManifest model and manifest loader."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestLoadManifest:
+    """Tests for load_manifest() function."""
+
+    def test_load_manifest_basic(self, fixtures_dir: Path) -> None:
+        from raki.ground_truth.manifest import load_manifest
+
+        manifest = load_manifest(
+            fixtures_dir / "manifests" / "basic.yaml",
+            project_root=fixtures_dir,
+        )
+        assert manifest.sessions.path is not None
+        assert manifest.sessions.format == "auto"
+
+    def test_load_manifest_validates_sessions_path(self, tmp_path: Path) -> None:
+        from raki.ground_truth.manifest import load_manifest
+
+        manifest_path = tmp_path / "raki.yaml"
+        manifest_path.write_text("sessions:\n  path: /nonexistent/path\n  format: auto\n")
+        with pytest.raises(ValueError, match="does not exist"):
+            load_manifest(manifest_path)
+
+    def test_load_manifest_filter_min_phases(self, fixtures_dir: Path) -> None:
+        from raki.ground_truth.manifest import load_manifest
+
+        manifest = load_manifest(
+            fixtures_dir / "manifests" / "basic.yaml",
+            project_root=fixtures_dir,
+        )
+        assert manifest.sessions.filter.min_phases == 2
+
+    def test_load_manifest_filter_defaults(self, tmp_path: Path) -> None:
+        """Filter defaults should be sensible when not specified."""
+        from raki.ground_truth.manifest import load_manifest
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        manifest_path = tmp_path / "raki.yaml"
+        manifest_path.write_text(f"sessions:\n  path: {sessions_dir}\n  format: auto\n")
+        manifest = load_manifest(manifest_path)
+        assert manifest.sessions.filter.min_phases == 0
+        assert manifest.sessions.filter.tickets is None
+        assert manifest.sessions.filter.after is None
+
+    def test_load_manifest_resolves_relative_paths(self, fixtures_dir: Path) -> None:
+        """Relative paths should be resolved against manifest parent directory."""
+        from raki.ground_truth.manifest import load_manifest
+
+        manifest = load_manifest(
+            fixtures_dir / "manifests" / "basic.yaml",
+            project_root=fixtures_dir,
+        )
+        # The path ../sessions relative to manifests/ should resolve to fixtures/sessions
+        expected = (fixtures_dir / "sessions").resolve()
+        assert manifest.sessions.path == expected
+
+    def test_load_manifest_path_traversal_guard(self, tmp_path: Path) -> None:
+        """Paths escaping the project root must be rejected."""
+        from raki.ground_truth.manifest import load_manifest
+
+        # Create directory structure: project_root/sub/ contains the manifest
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        sub_dir = project_root / "sub"
+        sub_dir.mkdir()
+        # Create sessions directory OUTSIDE the project root
+        external_sessions = tmp_path / "external_sessions"
+        external_sessions.mkdir()
+        manifest_path = sub_dir / "raki.yaml"
+        # ../../external_sessions goes: sub/ -> project/ -> tmp_path/external_sessions
+        manifest_path.write_text("sessions:\n  path: ../../external_sessions\n  format: auto\n")
+        with pytest.raises(ValueError, match="escapes project root"):
+            load_manifest(manifest_path, project_root=project_root)
+
+    def test_load_manifest_absolute_path_outside_root(self, tmp_path: Path) -> None:
+        """Absolute paths outside project root must be rejected."""
+        from raki.ground_truth.manifest import load_manifest
+
+        external_dir = tmp_path / "external"
+        external_dir.mkdir()
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        manifest_path = project_dir / "raki.yaml"
+        manifest_path.write_text(f"sessions:\n  path: {external_dir}\n  format: auto\n")
+        with pytest.raises(ValueError, match="escapes project root"):
+            load_manifest(manifest_path)
+
+    def test_load_manifest_project_root_defaults_to_manifest_parent(self, tmp_path: Path) -> None:
+        """When project_root is not specified, it defaults to the manifest's parent."""
+        from raki.ground_truth.manifest import load_manifest
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        manifest_path = tmp_path / "raki.yaml"
+        manifest_path.write_text("sessions:\n  path: sessions\n  format: auto\n")
+        manifest = load_manifest(manifest_path)
+        assert manifest.sessions.path == sessions_dir.resolve()
+
+    def test_load_manifest_empty_yaml(self, tmp_path: Path) -> None:
+        """Empty YAML file should raise a clear ValueError."""
+        from raki.ground_truth.manifest import load_manifest
+
+        manifest_path = tmp_path / "raki.yaml"
+        manifest_path.write_text("")
+        with pytest.raises(ValueError, match="YAML mapping"):
+            load_manifest(manifest_path)
+
+    def test_load_manifest_yaml_list_content(self, tmp_path: Path) -> None:
+        """YAML with a list at the top level should raise a clear ValueError."""
+        from raki.ground_truth.manifest import load_manifest
+
+        manifest_path = tmp_path / "raki.yaml"
+        manifest_path.write_text("- item1\n- item2\n")
+        with pytest.raises(ValueError, match="YAML mapping"):
+            load_manifest(manifest_path)
+
+    def test_load_manifest_missing_sessions_key(self, tmp_path: Path) -> None:
+        """YAML missing required sessions key should raise ValidationError."""
+        from raki.ground_truth.manifest import load_manifest
+
+        manifest_path = tmp_path / "raki.yaml"
+        manifest_path.write_text("ground_truth:\n  path: null\n")
+        with pytest.raises(ValidationError, match="sessions"):
+            load_manifest(manifest_path)
+
+    def test_load_manifest_source_path_traversal_guard(self, tmp_path: Path) -> None:
+        """Source paths escaping the project root must be rejected."""
+        from raki.ground_truth.manifest import load_manifest
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        sessions_dir = project_root / "sessions"
+        sessions_dir.mkdir()
+        external_docs = tmp_path / "external_docs"
+        external_docs.mkdir()
+        manifest_path = project_root / "raki.yaml"
+        manifest_path.write_text(
+            f"sessions:\n  path: sessions\n  format: auto\nsources:\n  - path: {external_docs}\n"
+        )
+        with pytest.raises(ValueError, match="escapes project root"):
+            load_manifest(manifest_path, project_root=project_root)
+
+    def test_load_manifest_ground_truth_path_traversal_guard(self, tmp_path: Path) -> None:
+        """Ground truth paths escaping the project root must be rejected."""
+        from raki.ground_truth.manifest import load_manifest
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        sessions_dir = project_root / "sessions"
+        sessions_dir.mkdir()
+        external_gt = tmp_path / "external_gt"
+        external_gt.mkdir()
+        manifest_path = project_root / "raki.yaml"
+        manifest_path.write_text(
+            f"sessions:\n  path: sessions\n  format: auto\nground_truth:\n  path: {external_gt}\n"
+        )
+        with pytest.raises(ValueError, match="escapes project root"):
+            load_manifest(manifest_path, project_root=project_root)
+
+    def test_load_manifest_synthetic_output_traversal_guard(self, tmp_path: Path) -> None:
+        """Synthetic output paths escaping the project root must be rejected."""
+        from raki.ground_truth.manifest import load_manifest
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        sessions_dir = project_root / "sessions"
+        sessions_dir.mkdir()
+        manifest_path = project_root / "raki.yaml"
+        manifest_path.write_text(
+            "sessions:\n  path: sessions\n  format: auto\n"
+            "synthetic:\n  enabled: true\n  output: ../outside\n"
+        )
+        with pytest.raises(ValueError, match="escapes project root"):
+            load_manifest(manifest_path, project_root=project_root)
+
+
+class TestEvalManifest:
+    """Tests for EvalManifest model structure."""
+
+    def test_manifest_has_sessions(self) -> None:
+        from raki.ground_truth.manifest import EvalManifest, SessionsConfig
+
+        manifest = EvalManifest(sessions=SessionsConfig(path=Path("/tmp/sessions")))
+        assert manifest.sessions.path == Path("/tmp/sessions")
+
+    def test_manifest_sources_default_empty(self) -> None:
+        from raki.ground_truth.manifest import EvalManifest, SessionsConfig
+
+        manifest = EvalManifest(sessions=SessionsConfig(path=Path("/tmp/sessions")))
+        assert manifest.sources == []
+
+    def test_manifest_ground_truth_default(self) -> None:
+        from raki.ground_truth.manifest import EvalManifest, SessionsConfig
+
+        manifest = EvalManifest(sessions=SessionsConfig(path=Path("/tmp/sessions")))
+        assert manifest.ground_truth.path is None
+
+    def test_manifest_synthetic_default(self) -> None:
+        from raki.ground_truth.manifest import EvalManifest, SessionsConfig
+
+        manifest = EvalManifest(sessions=SessionsConfig(path=Path("/tmp/sessions")))
+        assert manifest.synthetic.enabled is False
+        assert manifest.synthetic.count == 50
+        assert manifest.synthetic.seed == 42
+
+
+class TestSessionFilter:
+    """Tests for SessionFilter model."""
+
+    def test_filter_tickets(self) -> None:
+        from raki.ground_truth.manifest import SessionFilter
+
+        session_filter = SessionFilter(tickets=["PROJ-123", "PROJ-456"])
+        assert session_filter.tickets == ["PROJ-123", "PROJ-456"]
+
+    def test_filter_after_date(self) -> None:
+        from raki.ground_truth.manifest import SessionFilter
+
+        cutoff = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        session_filter = SessionFilter(after=cutoff)
+        assert session_filter.after == cutoff
+
+    def test_filter_min_phases(self) -> None:
+        from raki.ground_truth.manifest import SessionFilter
+
+        session_filter = SessionFilter(min_phases=3)
+        assert session_filter.min_phases == 3
+
+
+class TestDiscoverManifest:
+    """Tests for discover_manifest() function."""
+
+    def test_discover_manifest_raki_yaml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        raki_yaml = tmp_path / "raki.yaml"
+        raki_yaml.write_text(f"sessions:\n  path: {sessions_dir}\n  format: auto\n")
+        from raki.ground_truth.manifest import discover_manifest
+
+        found = discover_manifest()
+        assert found == raki_yaml
+
+    def test_discover_manifest_eval_manifest_yaml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        eval_yaml = tmp_path / "eval-manifest.yaml"
+        eval_yaml.write_text("sessions:\n  path: ./sessions\n  format: auto\n")
+        from raki.ground_truth.manifest import discover_manifest
+
+        found = discover_manifest()
+        assert found == eval_yaml
+
+    def test_discover_manifest_prefers_raki_yaml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When both exist, raki.yaml takes priority."""
+        monkeypatch.chdir(tmp_path)
+        raki_yaml = tmp_path / "raki.yaml"
+        raki_yaml.write_text("sessions:\n  path: ./sessions\n  format: auto\n")
+        eval_yaml = tmp_path / "eval-manifest.yaml"
+        eval_yaml.write_text("sessions:\n  path: ./sessions\n  format: auto\n")
+        from raki.ground_truth.manifest import discover_manifest
+
+        found = discover_manifest()
+        assert found == raki_yaml
+
+    def test_discover_manifest_not_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        from raki.ground_truth.manifest import discover_manifest
+
+        assert discover_manifest() is None


### PR DESCRIPTION
## Summary
- `EvalManifest` Pydantic model with sessions, sources, ground_truth, synthetic configs
- `load_manifest()` with path resolution and traversal guards on ALL path fields
- `discover_manifest()` auto-discovery of raki.yaml / eval-manifest.yaml
- Session filter support (min_phases, after date, ticket list)
- Guards against empty/non-dict YAML input

Refs #6

## Review
- Python Specialist: 1 CRITICAL (B904) + 4 IMPORTANT findings fixed (path traversal, YAML guard, test fixtures, edge cases), clean on re-review
- Security Specialist: not applicable (per specialist table)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko