### PR TITLE
feat(cli): wire run, validate, and adapters commands

### DIFF
--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -1,10 +1,255 @@
+"""Click CLI entry points for RAKI — run, validate, adapters."""
+
+from pathlib import Path
+
 import click
+from rich.console import Console
+
+console = Console()
+
+
+def _build_registry():
+    """Build the default adapter registry with all built-in adapters."""
+    from raki.adapters import AdapterRegistry, AlcoveAdapter, SessionSchemaAdapter
+
+    registry = AdapterRegistry()
+    registry.register(SessionSchemaAdapter())
+    registry.register(AlcoveAdapter())
+    return registry
+
+
+def _resolve_manifest(manifest_path: str | None, quiet: bool = False) -> Path:
+    """Resolve manifest path from explicit argument or auto-discovery.
+
+    Args:
+        manifest_path: Explicit path to manifest file, or None for auto-discovery.
+        quiet: When True, suppress the auto-discovery message.
+
+    Returns:
+        Resolved path to manifest file.
+
+    Raises:
+        click.BadParameter: If the explicit path does not exist.
+        click.UsageError: If no manifest is found via auto-discovery.
+    """
+    if manifest_path:
+        path = Path(manifest_path)
+        if not path.exists():
+            raise click.BadParameter(f"Manifest not found: {path}")
+        return path
+
+    from raki.ground_truth.manifest import discover_manifest
+
+    found = discover_manifest()
+    if found is None:
+        raise click.UsageError(
+            "No manifest found. Provide --manifest or create raki.yaml / eval-manifest.yaml"
+        )
+    if not quiet:
+        console.print(f"[dim]Auto-discovered manifest: {found}[/dim]")
+    return found
+
+
+def _warn_unimplemented_options(**options: object) -> None:
+    """Print a warning for each option that was provided but is not yet implemented."""
+    for option_name, value in options.items():
+        if value is not None:
+            console.print(f"[yellow]Warning: --{option_name} is not yet implemented[/yellow]")
 
 
 @click.group()
 @click.version_option(package_name="raki")
 def main():
-    """RAKI — Retrieval Assessment for Knowledge Impact"""
+    """RAKI -- Retrieval Assessment for Knowledge Impact"""
+
+
+@main.command()
+@click.option("-m", "--manifest", "manifest_path", default=None, help="Path to manifest file")
+@click.option("-o", "--output", "output_dir", default="./results", help="Output directory")
+@click.option("--no-llm", is_flag=True, help="Skip LLM-backed metrics")
+@click.option("-q", "--quiet", is_flag=True, help="CI mode -- minimal output")
+@click.option("--threshold", type=float, default=None, help="Min score for exit code 0")
+@click.option("--adapter", "adapter_format", default=None, help="Force adapter (default: auto)")
+@click.option(
+    "--metrics",
+    "metric_names",
+    default=None,
+    help="Comma-separated metric list (default: all)",
+)
+@click.option(
+    "-p",
+    "--parallel",
+    "parallel_count",
+    type=int,
+    default=4,
+    help="Max parallel LLM calls",
+)
+@click.option("--tenant", default=None, help="Set tenant_id on the report")
+@click.option(
+    "--include-sessions",
+    is_flag=True,
+    help="Include full session data in JSON report",
+)
+@click.option("--json", "json_stdout", is_flag=True, help="Print JSON report to stdout")
+@click.option("-v", "--verbose", is_flag=True, help="Show debug output")
+def run(
+    manifest_path: str | None,
+    output_dir: str,
+    no_llm: bool,
+    quiet: bool,
+    threshold: float | None,
+    adapter_format: str | None,
+    metric_names: str | None,
+    parallel_count: int,
+    tenant: str | None,
+    include_sessions: bool,
+    json_stdout: bool,
+    verbose: bool,
+) -> None:
+    """Run evaluation against sessions."""
+    _warn_unimplemented_options(
+        adapter=adapter_format,
+        metrics=metric_names,
+        parallel=parallel_count if parallel_count != 4 else None,
+        tenant=tenant,
+    )
+    manifest_file = _resolve_manifest(manifest_path, quiet=quiet)
+
+    try:
+        from raki.ground_truth.manifest import load_manifest
+
+        manifest = load_manifest(manifest_file)
+    except Exception as exc:
+        console.print(f"[red]Error loading manifest: {exc}[/red]")
+        raise SystemExit(2) from exc
+
+    from raki.adapters import DatasetLoader
+
+    registry = _build_registry()
+    loader = DatasetLoader(registry)
+
+    if not quiet:
+        console.print(f"Loading sessions from [bold]{manifest.sessions.path}[/bold]...")
+
+    dataset = loader.load_directory(manifest.sessions.path)
+
+    if verbose:
+        for error in loader.errors:
+            console.print(f"  [red]Error: {error.path} -- {error.error}[/red]")
+        for skipped_path in loader.skipped:
+            console.print(f"  [dim]Skipped: {skipped_path}[/dim]")
+
+    if not quiet:
+        console.print(
+            f"Loaded [bold]{len(dataset.samples)}[/bold] sessions "
+            f"({len(loader.skipped)} skipped, {len(loader.errors)} errors)"
+        )
+
+    from raki.metrics import MetricsEngine
+    from raki.metrics.operational import ALL_OPERATIONAL
+
+    engine = MetricsEngine(ALL_OPERATIONAL)
+    report = engine.run(dataset, skip_llm=no_llm)
+
+    if not quiet:
+        from raki.report.cli_summary import print_summary
+
+        print_summary(
+            report,
+            session_count=len(dataset.samples),
+            skipped_count=len(loader.skipped),
+            error_count=len(loader.errors),
+        )
+
+    if threshold is not None and no_llm:
+        console.print(
+            "[yellow]Warning: --threshold is set but --no-llm is active. "
+            "Threshold applies to retrieval quality scores which require LLM metrics.[/yellow]"
+        )
+
+    output_path = Path(output_dir)
+    from raki.report.json_report import timestamp_filename, write_json_report
+
+    json_file = output_path / timestamp_filename(report)
+    write_json_report(report, json_file, include_sessions=include_sessions)
+
+    if json_stdout:
+        import json as json_mod
+
+        from raki.report.json_report import _strip_session_data
+
+        data = report.model_dump(mode="json")
+        if not include_sessions:
+            _strip_session_data(data)
+        click.echo(json_mod.dumps(data, indent=2, default=str))
+
+    if not quiet:
+        console.print(f"\nReport written:\n  JSON -> {json_file}")
+
+    if threshold is not None:
+        from raki.report.cli_summary import OPERATIONAL_METRICS
+
+        retrieval_scores = {
+            name: score
+            for name, score in report.aggregate_scores.items()
+            if name not in OPERATIONAL_METRICS
+        }
+        if retrieval_scores:
+            mean_retrieval = sum(retrieval_scores.values()) / len(retrieval_scores)
+            if mean_retrieval < threshold:
+                raise SystemExit(1)
+
+
+@main.command()
+@click.option("-m", "--manifest", "manifest_path", default=None, help="Path to manifest file")
+@click.option("-v", "--verbose", is_flag=True, help="Show debug output")
+def validate(manifest_path: str | None, verbose: bool) -> None:
+    """Check manifest and session data without running metrics."""
+    manifest_file = _resolve_manifest(manifest_path)
+
+    try:
+        from raki.ground_truth.manifest import load_manifest
+
+        manifest = load_manifest(manifest_file)
+    except Exception as exc:
+        console.print(f"[red]Error loading manifest: {exc}[/red]")
+        raise SystemExit(2) from exc
+    console.print(f"[green]\u2713[/green] Manifest loaded: {manifest_file}")
+    console.print(f"[green]\u2713[/green] Sessions path: {manifest.sessions.path}")
+
+    from raki.adapters import DatasetLoader
+
+    registry = _build_registry()
+    loader = DatasetLoader(registry)
+    dataset = loader.load_directory(manifest.sessions.path)
+
+    console.print(f"[green]\u2713[/green] {len(dataset.samples)} sessions loaded")
+
+    if loader.skipped:
+        console.print(
+            f"[yellow]\u26a0[/yellow] {len(loader.skipped)} directories skipped (no adapter match)"
+        )
+        if verbose:
+            for skipped_path in loader.skipped:
+                console.print(f"    {skipped_path.name}")
+
+    if loader.errors:
+        console.print(f"[red]\u2717[/red] {len(loader.errors)} sessions failed to load")
+        for error in loader.errors:
+            console.print(f"    {error.path.name}: {error.error}")
+
+    console.print(
+        f"\nReady to evaluate [bold]{len(dataset.samples)}[/bold] sessions"
+        f" ({len(loader.skipped)} skipped, {len(loader.errors)} errors)."
+    )
+
+
+@main.command()
+def adapters() -> None:
+    """List available session adapters."""
+    registry = _build_registry()
+    for adapter in registry.list_all():
+        console.print(f"  [bold]{adapter.name}[/bold]")
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,3 +84,35 @@ def rework_cycle_dir(sessions_dir: Path) -> Path:
 def malformed_dir(sessions_dir: Path) -> Path:
     """Return the path to the malformed session fixture."""
     return sessions_dir / "malformed"
+
+
+@pytest.fixture
+def manifest_with_session(tmp_path: Path, pass_simple_dir: Path) -> tuple[Path, Path]:
+    """Create a tmp_path with a manifest and a copied pass-simple session.
+
+    Returns:
+        Tuple of (manifest_path, sessions_directory).
+    """
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    session_dest = sessions / "101"
+    session_dest.mkdir()
+    for file_path in pass_simple_dir.iterdir():
+        (session_dest / file_path.name).write_text(file_path.read_text())
+    manifest = tmp_path / "raki.yaml"
+    manifest.write_text(f"sessions:\n  path: {sessions}\n  format: auto\n")
+    return manifest, sessions
+
+
+@pytest.fixture
+def empty_manifest(tmp_path: Path) -> Path:
+    """Create a tmp_path with a manifest pointing to an empty sessions directory.
+
+    Returns:
+        Path to the manifest file.
+    """
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    manifest = tmp_path / "raki.yaml"
+    manifest.write_text(f"sessions:\n  path: {sessions}\n  format: auto\n")
+    return manifest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,269 @@
+"""Tests for CLI commands: raki run, raki validate, raki adapters."""
+
+from click.testing import CliRunner
+
+from raki.cli import main
+
+
+class TestCliHelp:
+    def test_help_shows_all_commands(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "run" in result.output
+        assert "validate" in result.output
+        assert "adapters" in result.output
+
+
+class TestCliAdapters:
+    def test_lists_session_schema_adapter(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["adapters"])
+        assert result.exit_code == 0
+        assert "session-schema" in result.output
+
+    def test_lists_alcove_adapter(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["adapters"])
+        assert result.exit_code == 0
+        assert "alcove" in result.output
+
+
+class TestCliValidate:
+    def test_validate_with_manifest(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(empty_manifest)])
+        assert result.exit_code == 0
+
+    def test_validate_shows_session_count(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(empty_manifest)])
+        assert "0 sessions loaded" in result.output
+
+    def test_validate_shows_skipped_and_errors(self, empty_manifest):
+        # Create a directory that no adapter can detect — it will be skipped
+        sessions_dir = empty_manifest.parent / "sessions"
+        unknown = sessions_dir / "unknown-dir"
+        unknown.mkdir()
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(empty_manifest)])
+        assert result.exit_code == 0
+        assert "skipped" in result.output.lower()
+
+    def test_validate_missing_manifest(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate"])
+        assert result.exit_code != 0
+
+    def test_validate_detailed_output_with_fixture(self, manifest_with_session):
+        """Validate shows sessions found, skipped, errors, partial data."""
+        manifest, sessions = manifest_with_session
+        # Add an unrecognizable directory
+        (sessions / "junk").mkdir()
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest)])
+        assert result.exit_code == 0
+        assert "1 sessions loaded" in result.output
+        assert "skipped" in result.output.lower()
+
+    def test_validate_catches_manifest_load_error(self, tmp_path):
+        """Validate exits with code 2 when manifest has invalid content."""
+        manifest = tmp_path / "raki.yaml"
+        manifest.write_text("invalid: yaml: content: [[[")
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest)])
+        assert result.exit_code == 2
+        assert "error" in result.output.lower()
+
+
+class TestCliRunNoLlm:
+    def test_run_no_llm_produces_json(self, manifest_with_session, tmp_path):
+        manifest, _sessions = manifest_with_session
+        output_dir = tmp_path / "results"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(manifest), "--no-llm", "-o", str(output_dir)],
+        )
+        assert result.exit_code == 0
+        json_files = list(output_dir.glob("*.json"))
+        assert len(json_files) == 1
+
+    def test_run_no_llm_shows_summary(self, manifest_with_session):
+        manifest, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(manifest), "--no-llm"],
+        )
+        assert result.exit_code == 0
+        assert "Operational Health" in result.output
+
+
+class TestCliRunQuiet:
+    def test_quiet_mode_suppresses_summary(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm", "-q"],
+        )
+        assert result.exit_code == 0
+        assert "Operational Health" not in result.output
+
+
+class TestCliRunDefaultManifest:
+    def test_discovers_raki_yaml(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest = tmp_path / "raki.yaml"
+        manifest.write_text(f"sessions:\n  path: {sessions}\n  format: auto\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "--no-llm"])
+        assert result.exit_code == 0
+
+    def test_discovers_eval_manifest_yaml(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest = tmp_path / "eval-manifest.yaml"
+        manifest.write_text(f"sessions:\n  path: {sessions}\n  format: auto\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "--no-llm"])
+        assert result.exit_code == 0
+
+    def test_prints_discovered_manifest(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest = tmp_path / "raki.yaml"
+        manifest.write_text(f"sessions:\n  path: {sessions}\n  format: auto\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "--no-llm"])
+        assert "raki.yaml" in result.output
+
+    def test_error_when_no_manifest_found(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "--no-llm"])
+        assert result.exit_code == 2
+
+
+class TestCliRunThreshold:
+    def test_warns_threshold_with_no_llm(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm", "--threshold", "0.8"],
+        )
+        assert "threshold" in result.output.lower()
+        assert "no-llm" in result.output.lower() or "no_llm" in result.output.lower()
+
+
+class TestCliRunJson:
+    def test_json_stdout_flag(self, manifest_with_session):
+        manifest, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(manifest), "--no-llm", "--json", "-q"],
+        )
+        assert result.exit_code == 0
+        # Output should contain valid JSON with run_id
+        assert '"run_id"' in result.output
+
+    def test_json_stdout_strips_session_data(self, manifest_with_session):
+        """JSON stdout should strip session data by default like write_json_report."""
+        import json
+
+        manifest, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(manifest), "--no-llm", "--json", "-q"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        for sample_result in data.get("sample_results", []):
+            sample = sample_result.get("sample", {})
+            for phase in sample.get("phases", []):
+                assert phase["output"] == "<stripped>"
+
+
+class TestCliRunVerbose:
+    def test_verbose_shows_debug_info(self, tmp_path):
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        # Add an unrecognizable directory to trigger skip output
+        (sessions / "unknown").mkdir()
+        manifest = tmp_path / "raki.yaml"
+        manifest.write_text(f"sessions:\n  path: {sessions}\n  format: auto\n")
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(manifest), "--no-llm", "-v"],
+        )
+        assert result.exit_code == 0
+        assert "Skipped" in result.output or "skipped" in result.output.lower()
+
+
+class TestCliExitCodes:
+    def test_exit_code_0_on_success(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm"],
+        )
+        assert result.exit_code == 0
+
+    def test_exit_code_2_on_error(self, tmp_path):
+        """Exit code 2 when manifest not found."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(tmp_path / "nonexistent.yaml")],
+        )
+        assert result.exit_code == 2
+
+
+class TestCliUnimplementedOptions:
+    def test_warns_adapter_option(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm", "--adapter", "custom"],
+        )
+        assert "Warning: --adapter is not yet implemented" in result.output
+
+    def test_warns_metrics_option(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm", "--metrics", "f1,recall"],
+        )
+        assert "Warning: --metrics is not yet implemented" in result.output
+
+    def test_warns_parallel_option(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm", "-p", "8"],
+        )
+        assert "Warning: --parallel is not yet implemented" in result.output
+
+    def test_warns_tenant_option(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm", "--tenant", "acme"],
+        )
+        assert "Warning: --tenant is not yet implemented" in result.output
+
+    def test_no_warning_for_default_parallel(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm"],
+        )
+        assert "Warning: --parallel" not in result.output


### PR DESCRIPTION
## Summary
Phase 1 CLI completion — wires all modules into the Click CLI:
- `raki run`: manifest → adapter registry → dataset loader → metrics engine → report pipeline
- `raki validate`: session discovery health check with detailed output
- `raki adapters`: lists registered adapters (session-schema, alcove)
- `--no-llm` mode skips LLM-dependent metrics
- `--json` stdout with session data stripping (respects --include-sessions)
- `--threshold` exit codes: 0 (pass), 1 (below threshold), 2 (error)
- Manifest auto-discovery (raki.yaml → eval-manifest.yaml)
- Warnings for unimplemented options (--adapter, --metrics, --parallel, --tenant)

Refs #8

## Review
- Python Specialist: 3 IMPORTANT findings fixed (validate error handling, unused options warning, fixture duplication), clean on re-review
- Security Specialist: 1 IMPORTANT finding fixed (--json stripping), clean on re-review
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko