### PR TITLE
feat(ground-truth): add ground truth loader and domain-based matcher

### DIFF
--- a/ground-truth/curated.yaml
+++ b/ground-truth/curated.yaml
@@ -1,0 +1,145 @@
+# Curated ground truth entries for RAKI evaluation.
+# Each entry covers a real gotcha, procedure, or fact from the project docs.
+
+- id: gt-001
+  question: "How should destructive git operations be handled in this project?"
+  expected_contexts:
+    - "no force-push"
+    - "no --no-verify"
+    - "no amending pushed commits"
+  reference_answer: >
+    Destructive git operations are prohibited. Never force-push, never use
+    --no-verify, and never amend pushed commits. Pre-commit hooks enforce
+    ruff check, ruff format, ty check, and email validation.
+  domains: [git, guardrails, safety]
+  difficulty: medium
+  knowledge_type: constraint
+  expected_phase: implement
+
+- id: gt-002
+  question: "What type checker does RAKI use and what strict-mode gotcha applies?"
+  expected_contexts:
+    - "ty for type checking"
+    - "Protocol attributes must be satisfied by class variables"
+  reference_answer: >
+    RAKI uses ty (not mypy) for type checking in strict mode. The key gotcha
+    is that Protocol attributes must be satisfied by class variables, not
+    instance attributes.
+  domains: [typing, tooling, conventions]
+  difficulty: medium
+  knowledge_type: fact
+  expected_phase: triage
+
+- id: gt-003
+  question: "How should YAML files be loaded safely?"
+  expected_contexts:
+    - "yaml.safe_load only"
+    - "never yaml.load"
+  reference_answer: >
+    Always use yaml.safe_load, never yaml.load. This prevents arbitrary
+    code execution from untrusted YAML content.
+  domains: [yaml, security, conventions]
+  difficulty: easy
+  knowledge_type: constraint
+  expected_phase: implement
+
+- id: gt-004
+  question: "How should mutable defaults be defined in Pydantic models?"
+  expected_contexts:
+    - "Field(default_factory=...)"
+    - "Pydantic 2"
+  reference_answer: >
+    Mutable defaults (lists, dicts, sets) must use
+    Field(default_factory=...) in Pydantic 2 models. Never use bare mutable
+    default values in field definitions.
+  domains: [models, pydantic, conventions]
+  difficulty: easy
+  knowledge_type: procedure
+  expected_phase: implement
+
+- id: gt-005
+  question: "How should operational and retrieval metrics be combined?"
+  expected_contexts:
+    - "no blended score"
+    - "separate categories"
+  reference_answer: >
+    Operational and retrieval metrics must never be combined into a single
+    blended score. They are reported as separate categories. Operational
+    metrics return raw values (cost in dollars, cycles as count), not
+    0-1 normalized values.
+  domains: [metrics, reporting, architecture]
+  difficulty: hard
+  knowledge_type: constraint
+  expected_phase: implement
+
+- id: gt-006
+  question: "What is the correct development methodology for RAKI?"
+  expected_contexts:
+    - "TDD"
+    - "write failing tests first"
+  reference_answer: >
+    RAKI follows strict TDD (Test-Driven Development). Write failing tests
+    first, then implement. No exceptions. Prefer small, reviewable changes
+    over large sweeps.
+  domains: [testing, methodology, conventions]
+  difficulty: easy
+  knowledge_type: procedure
+  expected_phase: triage
+
+- id: gt-007
+  question: "How must adapters handle sensitive data before populating EvalSample?"
+  expected_contexts:
+    - "redact_sensitive()"
+    - "all adapters must call redact_sensitive"
+  reference_answer: >
+    All adapters must call redact_sensitive() before populating EvalSample.
+    Reports strip raw session data by default; use --include-sessions to
+    opt in. No credentials may appear in code, config, or reports.
+  domains: [adapters, security, redaction]
+  difficulty: medium
+  knowledge_type: procedure
+  expected_phase: implement
+
+- id: gt-008
+  question: "What is the correct branch workflow for RAKI development?"
+  expected_contexts:
+    - "never commit to main directly"
+    - "worktree-based development"
+    - "task/<N>-<short-name>"
+  reference_answer: >
+    Never commit to main directly. All work happens on feature branches
+    using the naming convention task/<N>-<short-name>. Development uses
+    git worktrees under .worktrees/ with no more than 2 active worktrees
+    at once.
+  domains: [git, workflow, conventions]
+  difficulty: medium
+  knowledge_type: procedure
+  expected_phase: triage
+
+- id: gt-009
+  question: "How should constrained string fields be typed in RAKI models?"
+  expected_contexts:
+    - "Literal types"
+    - "not bare str"
+  reference_answer: >
+    Constrained string fields (e.g. severity levels, difficulty) must use
+    Literal types, not bare str. For example, ReviewFinding.severity uses
+    Literal["critical", "major", "minor"].
+  domains: [models, typing, conventions]
+  difficulty: easy
+  knowledge_type: constraint
+  expected_phase: implement
+
+- id: gt-010
+  question: "How does the adapter detection handle large session files?"
+  expected_contexts:
+    - "detect() must read only the first 4KB"
+    - "50MB+ session files"
+  reference_answer: >
+    Some session formats can be 50MB or larger. The detect() method in
+    adapters must read only the first 4KB of the file to determine the
+    format, avoiding loading the entire file into memory.
+  domains: [adapters, performance, detection]
+  difficulty: hard
+  knowledge_type: fact
+  expected_phase: implement

--- a/raki.yaml
+++ b/raki.yaml
@@ -1,0 +1,21 @@
+# RAKI evaluation manifest for bootstrap data.
+# Points at the curated ground truth and session fixtures used during
+# development and CI.
+
+sessions:
+  path: tests/fixtures/sessions
+  format: auto
+
+sources:
+  - path: AGENTS.md
+    repo: raki
+    domains: [conventions, architecture, tooling]
+
+ground_truth:
+  path: ground-truth/curated.yaml
+
+synthetic:
+  enabled: false
+  output: ground-truth/synthetic.yaml
+  count: 50
+  seed: 42

--- a/src/raki/ground_truth/__init__.py
+++ b/src/raki/ground_truth/__init__.py
@@ -1,3 +1,10 @@
 from raki.ground_truth.manifest import EvalManifest, discover_manifest, load_manifest
+from raki.ground_truth.matcher import load_ground_truth, match_ground_truth
 
-__all__ = ["EvalManifest", "discover_manifest", "load_manifest"]
+__all__ = [
+    "EvalManifest",
+    "discover_manifest",
+    "load_ground_truth",
+    "load_manifest",
+    "match_ground_truth",
+]

--- a/src/raki/ground_truth/matcher.py
+++ b/src/raki/ground_truth/matcher.py
@@ -1,0 +1,86 @@
+"""Ground truth loading from curated YAML and domain-based matching to sessions."""
+
+from pathlib import Path
+
+import yaml
+
+from raki.model import EvalSample
+from raki.model.ground_truth import GroundTruth
+
+
+def load_ground_truth(path: Path) -> list[GroundTruth]:
+    """Load ground truth entries from a curated YAML file.
+
+    Uses ``GroundTruth(**item)`` pattern so the Pydantic model is the single
+    source of truth for field definitions.  Non-model keys (e.g. ``id``,
+    ``source``) present in the YAML are silently filtered out.
+
+    Args:
+        path: Path to a YAML file containing a list of ground truth entries.
+
+    Returns:
+        A list of validated GroundTruth instances.  Returns an empty list
+        when the file is empty or does not contain a YAML list.
+    """
+    raw = yaml.safe_load(path.read_text())
+    if not isinstance(raw, list):
+        return []
+    entries: list[GroundTruth] = []
+    model_fields = set(GroundTruth.model_fields.keys())
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        filtered = {key: value for key, value in item.items() if key in model_fields}
+        entries.append(GroundTruth(**filtered))
+    return entries
+
+
+def match_ground_truth(
+    sample: EvalSample,
+    entries: list[GroundTruth],
+) -> GroundTruth | None:
+    """Match a session sample to the best ground truth entry by domain overlap.
+
+    Extracts domains from the triage phase's ``output_structured["code_area"]``
+    field and finds the ground truth entry with the highest domain overlap.
+
+    Args:
+        sample: The evaluation sample to match against.
+        entries: Available ground truth entries.
+
+    Returns:
+        The best-matching GroundTruth entry, or None if no overlap exists.
+    """
+    session_domains = _extract_domains(sample)
+    if not session_domains:
+        return None
+    best_match: GroundTruth | None = None
+    best_overlap = 0
+    for entry in entries:
+        overlap = len(session_domains & set(entry.domains))
+        if overlap > best_overlap:
+            best_overlap = overlap
+            best_match = entry
+    return best_match
+
+
+def _extract_domains(sample: EvalSample) -> set[str]:
+    """Extract domain tokens from a sample's triage phase output.
+
+    Looks at ``output_structured["code_area"]`` in any triage-phase result
+    and splits the value on commas and whitespace to produce domain tokens.
+
+    Args:
+        sample: The evaluation sample to extract domains from.
+
+    Returns:
+        A set of lower-cased domain token strings.
+    """
+    domains: set[str] = set()
+    for phase in sample.phases:
+        if phase.name == "triage" and phase.output_structured:
+            code_area = phase.output_structured.get("code_area", "")
+            if isinstance(code_area, str):
+                for token in code_area.replace(",", " ").split():
+                    domains.add(token.lower().strip())
+    return domains

--- a/tests/fixtures/ground_truth/curated.yaml
+++ b/tests/fixtures/ground_truth/curated.yaml
@@ -1,0 +1,25 @@
+- id: gt-test-001
+  question: "How should destructive git operations be handled?"
+  expected_contexts:
+    - "git command validation"
+    - "shell indirection detection"
+  reference_answer: >
+    Destructive git operations must be validated through
+    command validation and shell indirection detection.
+  domains: [git, guardrails]
+  source: test
+  difficulty: medium
+  knowledge_type: constraint
+  expected_phase: implement
+
+- id: gt-test-002
+  question: "What embedding dimension is required?"
+  expected_contexts:
+    - "768-dimensional vectors"
+  reference_answer: >
+    All embedding providers must produce 768-dimensional vectors.
+  domains: [embeddings, knowledge]
+  source: test
+  difficulty: easy
+  knowledge_type: fact
+  expected_phase: triage

--- a/tests/test_ground_truth.py
+++ b/tests/test_ground_truth.py
@@ -1,0 +1,207 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from raki.ground_truth.matcher import load_ground_truth, match_ground_truth
+from raki.model import EvalSample, PhaseResult, SessionMeta
+from raki.model.ground_truth import GroundTruth
+
+FIXTURES = Path(__file__).parent / "fixtures" / "ground_truth"
+
+
+def test_load_ground_truth():
+    entries = load_ground_truth(FIXTURES / "curated.yaml")
+    assert len(entries) == 2
+    assert entries[0].question is not None
+    assert len(entries[0].domains) > 0
+
+
+def test_load_ground_truth_preserves_fields():
+    entries = load_ground_truth(FIXTURES / "curated.yaml")
+    first = entries[0]
+    assert first.difficulty == "medium"
+    assert first.knowledge_type == "constraint"
+    assert first.expected_phase == "implement"
+    assert first.expected_contexts is not None
+    assert len(first.expected_contexts) == 2
+
+
+def test_load_ground_truth_filters_unknown_keys():
+    """Non-model keys like 'id' and 'source' should be filtered out, not cause errors."""
+    entries = load_ground_truth(FIXTURES / "curated.yaml")
+    assert len(entries) >= 2
+
+
+def test_load_ground_truth_empty_file(tmp_path: Path):
+    empty_file = tmp_path / "empty.yaml"
+    empty_file.write_text("")
+    entries = load_ground_truth(empty_file)
+    assert entries == []
+
+
+def test_load_ground_truth_non_list(tmp_path: Path):
+    non_list_file = tmp_path / "scalar.yaml"
+    non_list_file.write_text("not_a_list: true")
+    entries = load_ground_truth(non_list_file)
+    assert entries == []
+
+
+def test_load_ground_truth_skips_non_dict_items(tmp_path: Path):
+    """Non-dict items (strings, numbers, nulls) in the YAML list are silently skipped."""
+    mixed_file = tmp_path / "mixed.yaml"
+    mixed_file.write_text(
+        "- just a bare string\n"
+        "- 42\n"
+        "- null\n"
+        "- question: 'Valid entry'\n"
+        "  reference_answer: 'An answer'\n"
+        "  domains: [testing]\n"
+        "- question: 'Another valid entry'\n"
+        "  reference_answer: 'Another answer'\n"
+        "  domains: [quality]\n"
+    )
+    entries = load_ground_truth(mixed_file)
+    assert len(entries) == 2
+    assert entries[0].question == "Valid entry"
+    assert entries[1].question == "Another valid entry"
+
+
+def test_match_ground_truth_by_domain():
+    entries = [
+        GroundTruth(
+            question="How to handle git ops?",
+            reference_answer="Use guardrails",
+            domains=["git", "guardrails"],
+        ),
+        GroundTruth(
+            question="How to deploy?",
+            reference_answer="Use CI",
+            domains=["deployment", "ci"],
+        ),
+    ]
+    meta = SessionMeta(
+        session_id="1",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=1,
+        rework_cycles=0,
+    )
+    triage = PhaseResult(
+        name="triage",
+        generation=1,
+        status="completed",
+        output="git operations",
+        output_structured={"code_area": "git commands, guardrails"},
+    )
+    sample = EvalSample(session=meta, phases=[triage], findings=[], events=[])
+    matched = match_ground_truth(sample, entries)
+    assert matched is not None
+    assert "git" in matched.domains
+
+
+def test_match_ground_truth_no_match():
+    entries = [
+        GroundTruth(
+            question="How to deploy?",
+            reference_answer="Use CI",
+            domains=["deployment"],
+        ),
+    ]
+    meta = SessionMeta(
+        session_id="1",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=1,
+        rework_cycles=0,
+    )
+    triage = PhaseResult(
+        name="triage",
+        generation=1,
+        status="completed",
+        output="database migration",
+        output_structured={"code_area": "database"},
+    )
+    sample = EvalSample(session=meta, phases=[triage], findings=[], events=[])
+    matched = match_ground_truth(sample, entries)
+    assert matched is None
+
+
+def test_match_ground_truth_picks_best_overlap():
+    entries = [
+        GroundTruth(
+            question="Single domain match",
+            reference_answer="Partial",
+            domains=["git"],
+        ),
+        GroundTruth(
+            question="Double domain match",
+            reference_answer="Better",
+            domains=["git", "guardrails"],
+        ),
+    ]
+    meta = SessionMeta(
+        session_id="1",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=1,
+        rework_cycles=0,
+    )
+    triage = PhaseResult(
+        name="triage",
+        generation=1,
+        status="completed",
+        output="git guardrails",
+        output_structured={"code_area": "git, guardrails"},
+    )
+    sample = EvalSample(session=meta, phases=[triage], findings=[], events=[])
+    matched = match_ground_truth(sample, entries)
+    assert matched is not None
+    assert matched.question == "Double domain match"
+
+
+def test_match_ground_truth_no_triage_phase():
+    """If there is no triage phase, no domains are extracted and no match is returned."""
+    entries = [
+        GroundTruth(
+            question="How to deploy?",
+            reference_answer="Use CI",
+            domains=["deployment"],
+        ),
+    ]
+    meta = SessionMeta(
+        session_id="1",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=1,
+        rework_cycles=0,
+    )
+    implement = PhaseResult(
+        name="implement",
+        generation=1,
+        status="completed",
+        output="done",
+    )
+    sample = EvalSample(session=meta, phases=[implement], findings=[], events=[])
+    matched = match_ground_truth(sample, entries)
+    assert matched is None
+
+
+def test_match_ground_truth_no_structured_output():
+    """If triage has no output_structured, no domains are extracted."""
+    entries = [
+        GroundTruth(
+            question="How to deploy?",
+            reference_answer="Use CI",
+            domains=["deployment"],
+        ),
+    ]
+    meta = SessionMeta(
+        session_id="1",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=1,
+        rework_cycles=0,
+    )
+    triage = PhaseResult(
+        name="triage",
+        generation=1,
+        status="completed",
+        output="deployment stuff",
+    )
+    sample = EvalSample(session=meta, phases=[triage], findings=[], events=[])
+    matched = match_ground_truth(sample, entries)
+    assert matched is None


### PR DESCRIPTION
## Summary
- Add `load_ground_truth()` with `GroundTruth(**item)` pattern and non-dict item guard
- Add `match_ground_truth()` using domain overlap between ground truth and session triage domains
- Include 10 curated ground truth entries in `ground-truth/curated.yaml`
- Add bootstrap `raki.yaml` manifest

Refs #9

## Review
- Python Specialist: 1 IMPORTANT finding fixed (non-dict YAML crash), re-verified clean
- Security Specialist: not applicable
- RAG Specialist: clean (domain extraction matches spec, noted as future enhancement area)

## Notes
- Domain extraction currently scoped to triage phase `code_area` per spec; fallback chains can be added later
- Tie-breaking on equal domain overlap is first-match (deterministic given stable input order)
- PR #20 was an accidental merge of `main` into `feat/project-setup` — this PR is the correct one

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko