### PR TITLE
feat(report): add self-contained HTML report with dark theme

### DIFF
--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -203,6 +203,19 @@ def run(
     json_file = output_path / timestamp_filename(report)
     write_json_report(report, json_file, include_sessions=include_sessions)
 
+    try:
+        from raki.report.html_report import html_timestamp_filename, write_html_report
+
+        html_file = output_path / html_timestamp_filename(report)
+        write_html_report(report, html_file, include_sessions=include_sessions)
+    except ImportError:
+        html_file = None
+        if not quiet:
+            console.print(
+                "[yellow]Note: jinja2 not installed — skipping HTML report. "
+                "Install with: uv pip install raki[html][/yellow]"
+            )
+
     if json_stdout:
         import json as json_mod
 
@@ -214,7 +227,10 @@ def run(
         click.echo(json_mod.dumps(data, indent=2, default=str))
 
     if not quiet:
-        console.print(f"\nReport written:\n  JSON -> {json_file}")
+        report_msg = f"\nReport written:\n  JSON -> {json_file}"
+        if html_file is not None:
+            report_msg += f"\n  HTML -> {html_file}"
+        console.print(report_msg)
 
     if threshold is not None:
         from raki.report.cli_summary import OPERATIONAL_METRICS

--- a/src/raki/report/__init__.py
+++ b/src/raki/report/__init__.py
@@ -2,3 +2,10 @@ from raki.report.cli_summary import print_summary
 from raki.report.json_report import load_json_report, write_json_report
 
 __all__ = ["print_summary", "write_json_report", "load_json_report"]
+
+try:
+    from raki.report.html_report import write_html_report
+
+    __all__ = [*__all__, "write_html_report"]
+except ImportError:
+    pass

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -1,0 +1,188 @@
+"""HTML report generation — self-contained dark-themed report with Jinja2."""
+
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from jinja2 import Environment, PackageLoader
+
+from raki.model.report import EvalReport
+from raki.report.cli_summary import EXPERIMENTAL_METRICS, OPERATIONAL_METRICS
+
+
+@dataclass(frozen=True)
+class RecurringFailure:
+    """A finding issue that recurs across multiple sessions."""
+
+    issue: str
+    severity: Literal["critical", "major", "minor"]
+    count: int
+    sessions: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class WorstSessionEntry:
+    """A session with its average score, used for the worst-sessions shortcut."""
+
+    session_id: str
+    avg_score: float
+
+
+def html_color_for_score(score: float, higher_is_better: bool = True) -> str:
+    """Return a CSS color class name for a score value.
+
+    Matches the CLI color_for_score semantics: green >= 0.8, yellow >= 0.6, red below.
+    """
+    if higher_is_better:
+        if score >= 0.8:
+            return "green"
+        if score >= 0.6:
+            return "yellow"
+        return "red"
+    else:
+        if score <= 0.2:
+            return "green"
+        if score <= 0.4:
+            return "yellow"
+        return "red"
+
+
+def _split_scores(
+    aggregate_scores: dict[str, float],
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Split aggregate scores into operational and retrieval categories."""
+    operational = {
+        name: score for name, score in aggregate_scores.items() if name in OPERATIONAL_METRICS
+    }
+    retrieval = {
+        name: score for name, score in aggregate_scores.items() if name not in OPERATIONAL_METRICS
+    }
+    return operational, retrieval
+
+
+def _collect_recurring_failures(report: EvalReport) -> list[RecurringFailure]:
+    """Find issues that recur across multiple sessions, sorted by count descending."""
+    issue_counter: Counter[str] = Counter()
+    issue_severity: dict[str, Literal["critical", "major", "minor"]] = {}
+    issue_sessions: dict[str, list[str]] = {}
+
+    for sample_result in report.sample_results:
+        session_id = sample_result.sample.session.session_id
+        for finding in sample_result.sample.findings:
+            issue_counter[finding.issue] += 1
+            # Keep the highest severity seen for this issue
+            existing = issue_severity.get(finding.issue)
+            if existing is None or _severity_rank(finding.severity) > _severity_rank(existing):
+                issue_severity[finding.issue] = finding.severity
+            if finding.issue not in issue_sessions:
+                issue_sessions[finding.issue] = []
+            if session_id not in issue_sessions[finding.issue]:
+                issue_sessions[finding.issue].append(session_id)
+
+    # Only include issues that appear in more than one session
+    recurring = []
+    for issue_text, count in issue_counter.most_common():
+        if len(issue_sessions[issue_text]) > 1:
+            recurring.append(
+                RecurringFailure(
+                    issue=issue_text,
+                    severity=issue_severity[issue_text],
+                    count=count,
+                    sessions=issue_sessions[issue_text],
+                )
+            )
+
+    return recurring
+
+
+def _severity_rank(severity: str) -> int:
+    """Numeric rank for severity: critical > major > minor."""
+    ranks = {"critical": 3, "major": 2, "minor": 1}
+    return ranks.get(severity, 0)
+
+
+def compute_worst_sessions(report: EvalReport, limit: int = 5) -> list[WorstSessionEntry]:
+    """Compute the worst-performing sessions by average retrieval metric score.
+
+    Only uses normalized (0-1 range) retrieval metric scores for ranking.
+    Operational metrics (which have raw values) are excluded to avoid blending
+    scores from different categories. Returns an empty list if no retrieval
+    metrics exist.
+
+    Returns at most `limit` sessions sorted by ascending average score.
+    """
+    entries = []
+    for sample_result in report.sample_results:
+        session_id = sample_result.sample.session.session_id
+        session_scores = []
+        for metric_result in sample_result.scores:
+            if metric_result.name in OPERATIONAL_METRICS:
+                continue
+            if session_id in metric_result.sample_scores:
+                session_scores.append(metric_result.sample_scores[session_id])
+        if session_scores:
+            avg = sum(session_scores) / len(session_scores)
+            entries.append(WorstSessionEntry(session_id=session_id, avg_score=avg))
+
+    entries.sort(key=lambda entry: entry.avg_score)
+    return entries[:limit]
+
+
+def _build_jinja_env() -> Environment:
+    """Create a Jinja2 environment loading templates from the package."""
+    return Environment(
+        loader=PackageLoader("raki.report", "templates"),
+        autoescape=True,
+    )
+
+
+def write_html_report(report: EvalReport, output: Path, include_sessions: bool = False) -> None:
+    """Render and write a self-contained HTML report.
+
+    All CSS and JavaScript are inlined in the template — no external dependencies.
+    The output file can be opened directly in a browser, shared via email or Slack.
+
+    When include_sessions is False (the default), raw session data is stripped
+    from the report before rendering to avoid leaking sensitive information.
+    """
+    from raki.report.json_report import strip_session_data
+
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    if not include_sessions:
+        # Strip session data from a serialized copy, then reload as a clean report
+        data = report.model_dump(mode="json")
+        strip_session_data(data)
+        report = EvalReport.model_validate(data)
+
+    operational_scores, retrieval_scores = _split_scores(report.aggregate_scores)
+    recurring_failures = _collect_recurring_failures(report)
+    worst_sessions = compute_worst_sessions(report, limit=5)
+
+    env = _build_jinja_env()
+    template = env.get_template("report.html.j2")
+
+    html_content = template.render(
+        report=report,
+        operational_scores=operational_scores,
+        retrieval_scores=retrieval_scores,
+        experimental_metrics=EXPERIMENTAL_METRICS,
+        recurring_failures=recurring_failures,
+        worst_sessions=worst_sessions,
+        color_class=lambda score: f"color-{html_color_for_score(score)}",
+        color_name=html_color_for_score,
+    )
+
+    output.write_text(html_content)
+
+
+def html_timestamp_filename(report: EvalReport) -> str:
+    """Generate a timestamp-based filename for the HTML report.
+
+    Uses the same datetime format as json_report.timestamp_filename but with .html extension.
+    """
+    timestamp = report.timestamp
+    formatted = timestamp.strftime("%Y%m%dT%H%M%S")
+    return f"raki-report-{formatted}.html"

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from jinja2 import Environment, PackageLoader
-
 from raki.model.report import EvalReport
 from raki.report.cli_summary import EXPERIMENTAL_METRICS, OPERATIONAL_METRICS
 
@@ -129,8 +127,10 @@ def compute_worst_sessions(report: EvalReport, limit: int = 5) -> list[WorstSess
     return entries[:limit]
 
 
-def _build_jinja_env() -> Environment:
+def _build_jinja_env():  # type: ignore[no-any-return]
     """Create a Jinja2 environment loading templates from the package."""
+    from jinja2 import Environment, PackageLoader  # ty: ignore[unresolved-import]
+
     return Environment(
         loader=PackageLoader("raki.report", "templates"),
         autoescape=True,

--- a/src/raki/report/templates/report.html.j2
+++ b/src/raki/report/templates/report.html.j2
@@ -1,0 +1,617 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RAKI Evaluation Report &mdash; {{ report.run_id }}</title>
+<style>
+  :root {
+    --bg-primary: #0f0f1a;
+    --bg-secondary: #1a1a2e;
+    --bg-tertiary: #252540;
+    --bg-card: #1e1e35;
+    --text-primary: #e0e0e8;
+    --text-secondary: #a0a0b8;
+    --text-muted: #6a6a80;
+    --border-color: #2e2e48;
+    --accent: #6c63ff;
+    --green: #4caf50;
+    --yellow: #ffc107;
+    --red: #f44336;
+    --white-metric: #b0b0c8;
+    --severity-critical: #f44336;
+    --severity-major: #ff9800;
+    --severity-minor: #8bc34a;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    padding: 2rem;
+  }
+
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  header {
+    margin-bottom: 2rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  header h1 {
+    font-size: 1.8rem;
+    color: var(--text-primary);
+    margin-bottom: 0.5rem;
+  }
+
+  header .meta {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+
+  header .meta span {
+    margin-right: 1.5rem;
+  }
+
+  h2 {
+    font-size: 1.4rem;
+    margin: 1.5rem 0 1rem;
+    color: var(--text-primary);
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.5rem;
+  }
+
+  h3 {
+    font-size: 1.1rem;
+    margin: 1rem 0 0.5rem;
+    color: var(--text-primary);
+  }
+
+  /* Score cards */
+  .score-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .score-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .score-card .metric-name {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.4rem;
+  }
+
+  .score-card .metric-value {
+    font-size: 1.8rem;
+    font-weight: 700;
+    line-height: 1.2;
+  }
+
+  .score-card .metric-bar {
+    margin-top: 0.6rem;
+    height: 4px;
+    background: var(--bg-tertiary);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .score-card .metric-bar-fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width 0.3s ease;
+  }
+
+  .score-card .metric-tag {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-top: 0.4rem;
+  }
+
+  /* Color classes */
+  .color-green { color: var(--green); }
+  .color-yellow { color: var(--yellow); }
+  .color-red { color: var(--red); }
+  .color-white { color: var(--white-metric); }
+  .bg-green { background-color: var(--green); }
+  .bg-yellow { background-color: var(--yellow); }
+  .bg-red { background-color: var(--red); }
+  .bg-white { background-color: var(--white-metric); }
+
+  /* Category sections */
+  .category-section {
+    margin-bottom: 2rem;
+  }
+
+  .category-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--accent);
+    margin-bottom: 0.75rem;
+  }
+
+  /* Recurring failures table */
+  .failures-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+  }
+
+  .failures-table th,
+  .failures-table td {
+    padding: 0.6rem 0.8rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .failures-table th {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .failures-table td {
+    color: var(--text-primary);
+  }
+
+  .severity-badge {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+
+  .severity-critical { background: rgba(244, 67, 54, 0.2); color: var(--severity-critical); }
+  .severity-major { background: rgba(255, 152, 0, 0.2); color: var(--severity-major); }
+  .severity-minor { background: rgba(139, 195, 58, 0.2); color: var(--severity-minor); }
+
+  /* Worst sessions */
+  .worst-sessions {
+    margin-bottom: 2rem;
+  }
+
+  .worst-session-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.6rem 1rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    margin-bottom: 0.5rem;
+    cursor: pointer;
+    text-decoration: none;
+    color: var(--text-primary);
+    transition: background-color 0.15s;
+  }
+
+  .worst-session-row:hover {
+    background: var(--bg-tertiary);
+  }
+
+  .worst-session-row .session-id {
+    font-weight: 600;
+  }
+
+  .worst-session-row .session-score {
+    font-weight: 700;
+    font-size: 1.1rem;
+  }
+
+  /* Drill-down */
+  .drilldown-section {
+    margin-bottom: 2rem;
+  }
+
+  details {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    margin-bottom: 0.75rem;
+    overflow: hidden;
+  }
+
+  summary {
+    padding: 0.8rem 1.2rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-weight: 600;
+    color: var(--text-primary);
+    user-select: none;
+    list-style: none;
+  }
+
+  summary::-webkit-details-marker { display: none; }
+
+  summary::before {
+    content: "\25b6";
+    display: inline-block;
+    margin-right: 0.7rem;
+    font-size: 0.7rem;
+    transition: transform 0.2s;
+  }
+
+  details[open] > summary::before {
+    transform: rotate(90deg);
+  }
+
+  .detail-content {
+    padding: 0 1.2rem 1rem;
+  }
+
+  .detail-content .session-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+
+  .detail-content .session-meta .meta-item {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .detail-content .session-meta .meta-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+  }
+
+  .phase-list {
+    margin: 0.5rem 0;
+  }
+
+  .phase-item {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.35rem 0;
+    font-size: 0.9rem;
+  }
+
+  .phase-status {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+
+  .phase-status-completed { background: var(--green); }
+  .phase-status-failed { background: var(--red); }
+  .phase-status-skipped { background: var(--text-muted); }
+
+  .findings-list {
+    margin: 0.5rem 0;
+  }
+
+  .finding-item {
+    padding: 0.5rem 0.8rem;
+    border-left: 3px solid var(--border-color);
+    margin-bottom: 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .finding-item.finding-critical { border-left-color: var(--severity-critical); }
+  .finding-item.finding-major { border-left-color: var(--severity-major); }
+  .finding-item.finding-minor { border-left-color: var(--severity-minor); }
+
+  .finding-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .finding-issue {
+    color: var(--text-primary);
+  }
+
+  .finding-location {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+  }
+
+  .finding-suggestion {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-top: 0.2rem;
+    font-style: italic;
+  }
+
+  /* Score chips for drill-down */
+  .score-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0.5rem 0;
+  }
+
+  .score-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.2rem 0.6rem;
+    background: var(--bg-tertiary);
+    border-radius: 4px;
+    font-size: 0.8rem;
+  }
+
+  .score-chip .chip-name {
+    color: var(--text-secondary);
+  }
+
+  .score-chip .chip-value {
+    font-weight: 600;
+  }
+
+  /* Faithfulness breakdown */
+  .faithfulness-detail {
+    margin: 0.5rem 0;
+    padding: 0.5rem 0.8rem;
+    background: var(--bg-tertiary);
+    border-radius: 4px;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+  }
+
+  .faithfulness-detail .claims-label {
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  /* Footer */
+  footer {
+    margin-top: 3rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color);
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    text-align: center;
+  }
+
+  /* Empty state */
+  .empty-state {
+    color: var(--text-muted);
+    font-style: italic;
+    padding: 1rem 0;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <header>
+    <h1>RAKI Evaluation Report</h1>
+    <div class="meta">
+      <span><strong>Run:</strong> {{ report.run_id }}</span>
+      <span><strong>Timestamp:</strong> {{ report.timestamp.strftime('%Y-%m-%d %H:%M:%S UTC') }}</span>
+      <span><strong>Sessions:</strong> {{ report.sample_results | length }}</span>
+    </div>
+  </header>
+
+  {# --- Aggregate Scores --- #}
+  <section>
+    <h2>Aggregate Scores</h2>
+
+    {% if operational_scores %}
+    <div class="category-section">
+      <div class="category-label">Operational Health</div>
+      <div class="score-grid">
+        {% for name, score in operational_scores.items() %}
+        <div class="score-card">
+          <div class="metric-name">{{ name }}</div>
+          <div class="metric-value {{ color_class(score) }}">{{ "%.2f"|format(score) }}</div>
+          {% if score <= 1.0 and score >= 0.0 %}
+          <div class="metric-bar">
+            <div class="metric-bar-fill bg-{{ color_name(score) }}" style="width: {{ (score * 100)|int }}%"></div>
+          </div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    {% if retrieval_scores %}
+    <div class="category-section">
+      <div class="category-label">Retrieval Quality</div>
+      <div class="score-grid">
+        {% for name, score in retrieval_scores.items() %}
+        <div class="score-card">
+          <div class="metric-name">{{ name }}{% if name in experimental_metrics %} <span class="metric-tag">[experimental]</span>{% endif %}</div>
+          <div class="metric-value {{ color_class(score) }}">{{ "%.2f"|format(score) }}</div>
+          {% if score <= 1.0 and score >= 0.0 %}
+          <div class="metric-bar">
+            <div class="metric-bar-fill bg-{{ color_name(score) }}" style="width: {{ (score * 100)|int }}%"></div>
+          </div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+  </section>
+
+  {# --- Recurring Failures --- #}
+  {% if recurring_failures %}
+  <section>
+    <h2>Recurring Failures</h2>
+    <table class="failures-table">
+      <thead>
+        <tr>
+          <th>Issue</th>
+          <th>Severity</th>
+          <th>Count</th>
+          <th>Sessions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for failure in recurring_failures %}
+        <tr>
+          <td>{{ failure.issue }}</td>
+          <td><span class="severity-badge severity-{{ failure.severity }}">{{ failure.severity }}</span></td>
+          <td>{{ failure.count }}</td>
+          <td>{{ failure.sessions | join(", ") }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+  {% endif %}
+
+  {# --- Worst 5 Sessions --- #}
+  {% if worst_sessions %}
+  <section class="worst-sessions">
+    <h2>Worst {{ worst_sessions | length }} Sessions</h2>
+    {% for entry in worst_sessions %}
+    <a class="worst-session-row" href="#session-{{ entry.session_id }}">
+      <span class="session-id">{{ entry.session_id }}</span>
+      <span class="session-score {{ color_class(entry.avg_score) }}">{{ "%.2f"|format(entry.avg_score) }}</span>
+    </a>
+    {% endfor %}
+  </section>
+  {% endif %}
+
+  {# --- Per-Session Drill-Down --- #}
+  {% if report.sample_results %}
+  <section class="drilldown-section">
+    <h2>Per-Session Drill-Down</h2>
+    {% for sample_result in report.sample_results %}
+    {% set sample = sample_result.sample %}
+    {% set session_id = sample.session.session_id %}
+    <details id="session-{{ session_id }}">
+      <summary>
+        <span>{{ session_id }}</span>
+        <span class="score-chips">
+          {% for metric_result in sample_result.scores %}
+          {% if session_id in metric_result.sample_scores %}
+          {% set session_score = metric_result.sample_scores[session_id] %}
+          <span class="score-chip">
+            <span class="chip-name">{{ metric_result.name }}</span>
+            <span class="chip-value {{ color_class(session_score) }}">{{ "%.2f"|format(session_score) }}</span>
+          </span>
+          {% endif %}
+          {% endfor %}
+        </span>
+      </summary>
+      <div class="detail-content">
+        <div class="session-meta">
+          <div class="meta-item">
+            <span class="meta-label">Rework Cycles</span>
+            <span>{{ sample.session.rework_cycles }}</span>
+          </div>
+          {% if sample.session.total_cost_usd is not none %}
+          <div class="meta-item">
+            <span class="meta-label">Cost</span>
+            <span>${{ "%.2f"|format(sample.session.total_cost_usd) }}</span>
+          </div>
+          {% endif %}
+          <div class="meta-item">
+            <span class="meta-label">Phases</span>
+            <span>{{ sample.phases | length }}</span>
+          </div>
+        </div>
+
+        {# Phases #}
+        <h3>Phases</h3>
+        <div class="phase-list">
+          {% for phase in sample.phases %}
+          <div class="phase-item">
+            <span class="phase-status phase-status-{{ phase.status }}"></span>
+            <span>{{ phase.name }} (gen {{ phase.generation }})</span>
+            <span style="color: var(--text-muted);">&mdash; {{ phase.status }}</span>
+          </div>
+          {% endfor %}
+        </div>
+
+        {# Findings #}
+        {% if sample.findings %}
+        <h3>Findings</h3>
+        <div class="findings-list">
+          {% for finding in sample.findings %}
+          <div class="finding-item finding-{{ finding.severity }}">
+            <div class="finding-header">
+              <span class="severity-badge severity-{{ finding.severity }}">{{ finding.severity }}</span>
+              <span class="finding-issue">{{ finding.issue }}</span>
+            </div>
+            {% if finding.file %}
+            <div class="finding-location">{{ finding.file }}{% if finding.line %}:{{ finding.line }}{% endif %}</div>
+            {% endif %}
+            {% if finding.suggestion %}
+            <div class="finding-suggestion">{{ finding.suggestion }}</div>
+            {% endif %}
+          </div>
+          {% endfor %}
+        </div>
+        {% endif %}
+
+        {# Faithfulness breakdown #}
+        {% for metric_result in sample_result.scores %}
+        {% if metric_result.name == "faithfulness" and metric_result.details %}
+        <div class="faithfulness-detail">
+          <span class="claims-label">Faithfulness Claims:</span>
+          {% if "claims_verified" in metric_result.details and "claims_total" in metric_result.details %}
+          {{ metric_result.details["claims_verified"] }} / {{ metric_result.details["claims_total"] }} claims verified
+          {% else %}
+          {% for detail_key, detail_val in metric_result.details.items() %}
+          {{ detail_key }}: {{ detail_val }}{% if not loop.last %}, {% endif %}
+          {% endfor %}
+          {% endif %}
+        </div>
+        {% endif %}
+        {% endfor %}
+      </div>
+    </details>
+    {% endfor %}
+  </section>
+  {% endif %}
+
+  <footer>
+    Generated by RAKI &mdash; Retrieval Assessment for Knowledge Impact
+  </footer>
+</div>
+
+<script>
+/* Toggle all sessions open/closed */
+(function() {
+  document.querySelectorAll('.worst-session-row').forEach(function(row) {
+    row.addEventListener('click', function(event) {
+      event.preventDefault();
+      var targetId = this.getAttribute('href').substring(1);
+      var target = document.getElementById(targetId);
+      if (target) {
+        target.setAttribute('open', '');
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+})();
+</script>
+</body>
+</html>

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -1,0 +1,589 @@
+"""Tests for HTML report generation — self-contained, dark-themed, collapsible drill-down."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from raki.model.phases import ReviewFinding
+from raki.model.report import EvalReport, MetricResult, SampleResult
+
+from conftest import make_sample
+
+
+def _make_minimal_report() -> EvalReport:
+    """Report with only aggregate scores, no sample results."""
+    return EvalReport(
+        run_id="eval-html-001",
+        timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+        config={"adapter": "session-schema", "metrics": ["rework_cycles"]},
+        aggregate_scores={
+            "first_pass_verify_rate": 0.58,
+            "rework_cycles": 1.3,
+            "review_severity_distribution": 0.85,
+            "cost_efficiency": 18.4,
+        },
+    )
+
+
+def _make_report_with_samples() -> EvalReport:
+    """Report with sample results including sessions, phases, and findings."""
+    findings_session_a = [
+        ReviewFinding(
+            reviewer="reviewer-1",
+            severity="critical",
+            file="main.py",
+            line=42,
+            issue="SQL injection vulnerability",
+            suggestion="Use parameterized queries",
+        ),
+        ReviewFinding(
+            reviewer="reviewer-1",
+            severity="minor",
+            file="utils.py",
+            line=10,
+            issue="Unused import",
+        ),
+    ]
+    findings_session_b = [
+        ReviewFinding(
+            reviewer="reviewer-2",
+            severity="critical",
+            file="main.py",
+            line=50,
+            issue="SQL injection vulnerability",
+            suggestion="Use parameterized queries",
+        ),
+        ReviewFinding(
+            reviewer="reviewer-2",
+            severity="major",
+            file="config.py",
+            line=5,
+            issue="Hardcoded credentials",
+            suggestion="Use environment variables",
+        ),
+    ]
+    sample_a = make_sample(
+        "session-alpha",
+        rework_cycles=2,
+        cost=25.0,
+        verify_status="failed",
+        findings=findings_session_a,
+    )
+    sample_b = make_sample(
+        "session-beta",
+        rework_cycles=1,
+        cost=15.0,
+        verify_status="completed",
+        findings=findings_session_b,
+    )
+    sample_c = make_sample(
+        "session-gamma",
+        rework_cycles=0,
+        cost=8.0,
+        verify_status="completed",
+    )
+
+    metric_rework = MetricResult(
+        name="rework_cycles",
+        score=1.0,
+        sample_scores={
+            "session-alpha": 2.0,
+            "session-beta": 1.0,
+            "session-gamma": 0.0,
+        },
+    )
+    metric_verify = MetricResult(
+        name="first_pass_verify_rate",
+        score=0.67,
+        sample_scores={
+            "session-alpha": 0.0,
+            "session-beta": 1.0,
+            "session-gamma": 1.0,
+        },
+    )
+    metric_faith = MetricResult(
+        name="faithfulness",
+        score=0.80,
+        details={"claims_verified": 24, "claims_total": 30},
+        sample_scores={
+            "session-alpha": 0.60,
+            "session-beta": 0.90,
+            "session-gamma": 0.90,
+        },
+    )
+
+    sample_results = [
+        SampleResult(sample=sample_a, scores=[metric_rework, metric_verify, metric_faith]),
+        SampleResult(sample=sample_b, scores=[metric_rework, metric_verify, metric_faith]),
+        SampleResult(sample=sample_c, scores=[metric_rework, metric_verify, metric_faith]),
+    ]
+
+    return EvalReport(
+        run_id="eval-html-samples-001",
+        timestamp=datetime(2026, 4, 18, 14, 30, 0, tzinfo=timezone.utc),
+        config={"adapter": "session-schema"},
+        aggregate_scores={
+            "first_pass_verify_rate": 0.67,
+            "rework_cycles": 1.0,
+            "review_severity_distribution": 0.85,
+            "cost_efficiency": 16.0,
+            "faithfulness": 0.80,
+        },
+        sample_results=sample_results,
+    )
+
+
+def _make_report_with_many_sessions() -> EvalReport:
+    """Report with 7 sessions to test 'worst 5' shortcut.
+
+    Uses a retrieval metric (context_precision) so compute_worst_sessions
+    correctly ranks sessions — operational metrics are excluded from ranking.
+    """
+    sample_results = []
+    scores_map = {
+        "session-01": 0.95,
+        "session-02": 0.30,
+        "session-03": 0.85,
+        "session-04": 0.10,
+        "session-05": 0.50,
+        "session-06": 0.20,
+        "session-07": 0.75,
+    }
+    for session_id, score in scores_map.items():
+        sample = make_sample(session_id, rework_cycles=int((1 - score) * 3))
+        metric = MetricResult(
+            name="context_precision",
+            score=score,
+            sample_scores={session_id: score},
+        )
+        sample_results.append(SampleResult(sample=sample, scores=[metric]))
+
+    return EvalReport(
+        run_id="eval-html-many",
+        timestamp=datetime(2026, 4, 18, 16, 0, 0, tzinfo=timezone.utc),
+        aggregate_scores={"context_precision": sum(scores_map.values()) / len(scores_map)},
+        sample_results=sample_results,
+    )
+
+
+# --- HTML generation tests ---
+
+
+class TestHtmlReportGeneration:
+    def test_generates_html_file(self, tmp_path: Path) -> None:
+        """write_html_report should create an HTML file at the given path."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        """Should create parent directories if they do not exist."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "nested" / "deep" / "report.html"
+        write_html_report(report, output)
+        assert output.exists()
+
+    def test_output_is_valid_html(self, tmp_path: Path) -> None:
+        """Output should start with <!DOCTYPE html> and contain closing </html>."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert content.strip().startswith("<!DOCTYPE html>")
+        assert "</html>" in content
+
+
+class TestHtmlSelfContained:
+    def test_no_external_css_links(self, tmp_path: Path) -> None:
+        """HTML should not reference any external CSS files."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert 'rel="stylesheet"' not in content
+        assert "<style>" in content
+
+    def test_no_external_js_scripts(self, tmp_path: Path) -> None:
+        """HTML should not reference any external JavaScript files."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Should have inline script but no src= attributes on script tags
+        assert "<script src=" not in content
+
+    def test_inline_styles_present(self, tmp_path: Path) -> None:
+        """CSS should be inline within a <style> tag."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "<style>" in content
+        assert "</style>" in content
+
+
+class TestHtmlDarkTheme:
+    def test_dark_background_color(self, tmp_path: Path) -> None:
+        """Dark theme should use a dark background color."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Should reference a dark background (e.g., #1a1a2e or similar dark color)
+        assert "background" in content.lower()
+
+
+class TestHtmlSections:
+    def test_aggregate_scores_section(self, tmp_path: Path) -> None:
+        """HTML should contain an aggregate scores section."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "Aggregate" in content or "aggregate" in content
+
+    def test_operational_health_displayed(self, tmp_path: Path) -> None:
+        """Operational metrics should appear in the report."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "first_pass_verify_rate" in content
+        assert "rework_cycles" in content
+
+    def test_retrieval_quality_displayed(self, tmp_path: Path) -> None:
+        """Retrieval metrics should appear when present."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "faithfulness" in content
+
+    def test_recurring_failures_section(self, tmp_path: Path) -> None:
+        """Should show recurring failures (most common findings across sessions)."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # "SQL injection vulnerability" appears in 2 sessions - should be listed
+        assert "Recurring" in content or "recurring" in content
+        assert "SQL injection" in content
+
+    def test_per_session_drilldown(self, tmp_path: Path) -> None:
+        """Each session should be present in the drill-down section."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "session-alpha" in content
+        assert "session-beta" in content
+        assert "session-gamma" in content
+
+
+class TestHtmlCollapsibleDetails:
+    def test_collapsible_elements_present(self, tmp_path: Path) -> None:
+        """Session details should use HTML <details>/<summary> for collapsible sections."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "<details" in content
+        assert "<summary" in content
+
+    def test_phases_shown_in_drilldown(self, tmp_path: Path) -> None:
+        """Phase details should be visible in the session drill-down."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "implement" in content
+        assert "verify" in content
+
+    def test_findings_shown_in_drilldown(self, tmp_path: Path) -> None:
+        """Findings should be shown within session drill-down."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "SQL injection vulnerability" in content
+        assert "critical" in content.lower()
+
+
+class TestHtmlColorCoding:
+    def test_color_function_matches_cli(self) -> None:
+        """html_color_for_score should match CLI color_for_score semantics."""
+        from raki.report.html_report import html_color_for_score
+
+        assert html_color_for_score(0.85) != html_color_for_score(0.45)
+        # High score should be greenish, low score should be reddish
+        high_color = html_color_for_score(0.85)
+        low_color = html_color_for_score(0.45)
+        assert high_color != low_color
+
+    def test_score_colors_in_html(self, tmp_path: Path) -> None:
+        """Score values in HTML should have color styling applied."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Color values should appear in the HTML (as inline styles or CSS classes)
+        assert "color:" in content or "class=" in content
+
+
+class TestHtmlWorstSessions:
+    def test_worst_sessions_section(self, tmp_path: Path) -> None:
+        """Should show a 'Worst 5 sessions' section when there are enough sessions."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_many_sessions()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "Worst" in content or "worst" in content
+
+    def test_worst_sessions_ordered(self, tmp_path: Path) -> None:
+        """Worst sessions should show lowest-scoring sessions first."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_many_sessions()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # session-04 (score 0.10) should appear in worst sessions
+        assert "session-04" in content
+        # session-06 (score 0.20) should appear in worst sessions
+        assert "session-06" in content
+
+    def test_worst_sessions_limited_to_five(self, tmp_path: Path) -> None:
+        """Worst sessions shortcut should show at most 5 sessions."""
+        from raki.report.html_report import compute_worst_sessions
+
+        report = _make_report_with_many_sessions()
+        worst = compute_worst_sessions(report, limit=5)
+        assert len(worst) == 5
+
+
+class TestHtmlTimestampFilename:
+    def test_html_timestamp_filename(self) -> None:
+        """HTML report should use timestamp-based filename similar to JSON report."""
+        from raki.report.html_report import html_timestamp_filename
+
+        report = _make_minimal_report()
+        filename = html_timestamp_filename(report)
+        assert filename.endswith(".html")
+        assert "raki-report" in filename
+
+
+class TestHtmlMetadata:
+    def test_run_id_in_html(self, tmp_path: Path) -> None:
+        """The run ID should appear in the HTML report."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "eval-html-001" in content
+
+    def test_timestamp_in_html(self, tmp_path: Path) -> None:
+        """The report timestamp should appear in the HTML report."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "2026" in content
+
+
+class TestHtmlFaithfulnessBreakdown:
+    def test_faithfulness_details_shown(self, tmp_path: Path) -> None:
+        """When faithfulness metric has claim details, they should be shown."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # The faithfulness metric has details with claims_verified/claims_total
+        assert "claims" in content.lower() or "faithfulness" in content.lower()
+
+
+class TestHtmlSessionStripping:
+    def test_strips_session_data_by_default(self, tmp_path: Path) -> None:
+        """HTML report should strip raw session data by default (--include-sessions to opt in).
+
+        Verifies that write_html_report applies strip_session_data to the report
+        before rendering, matching the JSON report's default behavior.
+        """
+        from unittest.mock import patch
+
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+
+        # Capture the report object that gets passed to the template
+        captured_reports: list[EvalReport] = []
+        original_build_env = __import__(
+            "raki.report.html_report", fromlist=["_build_jinja_env"]
+        )._build_jinja_env
+
+        def capture_env():
+            env = original_build_env()
+            original_get_template = env.get_template
+
+            def patched_get_template(name):
+                template = original_get_template(name)
+                original_render = template.render
+
+                def patched_render(**kwargs):
+                    captured_reports.append(kwargs["report"])
+                    return original_render(**kwargs)
+
+                template.render = patched_render
+                return template
+
+            env.get_template = patched_get_template
+            return env
+
+        with patch("raki.report.html_report._build_jinja_env", side_effect=capture_env):
+            write_html_report(report, output)
+
+        assert len(captured_reports) == 1
+        rendered_report = captured_reports[0]
+        # Phase outputs should be replaced with the stripped sentinel
+        for sample_result in rendered_report.sample_results:
+            for phase in sample_result.sample.phases:
+                assert phase.output == "<stripped>"
+                assert phase.output_structured is None
+                assert phase.knowledge_context is None
+                assert phase.instruction_context is None
+
+    def test_include_sessions_retains_data(self, tmp_path: Path) -> None:
+        """When include_sessions=True, raw session data should be retained."""
+        from unittest.mock import patch
+
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+
+        captured_reports: list[EvalReport] = []
+        original_build_env = __import__(
+            "raki.report.html_report", fromlist=["_build_jinja_env"]
+        )._build_jinja_env
+
+        def capture_env():
+            env = original_build_env()
+            original_get_template = env.get_template
+
+            def patched_get_template(name):
+                template = original_get_template(name)
+                original_render = template.render
+
+                def patched_render(**kwargs):
+                    captured_reports.append(kwargs["report"])
+                    return original_render(**kwargs)
+
+                template.render = patched_render
+                return template
+
+            env.get_template = patched_get_template
+            return env
+
+        with patch("raki.report.html_report._build_jinja_env", side_effect=capture_env):
+            write_html_report(report, output, include_sessions=True)
+
+        assert len(captured_reports) == 1
+        rendered_report = captured_reports[0]
+        # Phase outputs should NOT be stripped
+        has_real_output = False
+        for sample_result in rendered_report.sample_results:
+            for phase in sample_result.sample.phases:
+                if phase.output != "<stripped>":
+                    has_real_output = True
+        assert has_real_output
+
+
+class TestComputeWorstSessionsRetrieval:
+    def test_excludes_operational_metrics(self) -> None:
+        """compute_worst_sessions should only use retrieval metrics, not operational ones."""
+        from raki.report.html_report import compute_worst_sessions
+
+        sample = make_sample("session-ops-only", rework_cycles=3, cost=50.0)
+        metric = MetricResult(
+            name="rework_cycles",
+            score=3.0,
+            sample_scores={"session-ops-only": 3.0},
+        )
+        report = EvalReport(
+            run_id="ops-only",
+            aggregate_scores={"rework_cycles": 3.0},
+            sample_results=[SampleResult(sample=sample, scores=[metric])],
+        )
+        worst = compute_worst_sessions(report, limit=5)
+        # No retrieval metrics -> should return empty
+        assert worst == []
+
+    def test_uses_retrieval_metrics_only(self) -> None:
+        """compute_worst_sessions should rank by retrieval scores, ignoring operational."""
+        from raki.report.html_report import compute_worst_sessions
+
+        sample = make_sample("session-mixed", rework_cycles=2, cost=30.0)
+        operational_metric = MetricResult(
+            name="rework_cycles",
+            score=2.0,
+            sample_scores={"session-mixed": 2.0},
+        )
+        retrieval_metric = MetricResult(
+            name="faithfulness",
+            score=0.70,
+            sample_scores={"session-mixed": 0.70},
+        )
+        report = EvalReport(
+            run_id="mixed",
+            aggregate_scores={"rework_cycles": 2.0, "faithfulness": 0.70},
+            sample_results=[
+                SampleResult(sample=sample, scores=[operational_metric, retrieval_metric])
+            ],
+        )
+        worst = compute_worst_sessions(report, limit=5)
+        assert len(worst) == 1
+        # Should use faithfulness (0.70), not the blended avg of (2.0 + 0.70) / 2
+        assert worst[0].avg_score == pytest.approx(0.70)

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("jinja2")
+
 from raki.model.phases import ReviewFinding
 from raki.model.report import EvalReport, MetricResult, SampleResult
 


### PR DESCRIPTION
## Summary
- Add self-contained HTML report with inline CSS/JS, dark theme, no external dependencies
- Sections: aggregate scores, recurring failures, worst-5-sessions shortcut, per-session drill-down
- Collapsible session details with phases, findings, severity badges
- Color-coded metrics matching CLI scheme
- Respects `--include-sessions` flag — strips session data by default
- Worst sessions ranking uses only retrieval metrics (no blended scores)
- Jinja2 import guarded for optional `html` extra dependency
- `RecurringFailure.severity` uses `Literal` type per conventions

Refs #12

## Review
- Python Specialist: 3 findings fixed (Literal type, jinja2 guard, color coding noted), re-verified clean
- Security Specialist: 1 CRITICAL fixed (--include-sessions respected), re-verified clean
- RAG Specialist: 1 finding fixed (no blended scores in worst sessions), re-verified clean

## Notes
- Color coding for non-normalized operational metrics (e.g., cost_efficiency=18.4) is consistent with CLI behavior — both use the same thresholds. Template guards bar visualization for non-0-1 values.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko