### PR TITLE
feat(metrics): add experimental Ragas metrics and knowledge miss rate

### DIFF
--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from raki.adapters.redact import redact_sensitive
+
 console = Console()
 
 
@@ -84,6 +86,12 @@ def main():
     default=4,
     help="Max parallel LLM calls",
 )
+@click.option(
+    "--judge-model",
+    "judge_model",
+    default="claude-sonnet-4-6",
+    help="LLM model for judge metrics (default: claude-sonnet-4-6)",
+)
 @click.option("--tenant", default=None, help="Set tenant_id on the report")
 @click.option(
     "--include-sessions",
@@ -101,6 +109,7 @@ def run(
     adapter_format: str | None,
     metric_names: str | None,
     parallel_count: int,
+    judge_model: str,
     tenant: str | None,
     include_sessions: bool,
     json_stdout: bool,
@@ -110,7 +119,6 @@ def run(
     _warn_unimplemented_options(
         adapter=adapter_format,
         metrics=metric_names,
-        parallel=parallel_count if parallel_count != 4 else None,
         tenant=tenant,
     )
     manifest_file = _resolve_manifest(manifest_path, quiet=quiet)
@@ -120,7 +128,7 @@ def run(
 
         manifest = load_manifest(manifest_file)
     except Exception as exc:
-        console.print(f"[red]Error loading manifest: {exc}[/red]")
+        console.print(f"[red]Error loading manifest: {redact_sensitive(str(exc))}[/red]")
         raise SystemExit(2) from exc
 
     from raki.adapters import DatasetLoader
@@ -135,7 +143,7 @@ def run(
 
     if verbose:
         for error in loader.errors:
-            console.print(f"  [red]Error: {error.path} -- {error.error}[/red]")
+            console.print(f"  [red]Error: {error.path} -- {redact_sensitive(error.error)}[/red]")
         for skipped_path in loader.skipped:
             console.print(f"  [dim]Skipped: {skipped_path}[/dim]")
 
@@ -147,8 +155,30 @@ def run(
 
     from raki.metrics import MetricsEngine
     from raki.metrics.operational import ALL_OPERATIONAL
+    from raki.metrics.protocol import Metric, MetricConfig
 
-    engine = MetricsEngine(ALL_OPERATIONAL)
+    config = MetricConfig(
+        llm_model=judge_model,
+        batch_size=parallel_count,
+    )
+
+    all_metrics: list[Metric] = list(ALL_OPERATIONAL)
+    if not no_llm:
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+        from raki.metrics.ragas.recall import ContextRecallMetric
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        all_metrics.extend(
+            [
+                ContextPrecisionMetric(),
+                ContextRecallMetric(),
+                FaithfulnessMetric(),
+                AnswerRelevancyMetric(),
+            ]
+        )
+
+    engine = MetricsEngine(all_metrics, config=config)
     report = engine.run(dataset, skip_llm=no_llm)
 
     if not quiet:
@@ -176,11 +206,11 @@ def run(
     if json_stdout:
         import json as json_mod
 
-        from raki.report.json_report import _strip_session_data
+        from raki.report.json_report import strip_session_data
 
         data = report.model_dump(mode="json")
         if not include_sessions:
-            _strip_session_data(data)
+            strip_session_data(data)
         click.echo(json_mod.dumps(data, indent=2, default=str))
 
     if not quiet:
@@ -212,7 +242,7 @@ def validate(manifest_path: str | None, verbose: bool) -> None:
 
         manifest = load_manifest(manifest_file)
     except Exception as exc:
-        console.print(f"[red]Error loading manifest: {exc}[/red]")
+        console.print(f"[red]Error loading manifest: {redact_sensitive(str(exc))}[/red]")
         raise SystemExit(2) from exc
     console.print(f"[green]\u2713[/green] Manifest loaded: {manifest_file}")
     console.print(f"[green]\u2713[/green] Sessions path: {manifest.sessions.path}")
@@ -236,7 +266,7 @@ def validate(manifest_path: str | None, verbose: bool) -> None:
     if loader.errors:
         console.print(f"[red]\u2717[/red] {len(loader.errors)} sessions failed to load")
         for error in loader.errors:
-            console.print(f"    {error.path.name}: {error.error}")
+            console.print(f"    {error.path.name}: {redact_sensitive(error.error)}")
 
     console.print(
         f"\nReady to evaluate [bold]{len(dataset.samples)}[/bold] sessions"

--- a/src/raki/metrics/operational/__init__.py
+++ b/src/raki/metrics/operational/__init__.py
@@ -1,4 +1,5 @@
 from raki.metrics.operational.cost import CostEfficiency
+from raki.metrics.operational.knowledge_miss_rate import KnowledgeRetrievalMissRate
 from raki.metrics.operational.rework import ReworkCycles
 from raki.metrics.operational.severity import ReviewSeverityDistribution
 from raki.metrics.operational.verify_rate import FirstPassVerifyRate
@@ -8,12 +9,14 @@ ALL_OPERATIONAL = [
     ReworkCycles(),
     ReviewSeverityDistribution(),
     CostEfficiency(),
+    KnowledgeRetrievalMissRate(),
 ]
 
 __all__ = [
     "ALL_OPERATIONAL",
     "CostEfficiency",
     "FirstPassVerifyRate",
+    "KnowledgeRetrievalMissRate",
     "ReviewSeverityDistribution",
     "ReworkCycles",
 ]

--- a/src/raki/metrics/operational/knowledge_miss_rate.py
+++ b/src/raki/metrics/operational/knowledge_miss_rate.py
@@ -1,0 +1,78 @@
+"""Knowledge retrieval miss rate metric.
+
+For each rework-triggering finding (critical or major severity), classifies
+whether the issue stems from a retrieval gap (relevant knowledge was not
+retrieved) or a capability gap (knowledge was present but not applied).
+
+This is a purely operational metric -- no LLM required.
+"""
+
+from raki.metrics.protocol import MetricConfig
+from raki.model import EvalDataset, EvalSample
+from raki.model.report import MetricResult
+
+
+class KnowledgeRetrievalMissRate:
+    """Checks whether rework-triggering findings could have been prevented
+    by knowledge that was (or wasn't) in knowledge_context.
+
+    Score = retrieval_gaps / total_rework_findings.
+    Lower is better: 0.0 means all gaps are capability (knowledge was available),
+    1.0 means all gaps are retrieval (knowledge was missing).
+    """
+
+    name: str = "knowledge_retrieval_miss_rate"
+    requires_ground_truth: bool = False
+    requires_llm: bool = False
+    higher_is_better: bool = False
+    display_format: str = "score"
+    display_name: str = "Knowledge miss rate"
+
+    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:
+        retrieval_gaps = 0
+        capability_gaps = 0
+        total_rework_findings = 0
+
+        for sample in dataset.samples:
+            if sample.session.rework_cycles == 0:
+                continue
+
+            knowledge_text = self._extract_knowledge_context(sample)
+
+            for finding in sample.findings:
+                if finding.severity not in ("critical", "major"):
+                    continue
+                total_rework_findings += 1
+
+                # Word-boundary matching via set intersection avoids partial
+                # substring matches (e.g. "auth" matching "author").  Words must
+                # be longer than 4 characters to reduce false positives from
+                # common short words like "does", "code", "type".
+                issue_words_set = {word for word in finding.issue.lower().split() if len(word) > 4}
+                knowledge_words = set(knowledge_text.split()) if knowledge_text else set()
+                if issue_words_set & knowledge_words:
+                    capability_gaps += 1  # knowledge present but not applied
+                else:
+                    retrieval_gaps += 1  # no related knowledge retrieved
+
+        score = retrieval_gaps / total_rework_findings if total_rework_findings > 0 else 0.0
+        return MetricResult(
+            name=self.name,
+            score=score,
+            details={
+                "retrieval_gaps": retrieval_gaps,
+                "capability_gaps": capability_gaps,
+                "total_rework_findings": total_rework_findings,
+            },
+        )
+
+    @staticmethod
+    def _extract_knowledge_context(sample: EvalSample) -> str | None:
+        """Extract knowledge_context text from the latest implement or session phase."""
+        matching = [phase for phase in sample.phases if phase.name in ("implement", "session")]
+        if not matching:
+            return None
+        phase = max(matching, key=lambda phase: phase.generation)
+        if phase.knowledge_context is None:
+            return None
+        return phase.knowledge_context.lower()

--- a/src/raki/metrics/ragas/faithfulness.py
+++ b/src/raki/metrics/ragas/faithfulness.py
@@ -1,0 +1,107 @@
+"""Faithfulness metric using Ragas 0.4 legacy Faithfulness @dataclass.
+
+Measures whether the generated response is faithful to the retrieved contexts
+(i.e., not hallucinating beyond what the contexts provide).
+
+EXPERIMENTAL: This metric was designed for natural language answers, not code.
+Scores may be noisy for agentic code-generation sessions.
+"""
+
+import asyncio
+import logging
+
+from raki.adapters.redact import redact_sensitive
+from raki.metrics.protocol import MetricConfig
+from raki.metrics.ragas.adapter import to_ragas_rows
+from raki.metrics.ragas.async_utils import run_async
+from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+logger = logging.getLogger(__name__)
+
+
+class FaithfulnessMetric:
+    """Ragas-backed faithfulness metric satisfying the Metric protocol.
+
+    Uses the legacy Faithfulness @dataclass API with single_turn_ascore().
+    Marked as experimental -- designed for NL answers, not code.
+    """
+
+    name: str = "faithfulness"
+    requires_ground_truth: bool = False
+    requires_llm: bool = True
+    higher_is_better: bool = True
+    display_format: str = "score"
+    display_name: str = "Faithfulness"
+    experimental: bool = True
+
+    def compute(
+        self,
+        dataset: EvalDataset,
+        config: MetricConfig,
+    ) -> MetricResult:
+        rows = to_ragas_rows(dataset)
+        if not rows:
+            return MetricResult(name=self.name, score=0.0, details={"skipped": "no samples"})
+
+        from ragas.dataset_schema import SingleTurnSample  # ty: ignore[unresolved-import]
+        from ragas.metrics._faithfulness import (  # ty: ignore[unresolved-import]
+            Faithfulness as RagasFaithfulness,
+        )
+
+        llm = create_ragas_llm(config)
+        ragas_metric = RagasFaithfulness()
+        ragas_metric.llm = llm
+
+        judge_logger: JudgeLogger | None = None
+        if config.judge_log_path is not None:
+            judge_logger = JudgeLogger(config.judge_log_path)
+
+        sample_scores: dict[str, float] = {}
+        scores: list[float] = []
+
+        async def score_all():
+            semaphore = asyncio.Semaphore(config.batch_size)
+
+            async def score_one(row):
+                async with semaphore:
+                    try:
+                        sample = SingleTurnSample(
+                            user_input=row.user_input,
+                            response=row.response,
+                            retrieved_contexts=row.retrieved_contexts,
+                        )
+                        score = await ragas_metric.single_turn_ascore(sample)
+                        scores.append(score)
+                        sample_scores[row.session_id] = score
+                        if judge_logger:
+                            judge_logger.log(self.name, row.user_input, score, None)
+                    except Exception as exc:
+                        safe_error = redact_sensitive(f"ERROR: {exc}")
+                        logger.warning(
+                            "faithfulness scoring failed for session %s: %s",
+                            row.session_id,
+                            safe_error,
+                        )
+                        if judge_logger:
+                            judge_logger.log(self.name, row.user_input, -1.0, safe_error)
+
+            await asyncio.gather(*(score_one(row) for row in rows))
+
+        run_async(score_all())
+
+        mean_score = sum(scores) / len(scores) if scores else 0.0
+        return MetricResult(
+            name=self.name,
+            score=mean_score,
+            details={
+                "samples_scored": len(scores),
+                "samples_skipped": len(rows) - len(scores),
+                "experimental": True,
+                "caveat": (
+                    "Designed for NL answers, not code -- scores may be noisy for agentic sessions"
+                ),
+            },
+            sample_scores=sample_scores,
+        )

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -30,6 +30,19 @@ def create_ragas_llm(config: MetricConfig):
     )
 
 
+def create_ragas_embeddings():
+    """Create embeddings for answer_relevancy metric.
+
+    Uses the legacy Ragas embedding_factory which returns BaseRagasEmbeddings,
+    compatible with the AnswerRelevancy @dataclass metric.
+
+    Defers ragas imports so this module can be imported without ragas installed.
+    """
+    from ragas.embeddings import embedding_factory  # ty: ignore[unresolved-import]
+
+    return embedding_factory()
+
+
 def _validate_judge_log_path(log_path: Path) -> Path:
     """Validate that the judge log path is under the current working directory.
 
@@ -67,7 +80,7 @@ class JudgeLogger:
                 json.dumps(
                     {
                         "metric": metric_name,
-                        "user_input": redact_sensitive(user_input[:200]),
+                        "user_input": redact_sensitive(user_input)[:200],
                         "score": result_value,
                         "reason": result_reason,
                     }

--- a/src/raki/metrics/ragas/relevancy.py
+++ b/src/raki/metrics/ragas/relevancy.py
@@ -1,0 +1,109 @@
+"""Answer relevancy metric using Ragas 0.4 legacy AnswerRelevancy @dataclass.
+
+Measures how relevant the generated response is to the user's question.
+Requires both an LLM and embeddings.
+
+EXPERIMENTAL: This metric was designed for natural language answers, not code.
+Scores may be noisy for agentic code-generation sessions.
+"""
+
+import asyncio
+import logging
+
+from raki.adapters.redact import redact_sensitive
+from raki.metrics.protocol import MetricConfig
+from raki.metrics.ragas.adapter import to_ragas_rows
+from raki.metrics.ragas.async_utils import run_async
+from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_embeddings, create_ragas_llm
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+logger = logging.getLogger(__name__)
+
+
+class AnswerRelevancyMetric:
+    """Ragas-backed answer relevancy metric satisfying the Metric protocol.
+
+    Uses the legacy AnswerRelevancy @dataclass API with single_turn_ascore().
+    Requires embeddings via embedding_factory for cosine similarity scoring.
+    Marked as experimental -- designed for NL answers, not code.
+    """
+
+    name: str = "answer_relevancy"
+    requires_ground_truth: bool = False
+    requires_llm: bool = True
+    higher_is_better: bool = True
+    display_format: str = "score"
+    display_name: str = "Answer relevancy"
+    experimental: bool = True
+
+    def compute(
+        self,
+        dataset: EvalDataset,
+        config: MetricConfig,
+    ) -> MetricResult:
+        rows = to_ragas_rows(dataset)
+        if not rows:
+            return MetricResult(name=self.name, score=0.0, details={"skipped": "no samples"})
+
+        from ragas.dataset_schema import SingleTurnSample  # ty: ignore[unresolved-import]
+        from ragas.metrics._answer_relevance import (  # ty: ignore[unresolved-import]
+            AnswerRelevancy as RagasAnswerRelevancy,
+        )
+
+        llm = create_ragas_llm(config)
+        embeddings = create_ragas_embeddings()
+        ragas_metric = RagasAnswerRelevancy()
+        ragas_metric.llm = llm
+        ragas_metric.embeddings = embeddings
+
+        judge_logger: JudgeLogger | None = None
+        if config.judge_log_path is not None:
+            judge_logger = JudgeLogger(config.judge_log_path)
+
+        sample_scores: dict[str, float] = {}
+        scores: list[float] = []
+
+        async def score_all():
+            semaphore = asyncio.Semaphore(config.batch_size)
+
+            async def score_one(row):
+                async with semaphore:
+                    try:
+                        sample = SingleTurnSample(
+                            user_input=row.user_input,
+                            response=row.response,
+                        )
+                        score = await ragas_metric.single_turn_ascore(sample)
+                        scores.append(score)
+                        sample_scores[row.session_id] = score
+                        if judge_logger:
+                            judge_logger.log(self.name, row.user_input, score, None)
+                    except Exception as exc:
+                        safe_error = redact_sensitive(f"ERROR: {exc}")
+                        logger.warning(
+                            "answer_relevancy scoring failed for session %s: %s",
+                            row.session_id,
+                            safe_error,
+                        )
+                        if judge_logger:
+                            judge_logger.log(self.name, row.user_input, -1.0, safe_error)
+
+            await asyncio.gather(*(score_one(row) for row in rows))
+
+        run_async(score_all())
+
+        mean_score = sum(scores) / len(scores) if scores else 0.0
+        return MetricResult(
+            name=self.name,
+            score=mean_score,
+            details={
+                "samples_scored": len(scores),
+                "samples_skipped": len(rows) - len(scores),
+                "experimental": True,
+                "caveat": (
+                    "Designed for NL answers, not code -- scores may be noisy for agentic sessions"
+                ),
+            },
+            sample_scores=sample_scores,
+        )

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -9,6 +9,12 @@ OPERATIONAL_METRICS = {
     "rework_cycles",
     "review_severity_distribution",
     "cost_efficiency",
+    "knowledge_retrieval_miss_rate",
+}
+
+EXPERIMENTAL_METRICS = {
+    "faithfulness",
+    "answer_relevancy",
 }
 
 
@@ -102,12 +108,17 @@ def print_summary(
     if retrieval:
         output_console.print("[bold]Retrieval Quality[/bold]")
         for name, score in retrieval.items():
-            output_console.print(format_metric_line(name, score))
+            tag = " [yellow]\\[experimental][/yellow]" if name in EXPERIMENTAL_METRICS else ""
+            output_console.print(format_metric_line(name, score) + tag)
         if session_count < 50:
             output_console.print(
                 f"[dim]  \u26a0 Small sample size (n={session_count}) \u2014 "
                 "scores are directional, not definitive[/dim]"
             )
+        output_console.print(
+            "[dim]  \u26a0 Scores produced by same-provider LLM judge "
+            "\u2014 calibration caveat applies[/dim]"
+        )
         output_console.print()
 
     if skipped_count > 0 or error_count > 0:

--- a/src/raki/report/json_report.py
+++ b/src/raki/report/json_report.py
@@ -20,11 +20,11 @@ def write_json_report(report: EvalReport, output: Path, include_sessions: bool =
     output.parent.mkdir(parents=True, exist_ok=True)
     data = report.model_dump(mode="json")
     if not include_sessions:
-        _strip_session_data(data)
+        strip_session_data(data)
     output.write_text(json.dumps(data, indent=2, default=str))
 
 
-def _strip_session_data(data: dict) -> None:
+def strip_session_data(data: dict) -> None:
     """Remove large raw data fields from sample results to keep reports compact."""
     for sample_result in data.get("sample_results", []):
         sample = sample_result.get("sample", {})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,14 +244,6 @@ class TestCliUnimplementedOptions:
         )
         assert "Warning: --metrics is not yet implemented" in result.output
 
-    def test_warns_parallel_option(self, empty_manifest):
-        runner = CliRunner()
-        result = runner.invoke(
-            main,
-            ["run", "-m", str(empty_manifest), "--no-llm", "-p", "8"],
-        )
-        assert "Warning: --parallel is not yet implemented" in result.output
-
     def test_warns_tenant_option(self, empty_manifest):
         runner = CliRunner()
         result = runner.invoke(
@@ -260,10 +252,40 @@ class TestCliUnimplementedOptions:
         )
         assert "Warning: --tenant is not yet implemented" in result.output
 
-    def test_no_warning_for_default_parallel(self, empty_manifest):
+
+class TestCliJudgeModel:
+    def test_judge_model_option_accepted(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--no-llm",
+                "--judge-model",
+                "claude-opus-4-6",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_judge_model_default(self, empty_manifest):
+        """Default judge model should be accepted without errors."""
         runner = CliRunner()
         result = runner.invoke(
             main,
             ["run", "-m", str(empty_manifest), "--no-llm"],
         )
+        assert result.exit_code == 0
+
+
+class TestCliParallelWiring:
+    def test_parallel_option_accepted(self, empty_manifest):
+        """--parallel should be accepted without 'not yet implemented' warning."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm", "-p", "8"],
+        )
+        assert result.exit_code == 0
         assert "Warning: --parallel" not in result.output

--- a/tests/test_metrics_operational.py
+++ b/tests/test_metrics_operational.py
@@ -232,3 +232,219 @@ def test_engine_run_single():
 
     with pytest.raises(ValueError, match="Unknown metric"):
         engine.run_single("nonexistent_metric", dataset)
+
+
+# --- KnowledgeRetrievalMissRate ---
+
+
+def test_knowledge_miss_rate_no_rework():
+    """Sessions with zero rework should produce score 0.0."""
+    from raki.metrics.operational.knowledge_miss_rate import KnowledgeRetrievalMissRate
+
+    dataset = make_dataset(
+        make_sample("1", rework_cycles=0),
+        make_sample("2", rework_cycles=0),
+    )
+    result = KnowledgeRetrievalMissRate().compute(dataset, MetricConfig())
+    assert result.score == 0.0
+    assert result.details["total_rework_findings"] == 0
+    assert result.details["retrieval_gaps"] == 0
+    assert result.details["capability_gaps"] == 0
+
+
+def test_knowledge_miss_rate_retrieval_gap():
+    """Finding with no related knowledge should be classified as retrieval_gap."""
+    from raki.metrics.operational.knowledge_miss_rate import KnowledgeRetrievalMissRate
+
+    meta = SessionMeta(
+        session_id="rework-1",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=3,
+        rework_cycles=1,
+    )
+    implement_phase = PhaseResult(
+        name="implement",
+        generation=1,
+        status="completed",
+        output="done",
+        knowledge_context="information about database schemas and migrations",
+    )
+    finding = ReviewFinding(
+        reviewer="ai-review",
+        severity="critical",
+        issue="Missing authentication check on the API endpoint",
+    )
+    sample = EvalSample(
+        session=meta,
+        phases=[implement_phase],
+        findings=[finding],
+        events=[],
+    )
+    dataset = make_dataset(sample)
+    result = KnowledgeRetrievalMissRate().compute(dataset, MetricConfig())
+
+    assert result.score == 1.0  # all findings are retrieval gaps
+    assert result.details["retrieval_gaps"] == 1
+    assert result.details["capability_gaps"] == 0
+    assert result.details["total_rework_findings"] == 1
+
+
+def test_knowledge_miss_rate_capability_gap():
+    """Finding with related knowledge present should be classified as capability_gap."""
+    from raki.metrics.operational.knowledge_miss_rate import KnowledgeRetrievalMissRate
+
+    meta = SessionMeta(
+        session_id="rework-2",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=3,
+        rework_cycles=1,
+    )
+    implement_phase = PhaseResult(
+        name="implement",
+        generation=1,
+        status="completed",
+        output="done",
+        knowledge_context="Authentication must validate tokens before processing requests",
+    )
+    finding = ReviewFinding(
+        reviewer="ai-review",
+        severity="major",
+        issue="Missing authentication check on the endpoint",
+    )
+    sample = EvalSample(
+        session=meta,
+        phases=[implement_phase],
+        findings=[finding],
+        events=[],
+    )
+    dataset = make_dataset(sample)
+    result = KnowledgeRetrievalMissRate().compute(dataset, MetricConfig())
+
+    assert result.score == 0.0  # no retrieval gaps, all capability gaps
+    assert result.details["retrieval_gaps"] == 0
+    assert result.details["capability_gaps"] == 1
+    assert result.details["total_rework_findings"] == 1
+
+
+def test_knowledge_miss_rate_mixed_gaps():
+    """Mix of retrieval and capability gaps should produce correct ratio."""
+    from raki.metrics.operational.knowledge_miss_rate import KnowledgeRetrievalMissRate
+
+    meta = SessionMeta(
+        session_id="rework-3",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=3,
+        rework_cycles=1,
+    )
+    implement_phase = PhaseResult(
+        name="implement",
+        generation=1,
+        status="completed",
+        output="done",
+        knowledge_context="Authentication tokens must be validated before processing",
+    )
+    finding_capability = ReviewFinding(
+        reviewer="ai-review",
+        severity="critical",
+        issue="Missing authentication token validation",
+    )
+    finding_retrieval = ReviewFinding(
+        reviewer="ai-review",
+        severity="major",
+        issue="Database connection pooling not configured properly",
+    )
+    sample = EvalSample(
+        session=meta,
+        phases=[implement_phase],
+        findings=[finding_capability, finding_retrieval],
+        events=[],
+    )
+    dataset = make_dataset(sample)
+    result = KnowledgeRetrievalMissRate().compute(dataset, MetricConfig())
+
+    assert result.details["total_rework_findings"] == 2
+    assert result.details["capability_gaps"] == 1
+    assert result.details["retrieval_gaps"] == 1
+    assert result.score == pytest.approx(0.5)  # 1 retrieval / 2 total
+
+
+def test_knowledge_miss_rate_ignores_minor_findings():
+    """Minor findings should not be counted in the miss rate."""
+    from raki.metrics.operational.knowledge_miss_rate import KnowledgeRetrievalMissRate
+
+    meta = SessionMeta(
+        session_id="minor-only",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=3,
+        rework_cycles=1,
+    )
+    implement_phase = PhaseResult(
+        name="implement",
+        generation=1,
+        status="completed",
+        output="done",
+    )
+    finding = ReviewFinding(
+        reviewer="ai-review",
+        severity="minor",
+        issue="Style nit: use snake_case",
+    )
+    sample = EvalSample(
+        session=meta,
+        phases=[implement_phase],
+        findings=[finding],
+        events=[],
+    )
+    dataset = make_dataset(sample)
+    result = KnowledgeRetrievalMissRate().compute(dataset, MetricConfig())
+
+    assert result.score == 0.0
+    assert result.details["total_rework_findings"] == 0
+
+
+def test_knowledge_miss_rate_properties():
+    from raki.metrics.operational.knowledge_miss_rate import KnowledgeRetrievalMissRate
+
+    metric = KnowledgeRetrievalMissRate()
+    assert metric.name == "knowledge_retrieval_miss_rate"
+    assert metric.requires_ground_truth is False
+    assert metric.requires_llm is False
+    assert metric.higher_is_better is False
+    assert metric.display_format == "score"
+    assert metric.display_name == "Knowledge miss rate"
+
+
+def test_knowledge_miss_rate_uses_session_phase_fallback():
+    """Should find knowledge_context from 'session' phase when 'implement' is absent."""
+    from raki.metrics.operational.knowledge_miss_rate import KnowledgeRetrievalMissRate
+
+    meta = SessionMeta(
+        session_id="session-phase",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=2,
+        rework_cycles=1,
+    )
+    session_phase = PhaseResult(
+        name="session",
+        generation=1,
+        status="completed",
+        output="done",
+        knowledge_context="information about authentication and authorization patterns",
+    )
+    finding = ReviewFinding(
+        reviewer="ai-review",
+        severity="critical",
+        issue="Missing authentication check",
+    )
+    sample = EvalSample(
+        session=meta,
+        phases=[session_phase],
+        findings=[finding],
+        events=[],
+    )
+    dataset = make_dataset(sample)
+    result = KnowledgeRetrievalMissRate().compute(dataset, MetricConfig())
+
+    # "authentication" appears in knowledge_context, so it's a capability gap
+    assert result.details["capability_gaps"] == 1
+    assert result.details["retrieval_gaps"] == 0

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -823,6 +823,7 @@ class TestAnswerRelevancyMetric:
 class TestFaithfulnessIntegration:
     def test_faithfulness_returns_score_between_0_and_1(self):
         """Requires Ragas + LLM credentials. Scores a simple sample."""
+        pytest.importorskip("ragas")
         from raki.metrics.ragas.faithfulness import FaithfulnessMetric
 
         ground_truth = GroundTruth(
@@ -845,6 +846,7 @@ class TestFaithfulnessIntegration:
 class TestAnswerRelevancyIntegration:
     def test_relevancy_returns_score_between_0_and_1(self):
         """Requires Ragas + LLM + Embeddings credentials. Scores a simple sample."""
+        pytest.importorskip("ragas")
         from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
 
         sample = _make_sample_with_knowledge()

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -517,3 +517,342 @@ class TestMetricConfigJudgeLogPath:
         log_path = tmp_path / "judge.jsonl"
         config = MetricConfig(judge_log_path=log_path)
         assert config.judge_log_path == log_path
+
+
+# ---------------------------------------------------------------------------
+# Faithfulness mock helpers (legacy dataclass API)
+# ---------------------------------------------------------------------------
+
+
+def _install_faithfulness_mock(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_metric_class: MagicMock,
+) -> None:
+    """Insert a fake ``ragas.metrics._faithfulness`` module into sys.modules.
+
+    Faithfulness is a legacy @dataclass metric that uses single_turn_ascore()
+    and returns a plain float, not a MetricResult.
+    """
+    import sys
+
+    fake_faithfulness_mod = MagicMock()
+    setattr(fake_faithfulness_mod, "Faithfulness", mock_metric_class)
+    fake_dataset_schema = MagicMock()
+    fake_dataset_schema.SingleTurnSample = MagicMock()
+    monkeypatch.setitem(sys.modules, "ragas", MagicMock())
+    monkeypatch.setitem(sys.modules, "ragas.metrics", MagicMock())
+    monkeypatch.setitem(sys.modules, "ragas.metrics._faithfulness", fake_faithfulness_mod)
+    monkeypatch.setitem(sys.modules, "ragas.dataset_schema", fake_dataset_schema)
+
+
+def _install_relevancy_mock(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_metric_class: MagicMock,
+) -> None:
+    """Insert a fake ``ragas.metrics._answer_relevance`` module into sys.modules.
+
+    AnswerRelevancy is a legacy @dataclass metric that uses single_turn_ascore()
+    and returns a plain float, not a MetricResult.
+    """
+    import sys
+
+    fake_relevancy_mod = MagicMock()
+    setattr(fake_relevancy_mod, "AnswerRelevancy", mock_metric_class)
+    fake_dataset_schema = MagicMock()
+    fake_dataset_schema.SingleTurnSample = MagicMock()
+    fake_embeddings = MagicMock()
+    fake_embeddings.embedding_factory = MagicMock(return_value=MagicMock())
+    monkeypatch.setitem(sys.modules, "ragas", MagicMock())
+    monkeypatch.setitem(sys.modules, "ragas.metrics", MagicMock())
+    monkeypatch.setitem(sys.modules, "ragas.metrics._answer_relevance", fake_relevancy_mod)
+    monkeypatch.setitem(sys.modules, "ragas.dataset_schema", fake_dataset_schema)
+    monkeypatch.setitem(sys.modules, "ragas.embeddings", fake_embeddings)
+
+
+# ---------------------------------------------------------------------------
+# Faithfulness metric tests — mock ragas so tests run without it installed
+# ---------------------------------------------------------------------------
+
+
+class TestFaithfulnessMetric:
+    def test_skips_without_samples(self):
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        metric = FaithfulnessMetric()
+        sample = _make_sample_with_knowledge(knowledge_context=None)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+        result = metric.compute(dataset, config)
+        assert result.score == 0.0
+        assert result.details.get("skipped") == "no samples"
+
+    def test_experimental_flag(self):
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        metric = FaithfulnessMetric()
+        assert metric.experimental is True
+
+    def test_protocol_properties(self):
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        metric = FaithfulnessMetric()
+        assert metric.name == "faithfulness"
+        assert metric.requires_ground_truth is False
+        assert metric.requires_llm is True
+        assert metric.higher_is_better is True
+        assert metric.display_format == "score"
+        assert metric.display_name == "Faithfulness"
+
+    def test_computes_with_mocked_ragas(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.single_turn_ascore = AsyncMock(return_value=0.9)
+
+        mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
+        _install_faithfulness_mock(monkeypatch, mock_faithfulness_class)
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+
+        log_path = tmp_path / "judge.jsonl"
+        config = MetricConfig(judge_log_path=log_path)
+
+        with patch(
+            "raki.metrics.ragas.faithfulness.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = FaithfulnessMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.name == "faithfulness"
+        assert result.score == pytest.approx(0.9)
+        assert result.details["samples_scored"] == 1
+        assert result.details["experimental"] is True
+        assert "NL answers" in result.details["caveat"]
+        assert "1" in result.sample_scores
+
+        log_lines = log_path.read_text().strip().split("\n")
+        assert len(log_lines) == 1
+        log_entry = json.loads(log_lines[0])
+        assert log_entry["metric"] == "faithfulness"
+        assert log_entry["score"] == 0.9
+
+    def test_does_not_require_ground_truth(self, monkeypatch: pytest.MonkeyPatch):
+        """Faithfulness scores all samples, not just those with ground truth."""
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.single_turn_ascore = AsyncMock(return_value=0.8)
+
+        mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
+        _install_faithfulness_mock(monkeypatch, mock_faithfulness_class)
+
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with patch(
+            "raki.metrics.ragas.faithfulness.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = FaithfulnessMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.8)
+        assert result.details["samples_scored"] == 1
+
+    def test_handles_ascore_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.single_turn_ascore = AsyncMock(
+            side_effect=RuntimeError("LLM unavailable")
+        )
+
+        mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
+        _install_faithfulness_mock(monkeypatch, mock_faithfulness_class)
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+
+        log_path = tmp_path / "judge.jsonl"
+        config = MetricConfig(judge_log_path=log_path)
+
+        with patch(
+            "raki.metrics.ragas.faithfulness.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = FaithfulnessMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == 0.0
+        assert result.details["samples_scored"] == 0
+
+        log_entry = json.loads(log_path.read_text().strip())
+        assert log_entry["score"] == -1.0
+        assert "LLM unavailable" in log_entry["reason"]
+
+
+# ---------------------------------------------------------------------------
+# AnswerRelevancy metric tests — mock ragas so tests run without it installed
+# ---------------------------------------------------------------------------
+
+
+class TestAnswerRelevancyMetric:
+    def test_skips_without_samples(self):
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        metric = AnswerRelevancyMetric()
+        sample = _make_sample_with_knowledge(knowledge_context=None)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+        result = metric.compute(dataset, config)
+        assert result.score == 0.0
+        assert result.details.get("skipped") == "no samples"
+
+    def test_experimental_flag(self):
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        metric = AnswerRelevancyMetric()
+        assert metric.experimental is True
+
+    def test_protocol_properties(self):
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        metric = AnswerRelevancyMetric()
+        assert metric.name == "answer_relevancy"
+        assert metric.requires_ground_truth is False
+        assert metric.requires_llm is True
+        assert metric.higher_is_better is True
+        assert metric.display_format == "score"
+        assert metric.display_name == "Answer relevancy"
+
+    def test_computes_with_mocked_ragas(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.single_turn_ascore = AsyncMock(return_value=0.78)
+
+        mock_relevancy_class = MagicMock(return_value=mock_metric_instance)
+        _install_relevancy_mock(monkeypatch, mock_relevancy_class)
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+
+        log_path = tmp_path / "judge.jsonl"
+        config = MetricConfig(judge_log_path=log_path)
+
+        with (
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_llm",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_embeddings",
+                return_value=MagicMock(),
+            ),
+        ):
+            metric = AnswerRelevancyMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.name == "answer_relevancy"
+        assert result.score == pytest.approx(0.78)
+        assert result.details["samples_scored"] == 1
+        assert result.details["experimental"] is True
+        assert "NL answers" in result.details["caveat"]
+        assert "1" in result.sample_scores
+
+        log_lines = log_path.read_text().strip().split("\n")
+        assert len(log_lines) == 1
+        log_entry = json.loads(log_lines[0])
+        assert log_entry["metric"] == "answer_relevancy"
+        assert log_entry["score"] == 0.78
+
+    def test_handles_ascore_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.single_turn_ascore = AsyncMock(
+            side_effect=RuntimeError("Embeddings failed")
+        )
+
+        mock_relevancy_class = MagicMock(return_value=mock_metric_instance)
+        _install_relevancy_mock(monkeypatch, mock_relevancy_class)
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+
+        log_path = tmp_path / "judge.jsonl"
+        config = MetricConfig(judge_log_path=log_path)
+
+        with (
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_llm",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_embeddings",
+                return_value=MagicMock(),
+            ),
+        ):
+            metric = AnswerRelevancyMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == 0.0
+        assert result.details["samples_scored"] == 0
+
+        log_entry = json.loads(log_path.read_text().strip())
+        assert log_entry["score"] == -1.0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (slow, requires LLM) — marked for selective running
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestFaithfulnessIntegration:
+    def test_faithfulness_returns_score_between_0_and_1(self):
+        """Requires Ragas + LLM credentials. Scores a simple sample."""
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        ground_truth = GroundTruth(
+            question="How to validate input?",
+            reference_answer="Use pydantic models with Field validators",
+            domains=["validation"],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        metric = FaithfulnessMetric()
+        result = metric.compute(dataset, config)
+
+        assert 0.0 <= result.score <= 1.0
+        assert result.details["samples_scored"] >= 1
+
+
+@pytest.mark.slow
+class TestAnswerRelevancyIntegration:
+    def test_relevancy_returns_score_between_0_and_1(self):
+        """Requires Ragas + LLM + Embeddings credentials. Scores a simple sample."""
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        metric = AnswerRelevancyMetric()
+        result = metric.compute(dataset, config)
+
+        assert 0.0 <= result.score <= 1.0
+        assert result.details["samples_scored"] >= 1

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -297,7 +297,7 @@ class TestPrintSummary:
         from rich.console import Console
 
         report = EvalReport(
-            run_id="eval-both",
+            run_id="both-categories",
             aggregate_scores={
                 "first_pass_verify_rate": 0.80,
                 "faithfulness": 0.92,
@@ -309,3 +309,71 @@ class TestPrintSummary:
         output = string_io.getvalue()
         assert "Operational Health" in output
         assert "Retrieval Quality" in output
+
+    def test_experimental_tag_for_faithfulness(self) -> None:
+        """Faithfulness should show [experimental] tag in CLI summary."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        report = EvalReport(
+            run_id="exp-faith",
+            aggregate_scores={
+                "faithfulness": 0.85,
+            },
+        )
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True)
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "experimental" in output.lower()
+
+    def test_experimental_tag_for_answer_relevancy(self) -> None:
+        """answer_relevancy should show [experimental] tag in CLI summary."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        report = EvalReport(
+            run_id="exp-relevancy",
+            aggregate_scores={
+                "answer_relevancy": 0.72,
+            },
+        )
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True)
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "experimental" in output.lower()
+
+    def test_calibration_caveat_for_retrieval_metrics(self) -> None:
+        """When retrieval metrics are shown, a calibration caveat should appear."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        report = EvalReport(
+            run_id="calibration-test",
+            aggregate_scores={
+                "context_precision": 0.80,
+                "faithfulness": 0.85,
+            },
+        )
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True)
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "same-provider" in output.lower() or "llm judge" in output.lower()
+
+    def test_no_calibration_caveat_when_no_retrieval(self) -> None:
+        """When only operational metrics are shown, no calibration caveat should appear."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        report = _make_report()
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True)
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "same-provider" not in output.lower()


### PR DESCRIPTION
## Summary
- Add `FaithfulnessMetric` and `AnswerRelevancyMetric` (experimental) using Ragas 0.4 legacy `single_turn_ascore(SingleTurnSample)` API
- Add `KnowledgeRetrievalMissRate` operational metric classifying rework findings as retrieval_gap or capability_gap via word-boundary set intersection
- Wire `--judge-model` and `--parallel` CLI flags to `MetricConfig`
- Add `[experimental]` tags and calibration caveat to CLI summary reports
- Add `create_ragas_embeddings()` for AnswerRelevancy's embedding needs
- Rename `_strip_session_data` → `strip_session_data` (public API)

Refs #11

## Review
- Python Specialist: 3 findings fixed (keyword heuristic, type annotation, private import), re-verified clean
- Security Specialist: 2 findings fixed (truncation order, CLI exception redaction), re-verified clean
- RAG Specialist: 2 findings fixed (keyword heuristic, generation selection), re-verified clean

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko