### PR TITLE
feat(metrics): add Ragas core metrics with context precision and recall

### DIFF
--- a/src/raki/metrics/ragas/__init__.py
+++ b/src/raki/metrics/ragas/__init__.py
@@ -1,0 +1,5 @@
+"""Ragas-backed retrieval quality metrics.
+
+This package is isolated from the rest of RAKI. Ragas imports are deferred
+to avoid hard dependency — the ``ragas`` extra must be installed.
+"""

--- a/src/raki/metrics/ragas/adapter.py
+++ b/src/raki/metrics/ragas/adapter.py
@@ -1,0 +1,82 @@
+"""Adapter from EvalDataset to Ragas-compatible row format.
+
+Maps EvalSample fields to Ragas 0.4 SingleTurnSample field names without
+importing ragas — this module has no ragas dependency.
+"""
+
+from dataclasses import dataclass
+
+from raki.model import EvalDataset, EvalSample
+from raki.model.phases import PhaseResult
+
+
+@dataclass
+class RagasRow:
+    """Internal representation matching Ragas 0.4 SingleTurnSample fields."""
+
+    session_id: str
+    user_input: str  # maps to SingleTurnSample.user_input
+    retrieved_contexts: list[str]  # maps to SingleTurnSample.retrieved_contexts
+    response: str  # maps to SingleTurnSample.response
+    reference: str | None  # maps to SingleTurnSample.reference (was ground_truths in v0.3)
+
+
+def to_ragas_rows(dataset: EvalDataset) -> list[RagasRow]:
+    """Extract RagasRow objects from an EvalDataset.
+
+    Skips samples that have no implement/session phase or no knowledge_context.
+    """
+    rows: list[RagasRow] = []
+    for sample in dataset.samples:
+        implement = _find_phase(sample, "implement") or _find_phase(sample, "session")
+        if implement is None or implement.knowledge_context is None:
+            continue
+        contexts = [
+            chunk.strip() for chunk in implement.knowledge_context.split("\n---\n") if chunk.strip()
+        ]
+        if not contexts:
+            continue
+        user_input = _extract_question(sample)
+        response = implement.output
+        reference = None
+        if sample.ground_truth and sample.ground_truth.reference_answer:
+            reference = sample.ground_truth.reference_answer
+        rows.append(
+            RagasRow(
+                session_id=sample.session.session_id,
+                user_input=user_input,
+                retrieved_contexts=contexts,
+                response=response,
+                reference=reference,
+            )
+        )
+    return rows
+
+
+def _find_phase(sample: EvalSample, name: str) -> PhaseResult | None:
+    """Find the latest generation of a named phase."""
+    phases = [phase for phase in sample.phases if phase.name == name]
+    if not phases:
+        return None
+    return max(phases, key=lambda phase: phase.generation)
+
+
+def _extract_question(sample: EvalSample) -> str:
+    """Extract a question/task description from the sample.
+
+    Priority:
+    1. Ground truth question
+    2. Triage approach or summary from output_structured
+    3. Session ticket or session_id as fallback
+    """
+    if sample.ground_truth and sample.ground_truth.question:
+        return sample.ground_truth.question
+    for phase in sample.phases:
+        if phase.name == "triage" and phase.output_structured:
+            approach = phase.output_structured.get("approach", "")
+            if approach:
+                return approach
+            summary = phase.output_structured.get("summary", "")
+            if summary:
+                return summary
+    return sample.session.ticket or sample.session.session_id

--- a/src/raki/metrics/ragas/async_utils.py
+++ b/src/raki/metrics/ragas/async_utils.py
@@ -1,0 +1,27 @@
+"""Async utilities for running coroutines from synchronous Metric.compute() methods.
+
+Provides loop-safe async execution — avoids bare asyncio.run() which fails
+when called from within an already-running event loop.
+"""
+
+import asyncio
+import concurrent.futures
+from collections.abc import Coroutine
+from typing import Any
+
+
+def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
+    """Run an async coroutine safely from sync context.
+
+    If no event loop is running, uses asyncio.run() directly.
+    If an event loop IS running (e.g., inside pytest-asyncio or Jupyter),
+    spawns a new thread with its own event loop.
+    """
+    try:
+        asyncio.get_running_loop()
+        # Already inside an event loop — run in a separate thread
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(asyncio.run, coro).result()
+    except RuntimeError:
+        # No running loop — safe to use asyncio.run directly
+        return asyncio.run(coro)

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -1,0 +1,76 @@
+"""LLM setup and judge logging for Ragas metrics.
+
+Uses Ragas 0.4 llm_factory with AsyncAnthropicVertex for Anthropic models
+on Google Cloud Vertex AI.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+from raki.adapters.redact import redact_sensitive
+from raki.metrics.protocol import MetricConfig
+
+logger = logging.getLogger(__name__)
+
+
+def create_ragas_llm(config: MetricConfig):
+    """Create a Ragas LLM using the 0.4 llm_factory.
+
+    Defers ragas and anthropic imports so this module can be imported
+    without those packages installed.
+    """
+    from anthropic import AsyncAnthropicVertex  # ty: ignore[unresolved-import]
+    from ragas.llms import llm_factory  # ty: ignore[unresolved-import]
+
+    client = AsyncAnthropicVertex()
+    return llm_factory(
+        config.llm_model,
+        client=client,
+    )
+
+
+def _validate_judge_log_path(log_path: Path) -> Path:
+    """Validate that the judge log path is under the current working directory.
+
+    Follows the same path traversal guard pattern used by the session schema
+    adapter and manifest loader.
+    """
+    resolved = log_path.resolve()
+    cwd = Path.cwd().resolve()
+    if not resolved.is_relative_to(cwd):
+        raise ValueError(f"judge_log_path escapes project root: {resolved} is not under {cwd}")
+    return resolved
+
+
+class JudgeLogger:
+    """Logs all LLM judge calls to JSONL for audit.
+
+    Each line is a JSON object with metric name, truncated and redacted
+    user_input, score, and optional reason.
+    """
+
+    def __init__(self, log_path: Path):
+        self.log_path = _validate_judge_log_path(log_path)
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def log(
+        self,
+        metric_name: str,
+        user_input: str,
+        result_value: float,
+        result_reason: str | None,
+    ) -> None:
+        """Append a judge call record to the JSONL log file."""
+        with self.log_path.open("a") as log_file:
+            log_file.write(
+                json.dumps(
+                    {
+                        "metric": metric_name,
+                        "user_input": redact_sensitive(user_input[:200]),
+                        "score": result_value,
+                        "reason": result_reason,
+                    }
+                )
+                + "\n"
+            )

--- a/src/raki/metrics/ragas/precision.py
+++ b/src/raki/metrics/ragas/precision.py
@@ -1,0 +1,95 @@
+"""Context precision metric using Ragas 0.4 ContextPrecisionWithReference.
+
+Measures how relevant the retrieved contexts are to answering the user's question,
+given a reference answer. Higher is better.
+"""
+
+import asyncio
+import logging
+
+from raki.adapters.redact import redact_sensitive
+from raki.metrics.protocol import MetricConfig
+from raki.metrics.ragas.adapter import to_ragas_rows
+from raki.metrics.ragas.async_utils import run_async
+from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+logger = logging.getLogger(__name__)
+
+
+class ContextPrecisionMetric:
+    """Ragas-backed context precision metric satisfying the Metric protocol."""
+
+    name: str = "context_precision"
+    requires_ground_truth: bool = True
+    requires_llm: bool = True
+    higher_is_better: bool = True
+    display_format: str = "score"
+    display_name: str = "Context precision"
+
+    def compute(
+        self,
+        dataset: EvalDataset,
+        config: MetricConfig,
+    ) -> MetricResult:
+        rows = to_ragas_rows(dataset)
+        rows_with_ref = [row for row in rows if row.reference is not None]
+        if not rows_with_ref:
+            return MetricResult(name=self.name, score=0.0, details={"skipped": "no ground truth"})
+
+        from ragas.metrics.collections import (  # ty: ignore[unresolved-import]
+            ContextPrecisionWithReference,
+        )
+
+        llm = create_ragas_llm(config)
+        ragas_metric = ContextPrecisionWithReference(llm=llm)
+
+        judge_logger: JudgeLogger | None = None
+        if config.judge_log_path is not None:
+            judge_logger = JudgeLogger(config.judge_log_path)
+
+        sample_scores: dict[str, float] = {}
+        scores: list[float] = []
+
+        async def score_all():
+            semaphore = asyncio.Semaphore(config.batch_size)
+
+            async def score_one(row):
+                async with semaphore:
+                    try:
+                        result = await ragas_metric.ascore(
+                            user_input=row.user_input,
+                            retrieved_contexts=row.retrieved_contexts,
+                            reference=row.reference,
+                        )
+                        score = result if isinstance(result, float) else result.value
+                        scores.append(score)
+                        sample_scores[row.session_id] = score
+                        reason = None if isinstance(result, float) else result.reason
+                        if judge_logger:
+                            judge_logger.log(self.name, row.user_input, score, reason)
+                    except Exception as exc:
+                        safe_error = redact_sensitive(f"ERROR: {exc}")
+                        logger.warning(
+                            "context_precision scoring failed for session %s: %s",
+                            row.session_id,
+                            safe_error,
+                        )
+                        if judge_logger:
+                            judge_logger.log(self.name, row.user_input, -1.0, safe_error)
+
+            await asyncio.gather(*(score_one(row) for row in rows_with_ref))
+
+        run_async(score_all())
+
+        mean_score = sum(scores) / len(scores) if scores else 0.0
+        return MetricResult(
+            name=self.name,
+            score=mean_score,
+            details={
+                "samples_scored": len(scores),
+                "samples_skipped": len(rows_with_ref) - len(scores),
+            },
+            sample_scores=sample_scores,
+        )

--- a/src/raki/metrics/ragas/recall.py
+++ b/src/raki/metrics/ragas/recall.py
@@ -1,0 +1,95 @@
+"""Context recall metric using Ragas 0.4 ContextRecall.
+
+Measures how well the retrieved contexts cover the information needed
+to answer the question, given a reference answer. Higher is better.
+"""
+
+import asyncio
+import logging
+
+from raki.adapters.redact import redact_sensitive
+from raki.metrics.protocol import MetricConfig
+from raki.metrics.ragas.adapter import to_ragas_rows
+from raki.metrics.ragas.async_utils import run_async
+from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+logger = logging.getLogger(__name__)
+
+
+class ContextRecallMetric:
+    """Ragas-backed context recall metric satisfying the Metric protocol."""
+
+    name: str = "context_recall"
+    requires_ground_truth: bool = True
+    requires_llm: bool = True
+    higher_is_better: bool = True
+    display_format: str = "score"
+    display_name: str = "Context recall"
+
+    def compute(
+        self,
+        dataset: EvalDataset,
+        config: MetricConfig,
+    ) -> MetricResult:
+        rows = to_ragas_rows(dataset)
+        rows_with_ref = [row for row in rows if row.reference is not None]
+        if not rows_with_ref:
+            return MetricResult(name=self.name, score=0.0, details={"skipped": "no ground truth"})
+
+        from ragas.metrics.collections import (  # ty: ignore[unresolved-import]
+            ContextRecall,
+        )
+
+        llm = create_ragas_llm(config)
+        ragas_metric = ContextRecall(llm=llm)
+
+        judge_logger: JudgeLogger | None = None
+        if config.judge_log_path is not None:
+            judge_logger = JudgeLogger(config.judge_log_path)
+
+        sample_scores: dict[str, float] = {}
+        scores: list[float] = []
+
+        async def score_all():
+            semaphore = asyncio.Semaphore(config.batch_size)
+
+            async def score_one(row):
+                async with semaphore:
+                    try:
+                        result = await ragas_metric.ascore(
+                            user_input=row.user_input,
+                            retrieved_contexts=row.retrieved_contexts,
+                            reference=row.reference,
+                        )
+                        score = result if isinstance(result, float) else result.value
+                        scores.append(score)
+                        sample_scores[row.session_id] = score
+                        reason = None if isinstance(result, float) else result.reason
+                        if judge_logger:
+                            judge_logger.log(self.name, row.user_input, score, reason)
+                    except Exception as exc:
+                        safe_error = redact_sensitive(f"ERROR: {exc}")
+                        logger.warning(
+                            "context_recall scoring failed for session %s: %s",
+                            row.session_id,
+                            safe_error,
+                        )
+                        if judge_logger:
+                            judge_logger.log(self.name, row.user_input, -1.0, safe_error)
+
+            await asyncio.gather(*(score_one(row) for row in rows_with_ref))
+
+        run_async(score_all())
+
+        mean_score = sum(scores) / len(scores) if scores else 0.0
+        return MetricResult(
+            name=self.name,
+            score=mean_score,
+            details={
+                "samples_scored": len(scores),
+                "samples_skipped": len(rows_with_ref) - len(scores),
+            },
+            sample_scores=sample_scores,
+        )

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -1,0 +1,519 @@
+"""Tests for Ragas-backed retrieval quality metrics.
+
+Adapter tests (to_ragas_rows, RagasRow) run without Ragas installed.
+Metric tests mock ragas and run without it installed.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from raki.model import (
+    EvalDataset,
+    EvalSample,
+    PhaseResult,
+    SessionMeta,
+)
+from raki.model.ground_truth import GroundTruth
+from raki.metrics.protocol import MetricConfig
+from raki.metrics.ragas.adapter import RagasRow, to_ragas_rows
+from raki.metrics.ragas.llm_setup import JudgeLogger
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sample_with_knowledge(
+    session_id: str = "1",
+    knowledge_context: str | None = "entry 1\n---\nentry 2",
+    output: str = "The answer based on knowledge",
+    ground_truth: GroundTruth | None = None,
+) -> EvalSample:
+    meta = SessionMeta(
+        session_id=session_id,
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=2,
+        rework_cycles=0,
+    )
+    triage = PhaseResult(
+        name="triage",
+        generation=1,
+        status="completed",
+        output="small",
+        output_structured={"ticket_key": "101", "approach": "Add validation"},
+    )
+    implement = PhaseResult(
+        name="implement",
+        generation=1,
+        status="completed",
+        output=output,
+        knowledge_context=knowledge_context,
+    )
+    return EvalSample(
+        session=meta,
+        phases=[triage, implement],
+        findings=[],
+        events=[],
+        ground_truth=ground_truth,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adapter tests — no ragas dependency needed
+# ---------------------------------------------------------------------------
+
+
+class TestRagasRow:
+    def test_ragas_row_fields(self):
+        row = RagasRow(
+            session_id="s1",
+            user_input="How to validate?",
+            retrieved_contexts=["ctx1", "ctx2"],
+            response="Use pydantic",
+            reference="Use pydantic models",
+        )
+        assert row.session_id == "s1"
+        assert row.user_input == "How to validate?"
+        assert row.retrieved_contexts == ["ctx1", "ctx2"]
+        assert row.response == "Use pydantic"
+        assert row.reference == "Use pydantic models"
+
+    def test_ragas_row_reference_none(self):
+        row = RagasRow(
+            session_id="s1",
+            user_input="q",
+            retrieved_contexts=["c"],
+            response="r",
+            reference=None,
+        )
+        assert row.reference is None
+
+
+class TestToRagasRows:
+    def test_extracts_contexts_with_ground_truth(self):
+        ground_truth = GroundTruth(
+            question="How to validate?",
+            reference_answer="Use pydantic",
+            domains=["validation"],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 1
+        assert rows[0].retrieved_contexts == ["entry 1", "entry 2"]
+        assert rows[0].user_input == "How to validate?"
+        assert rows[0].response == "The answer based on knowledge"
+        assert rows[0].reference == "Use pydantic"
+
+    def test_uses_ticket_summary_when_no_ground_truth(self):
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 1
+        assert "Add validation" in rows[0].user_input
+        assert rows[0].reference is None
+
+    def test_skips_samples_without_knowledge_context(self):
+        sample = _make_sample_with_knowledge(knowledge_context=None)
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 0
+
+    def test_skips_samples_without_implement_phase(self):
+        meta = SessionMeta(
+            session_id="x",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=1,
+            rework_cycles=0,
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[PhaseResult(name="triage", generation=1, status="completed", output="ok")],
+            findings=[],
+            events=[],
+        )
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 0
+
+    def test_multiple_samples(self):
+        gt1 = GroundTruth(question="Q1", reference_answer="A1", domains=[])
+        gt2 = GroundTruth(question="Q2", reference_answer="A2", domains=[])
+        sample1 = _make_sample_with_knowledge(session_id="s1", ground_truth=gt1)
+        sample2 = _make_sample_with_knowledge(session_id="s2", ground_truth=gt2)
+        no_knowledge = _make_sample_with_knowledge(session_id="s3", knowledge_context=None)
+        rows = to_ragas_rows(EvalDataset(samples=[sample1, sample2, no_knowledge]))
+        assert len(rows) == 2
+        assert {row.session_id for row in rows} == {"s1", "s2"}
+
+    def test_picks_latest_generation_implement_phase(self):
+        meta = SessionMeta(
+            session_id="gen-test",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=2,
+            rework_cycles=1,
+        )
+        impl_gen1 = PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
+            output="first attempt",
+            knowledge_context="old context",
+        )
+        impl_gen2 = PhaseResult(
+            name="implement",
+            generation=2,
+            status="completed",
+            output="second attempt",
+            knowledge_context="new ctx1\n---\nnew ctx2",
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[impl_gen1, impl_gen2],
+            findings=[],
+            events=[],
+        )
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 1
+        assert rows[0].response == "second attempt"
+        assert rows[0].retrieved_contexts == ["new ctx1", "new ctx2"]
+
+    def test_uses_session_phase_as_fallback(self):
+        meta = SessionMeta(
+            session_id="session-fallback",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=1,
+            rework_cycles=0,
+        )
+        session_phase = PhaseResult(
+            name="session",
+            generation=1,
+            status="completed",
+            output="session output",
+            knowledge_context="session knowledge",
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[session_phase],
+            findings=[],
+            events=[],
+            ground_truth=GroundTruth(question="Q?", reference_answer="A", domains=[]),
+        )
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 1
+        assert rows[0].response == "session output"
+        assert rows[0].retrieved_contexts == ["session knowledge"]
+
+
+# ---------------------------------------------------------------------------
+# JudgeLogger tests — no ragas dependency needed
+# ---------------------------------------------------------------------------
+
+
+class TestJudgeLogger:
+    def test_logs_to_jsonl(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.chdir(tmp_path)
+        log_path = tmp_path / "subdir" / "judge_log.jsonl"
+        judge_logger = JudgeLogger(log_path)
+        judge_logger.log("context_precision", "How to validate?", 0.85, "Good precision")
+        judge_logger.log("context_recall", "How to test?", 0.72, None)
+
+        lines = log_path.read_text().strip().split("\n")
+        assert len(lines) == 2
+
+        entry1 = json.loads(lines[0])
+        assert entry1["metric"] == "context_precision"
+        assert entry1["score"] == 0.85
+        assert entry1["reason"] == "Good precision"
+
+        entry2 = json.loads(lines[1])
+        assert entry2["metric"] == "context_recall"
+        assert entry2["score"] == 0.72
+        assert entry2["reason"] is None
+
+    def test_truncates_long_user_input(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.chdir(tmp_path)
+        log_path = tmp_path / "judge_log.jsonl"
+        judge_logger = JudgeLogger(log_path)
+        long_input = "x" * 500
+        judge_logger.log("test_metric", long_input, 0.5, None)
+
+        entry = json.loads(log_path.read_text().strip())
+        assert len(entry["user_input"]) == 200
+
+    def test_rejects_path_outside_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        subdir = tmp_path / "project"
+        subdir.mkdir()
+        monkeypatch.chdir(subdir)
+        outside_path = tmp_path / "outside" / "judge.jsonl"
+        with pytest.raises(ValueError, match="escapes project root"):
+            JudgeLogger(outside_path)
+
+
+# ---------------------------------------------------------------------------
+# Metric tests — mock ragas so tests run without it installed
+# ---------------------------------------------------------------------------
+
+
+def _install_ragas_mock(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_metric_class: MagicMock,
+    ragas_class_name: str,
+) -> None:
+    """Insert a fake ``ragas.metrics.collections`` module into sys.modules.
+
+    This lets ``from ragas.metrics.collections import <ragas_class_name>``
+    succeed inside ``compute()`` without ragas installed.
+    """
+    import sys
+
+    fake_collections = MagicMock()
+    setattr(fake_collections, ragas_class_name, mock_metric_class)
+    monkeypatch.setitem(sys.modules, "ragas", MagicMock())
+    monkeypatch.setitem(sys.modules, "ragas.metrics", MagicMock())
+    monkeypatch.setitem(sys.modules, "ragas.metrics.collections", fake_collections)
+
+
+class TestContextPrecisionMetric:
+    def test_skips_without_ground_truth(self):
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+
+        metric = ContextPrecisionMetric()
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+        result = metric.compute(dataset, config)
+        assert result.score == 0.0
+        assert result.details.get("skipped") == "no ground truth"
+
+    def test_computes_with_mocked_ragas(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_result = MagicMock()
+        mock_result.value = 0.85
+        mock_result.reason = "Good precision"
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_precision_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_precision_class, "ContextPrecisionWithReference")
+
+        ground_truth = GroundTruth(
+            question="How to validate?",
+            reference_answer="Use pydantic",
+            domains=["validation"],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+
+        log_path = tmp_path / "judge.jsonl"
+        config = MetricConfig(judge_log_path=log_path)
+
+        with patch(
+            "raki.metrics.ragas.precision.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextPrecisionMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.name == "context_precision"
+        assert result.score == pytest.approx(0.85)
+        assert result.details["samples_scored"] == 1
+        assert "1" in result.sample_scores
+
+        # Verify judge log was written
+        log_lines = log_path.read_text().strip().split("\n")
+        assert len(log_lines) == 1
+        log_entry = json.loads(log_lines[0])
+        assert log_entry["metric"] == "context_precision"
+        assert log_entry["score"] == 0.85
+
+    def test_handles_float_return_from_ascore(self, monkeypatch: pytest.MonkeyPatch):
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=0.75)
+
+        mock_precision_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_precision_class, "ContextPrecisionWithReference")
+
+        ground_truth = GroundTruth(
+            question="Q?",
+            reference_answer="A",
+            domains=[],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with patch(
+            "raki.metrics.ragas.precision.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextPrecisionMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.75)
+
+    def test_logs_errors_on_ascore_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(side_effect=RuntimeError("LLM down"))
+
+        mock_precision_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_precision_class, "ContextPrecisionWithReference")
+
+        ground_truth = GroundTruth(
+            question="Q?",
+            reference_answer="A",
+            domains=[],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+
+        log_path = tmp_path / "judge.jsonl"
+        config = MetricConfig(judge_log_path=log_path)
+
+        with patch(
+            "raki.metrics.ragas.precision.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextPrecisionMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == 0.0
+        assert result.details["samples_scored"] == 0
+
+        log_entry = json.loads(log_path.read_text().strip())
+        assert log_entry["score"] == -1.0
+        assert "LLM down" in log_entry["reason"]
+
+
+class TestContextRecallMetric:
+    def test_skips_without_ground_truth(self):
+        from raki.metrics.ragas.recall import ContextRecallMetric
+
+        metric = ContextRecallMetric()
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+        result = metric.compute(dataset, config)
+        assert result.score == 0.0
+        assert result.details.get("skipped") == "no ground truth"
+
+    def test_computes_with_mocked_ragas(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from raki.metrics.ragas.recall import ContextRecallMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_result = MagicMock()
+        mock_result.value = 0.92
+        mock_result.reason = "High recall"
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_recall_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_recall_class, "ContextRecall")
+
+        ground_truth = GroundTruth(
+            question="How to validate?",
+            reference_answer="Use pydantic",
+            domains=["validation"],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+
+        log_path = tmp_path / "judge.jsonl"
+        config = MetricConfig(judge_log_path=log_path)
+
+        with patch(
+            "raki.metrics.ragas.recall.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextRecallMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.name == "context_recall"
+        assert result.score == pytest.approx(0.92)
+        assert result.details["samples_scored"] == 1
+
+    def test_handles_float_return_from_ascore(self, monkeypatch: pytest.MonkeyPatch):
+        from raki.metrics.ragas.recall import ContextRecallMetric
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=0.88)
+
+        mock_recall_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_recall_class, "ContextRecall")
+
+        ground_truth = GroundTruth(
+            question="Q?",
+            reference_answer="A",
+            domains=[],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with patch(
+            "raki.metrics.ragas.recall.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextRecallMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.88)
+
+
+# ---------------------------------------------------------------------------
+# Async safety tests — verify _run_async works in different contexts
+# ---------------------------------------------------------------------------
+
+
+class TestRunAsync:
+    def test_run_async_outside_event_loop(self):
+        from raki.metrics.ragas.async_utils import run_async
+
+        async def simple_coro():
+            return 42
+
+        assert run_async(simple_coro()) == 42
+
+    def test_run_async_inside_event_loop(self):
+        """Verify run_async works even when called from within an event loop."""
+        import asyncio
+
+        from raki.metrics.ragas.async_utils import run_async
+
+        async def inner():
+            return 99
+
+        async def outer():
+            return run_async(inner())
+
+        result = asyncio.run(outer())
+        assert result == 99
+
+
+# ---------------------------------------------------------------------------
+# MetricConfig judge_log_path test
+# ---------------------------------------------------------------------------
+
+
+class TestMetricConfigJudgeLogPath:
+    def test_judge_log_path_default_none(self):
+        config = MetricConfig()
+        assert config.judge_log_path is None
+
+    def test_judge_log_path_set(self, tmp_path: Path):
+        log_path = tmp_path / "judge.jsonl"
+        config = MetricConfig(judge_log_path=log_path)
+        assert config.judge_log_path == log_path


### PR DESCRIPTION
## Summary
- Add `ContextPrecisionMetric` and `ContextRecallMetric` using Ragas 0.4.3 collections API
- Add `RagasRow` dataclass and `to_ragas_rows()` adapter for EvalDataset → Ragas mapping
- Add `create_ragas_llm()` using `llm_factory` with `AsyncAnthropicVertex`
- Add `JudgeLogger` with `redact_sensitive()` on inputs/errors and path traversal validation
- Add `run_async()` helper for loop-safe async execution
- Concurrent scoring via `asyncio.gather()` bounded by semaphore

Refs #10

## Review
- Python Specialist: 4 findings fixed (semaphore concurrency, return type, test skipping, kwargs confirmed), re-verified clean
- Security Specialist: 3 findings fixed (input redaction, error redaction, path validation), re-verified clean
- RAG Specialist: 3 findings fixed (concurrency, response kwarg removed, API confirmed), re-verified clean
- Note: AGENTS.md gotcha #2 is outdated — Ragas 0.4.3 `ascore()` takes kwargs, not `SingleTurnSample`

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko