### PR TITLE
feat(metrics): migrate Ragas metrics to public collections API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ Assigned-by: <developer-or-orchestrator>
 ## Gotchas
 
 1. **ty is strict** -- Protocol attributes must be satisfied by class variables, not instance attributes.
-2. **Ragas 0.4 API** -- imports from `ragas.metrics.collections`; `ascore()` takes `SingleTurnSample`, not kwargs.
+2. **Ragas 0.4 API** -- imports from `ragas.metrics.collections`; `ascore()` takes keyword args (`user_input`, `retrieved_contexts`, `response`, `reference`), not `SingleTurnSample`.
 3. **Large session files** -- some session formats can be 50MB+; `detect()` must read only the first 4KB.
 4. **ReviewFinding.severity** -- `Literal["critical", "major", "minor"]`, not bare `str`.
 5. **Operational metrics** -- return raw values (cost in $, cycles as count), not 0-1 normalized.

--- a/src/raki/metrics/ragas/adapter.py
+++ b/src/raki/metrics/ragas/adapter.py
@@ -1,7 +1,7 @@
 """Adapter from EvalDataset to Ragas-compatible row format.
 
-Maps EvalSample fields to Ragas 0.4 SingleTurnSample field names without
-importing ragas — this module has no ragas dependency.
+Maps EvalSample fields to Ragas 0.4 collections API ascore() keyword arg
+names without importing ragas -- this module has no ragas dependency.
 """
 
 from dataclasses import dataclass
@@ -12,13 +12,13 @@ from raki.model.phases import PhaseResult
 
 @dataclass
 class RagasRow:
-    """Internal representation matching Ragas 0.4 SingleTurnSample fields."""
+    """Internal representation matching Ragas 0.4 collections API ascore() kwargs."""
 
     session_id: str
-    user_input: str  # maps to SingleTurnSample.user_input
-    retrieved_contexts: list[str]  # maps to SingleTurnSample.retrieved_contexts
-    response: str  # maps to SingleTurnSample.response
-    reference: str | None  # maps to SingleTurnSample.reference (was ground_truths in v0.3)
+    user_input: str  # maps to ascore() kwarg user_input
+    retrieved_contexts: list[str]  # maps to ascore() kwarg retrieved_contexts
+    response: str  # maps to ascore() kwarg response
+    reference: str | None  # maps to ascore() kwarg reference (was ground_truths in v0.3)
 
 
 def to_ragas_rows(dataset: EvalDataset) -> list[RagasRow]:

--- a/src/raki/metrics/ragas/faithfulness.py
+++ b/src/raki/metrics/ragas/faithfulness.py
@@ -1,4 +1,4 @@
-"""Faithfulness metric using Ragas 0.4 legacy Faithfulness @dataclass.
+"""Faithfulness metric using Ragas 0.4 collections API.
 
 Measures whether the generated response is faithful to the retrieved contexts
 (i.e., not hallucinating beyond what the contexts provide).
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 class FaithfulnessMetric:
     """Ragas-backed faithfulness metric satisfying the Metric protocol.
 
-    Uses the legacy Faithfulness @dataclass API with single_turn_ascore().
+    Uses the public Ragas 0.4 collections API with ascore() keyword args.
     Marked as experimental -- designed for NL answers, not code.
     """
 
@@ -45,14 +45,12 @@ class FaithfulnessMetric:
         if not rows:
             return MetricResult(name=self.name, score=0.0, details={"skipped": "no samples"})
 
-        from ragas.dataset_schema import SingleTurnSample  # ty: ignore[unresolved-import]
-        from ragas.metrics._faithfulness import (  # ty: ignore[unresolved-import]
+        from ragas.metrics.collections import (  # ty: ignore[unresolved-import]
             Faithfulness as RagasFaithfulness,
         )
 
         llm = create_ragas_llm(config)
-        ragas_metric = RagasFaithfulness()
-        ragas_metric.llm = llm
+        ragas_metric = RagasFaithfulness(llm=llm)
 
         judge_logger: JudgeLogger | None = None
         if config.judge_log_path is not None:
@@ -67,16 +65,17 @@ class FaithfulnessMetric:
             async def score_one(row):
                 async with semaphore:
                     try:
-                        sample = SingleTurnSample(
+                        result = await ragas_metric.ascore(
                             user_input=row.user_input,
                             response=row.response,
                             retrieved_contexts=row.retrieved_contexts,
                         )
-                        score = await ragas_metric.single_turn_ascore(sample)
+                        score = result if isinstance(result, float) else result.value
                         scores.append(score)
                         sample_scores[row.session_id] = score
+                        reason = None if isinstance(result, float) else result.reason
                         if judge_logger:
-                            judge_logger.log(self.name, row.user_input, score, None)
+                            judge_logger.log(self.name, row.user_input, score, reason)
                     except Exception as exc:
                         safe_error = redact_sensitive(f"ERROR: {exc}")
                         logger.warning(

--- a/src/raki/metrics/ragas/relevancy.py
+++ b/src/raki/metrics/ragas/relevancy.py
@@ -1,7 +1,7 @@
-"""Answer relevancy metric using Ragas 0.4 legacy AnswerRelevancy @dataclass.
+"""Answer relevancy metric using Ragas 0.4 collections API.
 
 Measures how relevant the generated response is to the user's question.
-Requires both an LLM and embeddings.
+Requires both an LLM (for generation) and embeddings (for similarity scoring).
 
 EXPERIMENTAL: This metric was designed for natural language answers, not code.
 Scores may be noisy for agentic code-generation sessions.
@@ -24,8 +24,7 @@ logger = logging.getLogger(__name__)
 class AnswerRelevancyMetric:
     """Ragas-backed answer relevancy metric satisfying the Metric protocol.
 
-    Uses the legacy AnswerRelevancy @dataclass API with single_turn_ascore().
-    Requires embeddings via embedding_factory for cosine similarity scoring.
+    Uses the public Ragas 0.4 collections API with ascore() keyword args.
     Marked as experimental -- designed for NL answers, not code.
     """
 
@@ -46,16 +45,13 @@ class AnswerRelevancyMetric:
         if not rows:
             return MetricResult(name=self.name, score=0.0, details={"skipped": "no samples"})
 
-        from ragas.dataset_schema import SingleTurnSample  # ty: ignore[unresolved-import]
-        from ragas.metrics._answer_relevance import (  # ty: ignore[unresolved-import]
+        from ragas.metrics.collections import (  # ty: ignore[unresolved-import]
             AnswerRelevancy as RagasAnswerRelevancy,
         )
 
         llm = create_ragas_llm(config)
         embeddings = create_ragas_embeddings()
-        ragas_metric = RagasAnswerRelevancy()
-        ragas_metric.llm = llm
-        ragas_metric.embeddings = embeddings
+        ragas_metric = RagasAnswerRelevancy(llm=llm, embeddings=embeddings)
 
         judge_logger: JudgeLogger | None = None
         if config.judge_log_path is not None:
@@ -70,15 +66,16 @@ class AnswerRelevancyMetric:
             async def score_one(row):
                 async with semaphore:
                     try:
-                        sample = SingleTurnSample(
+                        result = await ragas_metric.ascore(
                             user_input=row.user_input,
                             response=row.response,
                         )
-                        score = await ragas_metric.single_turn_ascore(sample)
+                        score = result if isinstance(result, float) else result.value
                         scores.append(score)
                         sample_scores[row.session_id] = score
+                        reason = None if isinstance(result, float) else result.reason
                         if judge_logger:
-                            judge_logger.log(self.name, row.user_input, score, None)
+                            judge_logger.log(self.name, row.user_input, score, reason)
                     except Exception as exc:
                         safe_error = redact_sensitive(f"ERROR: {exc}")
                         logger.warning(

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -359,6 +359,42 @@ class TestContextPrecisionMetric:
 
         assert result.score == pytest.approx(0.75)
 
+    def test_ascore_called_with_correct_kwargs(self, monkeypatch: pytest.MonkeyPatch):
+        """Verify ascore() receives user_input, retrieved_contexts, reference as kwargs."""
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.90
+        mock_result.reason = None
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_precision_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_precision_class, "ContextPrecisionWithReference")
+
+        ground_truth = GroundTruth(
+            question="How to validate?",
+            reference_answer="Use pydantic",
+            domains=["validation"],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with patch(
+            "raki.metrics.ragas.precision.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextPrecisionMetric()
+            metric.compute(dataset, config)
+
+        mock_metric_instance.ascore.assert_called_once()
+        call_kwargs = mock_metric_instance.ascore.call_args.kwargs
+        assert call_kwargs["user_input"] == "How to validate?"
+        assert call_kwargs["retrieved_contexts"] == ["entry 1", "entry 2"]
+        assert call_kwargs["reference"] == "Use pydantic"
+
     def test_logs_errors_on_ascore_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         from raki.metrics.ragas.precision import ContextPrecisionMetric
 
@@ -472,6 +508,42 @@ class TestContextRecallMetric:
 
         assert result.score == pytest.approx(0.88)
 
+    def test_ascore_called_with_correct_kwargs(self, monkeypatch: pytest.MonkeyPatch):
+        """Verify ascore() receives user_input, retrieved_contexts, reference as kwargs."""
+        from raki.metrics.ragas.recall import ContextRecallMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.91
+        mock_result.reason = None
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_recall_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_recall_class, "ContextRecall")
+
+        ground_truth = GroundTruth(
+            question="How to validate?",
+            reference_answer="Use pydantic",
+            domains=["validation"],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with patch(
+            "raki.metrics.ragas.recall.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextRecallMetric()
+            metric.compute(dataset, config)
+
+        mock_metric_instance.ascore.assert_called_once()
+        call_kwargs = mock_metric_instance.ascore.call_args.kwargs
+        assert call_kwargs["user_input"] == "How to validate?"
+        assert call_kwargs["retrieved_contexts"] == ["entry 1", "entry 2"]
+        assert call_kwargs["reference"] == "Use pydantic"
+
 
 # ---------------------------------------------------------------------------
 # Async safety tests — verify _run_async works in different contexts
@@ -520,53 +592,9 @@ class TestMetricConfigJudgeLogPath:
 
 
 # ---------------------------------------------------------------------------
-# Faithfulness mock helpers (legacy dataclass API)
+# No legacy mock helpers -- all 4 metrics now use the collections API
+# via _install_ragas_mock() above.
 # ---------------------------------------------------------------------------
-
-
-def _install_faithfulness_mock(
-    monkeypatch: pytest.MonkeyPatch,
-    mock_metric_class: MagicMock,
-) -> None:
-    """Insert a fake ``ragas.metrics._faithfulness`` module into sys.modules.
-
-    Faithfulness is a legacy @dataclass metric that uses single_turn_ascore()
-    and returns a plain float, not a MetricResult.
-    """
-    import sys
-
-    fake_faithfulness_mod = MagicMock()
-    setattr(fake_faithfulness_mod, "Faithfulness", mock_metric_class)
-    fake_dataset_schema = MagicMock()
-    fake_dataset_schema.SingleTurnSample = MagicMock()
-    monkeypatch.setitem(sys.modules, "ragas", MagicMock())
-    monkeypatch.setitem(sys.modules, "ragas.metrics", MagicMock())
-    monkeypatch.setitem(sys.modules, "ragas.metrics._faithfulness", fake_faithfulness_mod)
-    monkeypatch.setitem(sys.modules, "ragas.dataset_schema", fake_dataset_schema)
-
-
-def _install_relevancy_mock(
-    monkeypatch: pytest.MonkeyPatch,
-    mock_metric_class: MagicMock,
-) -> None:
-    """Insert a fake ``ragas.metrics._answer_relevance`` module into sys.modules.
-
-    AnswerRelevancy is a legacy @dataclass metric that uses single_turn_ascore()
-    and returns a plain float, not a MetricResult.
-    """
-    import sys
-
-    fake_relevancy_mod = MagicMock()
-    setattr(fake_relevancy_mod, "AnswerRelevancy", mock_metric_class)
-    fake_dataset_schema = MagicMock()
-    fake_dataset_schema.SingleTurnSample = MagicMock()
-    fake_embeddings = MagicMock()
-    fake_embeddings.embedding_factory = MagicMock(return_value=MagicMock())
-    monkeypatch.setitem(sys.modules, "ragas", MagicMock())
-    monkeypatch.setitem(sys.modules, "ragas.metrics", MagicMock())
-    monkeypatch.setitem(sys.modules, "ragas.metrics._answer_relevance", fake_relevancy_mod)
-    monkeypatch.setitem(sys.modules, "ragas.dataset_schema", fake_dataset_schema)
-    monkeypatch.setitem(sys.modules, "ragas.embeddings", fake_embeddings)
 
 
 # ---------------------------------------------------------------------------
@@ -604,15 +632,20 @@ class TestFaithfulnessMetric:
         assert metric.display_name == "Faithfulness"
 
     def test_computes_with_mocked_ragas(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Faithfulness uses collections API ascore() with keyword args."""
         from raki.metrics.ragas.faithfulness import FaithfulnessMetric
 
         monkeypatch.chdir(tmp_path)
 
+        mock_result = MagicMock()
+        mock_result.value = 0.9
+        mock_result.reason = "Faithful response"
+
         mock_metric_instance = MagicMock()
-        mock_metric_instance.single_turn_ascore = AsyncMock(return_value=0.9)
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
 
         mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
-        _install_faithfulness_mock(monkeypatch, mock_faithfulness_class)
+        _install_ragas_mock(monkeypatch, mock_faithfulness_class, "Faithfulness")
 
         sample = _make_sample_with_knowledge()
         dataset = EvalDataset(samples=[sample])
@@ -640,15 +673,78 @@ class TestFaithfulnessMetric:
         assert log_entry["metric"] == "faithfulness"
         assert log_entry["score"] == 0.9
 
+    def test_ascore_called_with_correct_kwargs(self, monkeypatch: pytest.MonkeyPatch):
+        """Verify ascore() receives user_input, response, retrieved_contexts as kwargs."""
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.85
+        mock_result.reason = None
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_faithfulness_class, "Faithfulness")
+
+        ground_truth = GroundTruth(
+            question="How to validate?",
+            reference_answer="Use pydantic",
+            domains=["validation"],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with patch(
+            "raki.metrics.ragas.faithfulness.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = FaithfulnessMetric()
+            metric.compute(dataset, config)
+
+        mock_metric_instance.ascore.assert_called_once()
+        call_kwargs = mock_metric_instance.ascore.call_args.kwargs
+        assert call_kwargs["user_input"] == "How to validate?"
+        assert call_kwargs["response"] == "The answer based on knowledge"
+        assert call_kwargs["retrieved_contexts"] == ["entry 1", "entry 2"]
+
+    def test_handles_float_return_from_ascore(self, monkeypatch: pytest.MonkeyPatch):
+        """Faithfulness handles both MetricResult and plain float from ascore()."""
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=0.77)
+
+        mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_faithfulness_class, "Faithfulness")
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with patch(
+            "raki.metrics.ragas.faithfulness.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = FaithfulnessMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.77)
+
     def test_does_not_require_ground_truth(self, monkeypatch: pytest.MonkeyPatch):
         """Faithfulness scores all samples, not just those with ground truth."""
         from raki.metrics.ragas.faithfulness import FaithfulnessMetric
 
+        mock_result = MagicMock()
+        mock_result.value = 0.8
+        mock_result.reason = None
+
         mock_metric_instance = MagicMock()
-        mock_metric_instance.single_turn_ascore = AsyncMock(return_value=0.8)
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
 
         mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
-        _install_faithfulness_mock(monkeypatch, mock_faithfulness_class)
+        _install_ragas_mock(monkeypatch, mock_faithfulness_class, "Faithfulness")
 
         sample = _make_sample_with_knowledge(ground_truth=None)
         dataset = EvalDataset(samples=[sample])
@@ -670,12 +766,10 @@ class TestFaithfulnessMetric:
         monkeypatch.chdir(tmp_path)
 
         mock_metric_instance = MagicMock()
-        mock_metric_instance.single_turn_ascore = AsyncMock(
-            side_effect=RuntimeError("LLM unavailable")
-        )
+        mock_metric_instance.ascore = AsyncMock(side_effect=RuntimeError("LLM unavailable"))
 
         mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
-        _install_faithfulness_mock(monkeypatch, mock_faithfulness_class)
+        _install_ragas_mock(monkeypatch, mock_faithfulness_class, "Faithfulness")
 
         sample = _make_sample_with_knowledge()
         dataset = EvalDataset(samples=[sample])
@@ -733,15 +827,20 @@ class TestAnswerRelevancyMetric:
         assert metric.display_name == "Answer relevancy"
 
     def test_computes_with_mocked_ragas(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """AnswerRelevancy uses collections API ascore() with keyword args."""
         from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
 
         monkeypatch.chdir(tmp_path)
 
+        mock_result = MagicMock()
+        mock_result.value = 0.78
+        mock_result.reason = "Relevant answer"
+
         mock_metric_instance = MagicMock()
-        mock_metric_instance.single_turn_ascore = AsyncMock(return_value=0.78)
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
 
         mock_relevancy_class = MagicMock(return_value=mock_metric_instance)
-        _install_relevancy_mock(monkeypatch, mock_relevancy_class)
+        _install_ragas_mock(monkeypatch, mock_relevancy_class, "AnswerRelevancy")
 
         sample = _make_sample_with_knowledge()
         dataset = EvalDataset(samples=[sample])
@@ -775,18 +874,87 @@ class TestAnswerRelevancyMetric:
         assert log_entry["metric"] == "answer_relevancy"
         assert log_entry["score"] == 0.78
 
+    def test_ascore_called_with_correct_kwargs(self, monkeypatch: pytest.MonkeyPatch):
+        """Verify ascore() receives user_input and response as kwargs."""
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.82
+        mock_result.reason = None
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_relevancy_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_relevancy_class, "AnswerRelevancy")
+
+        ground_truth = GroundTruth(
+            question="How to validate?",
+            reference_answer="Use pydantic",
+            domains=["validation"],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with (
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_llm",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_embeddings",
+                return_value=MagicMock(),
+            ),
+        ):
+            metric = AnswerRelevancyMetric()
+            metric.compute(dataset, config)
+
+        mock_metric_instance.ascore.assert_called_once()
+        call_kwargs = mock_metric_instance.ascore.call_args.kwargs
+        assert call_kwargs["user_input"] == "How to validate?"
+        assert call_kwargs["response"] == "The answer based on knowledge"
+        assert "retrieved_contexts" not in call_kwargs
+
+    def test_handles_float_return_from_ascore(self, monkeypatch: pytest.MonkeyPatch):
+        """AnswerRelevancy handles both MetricResult and plain float from ascore()."""
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=0.65)
+
+        mock_relevancy_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_relevancy_class, "AnswerRelevancy")
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with (
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_llm",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_embeddings",
+                return_value=MagicMock(),
+            ),
+        ):
+            metric = AnswerRelevancyMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.65)
+
     def test_handles_ascore_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
 
         monkeypatch.chdir(tmp_path)
 
         mock_metric_instance = MagicMock()
-        mock_metric_instance.single_turn_ascore = AsyncMock(
-            side_effect=RuntimeError("Embeddings failed")
-        )
+        mock_metric_instance.ascore = AsyncMock(side_effect=RuntimeError("Embeddings failed"))
 
         mock_relevancy_class = MagicMock(return_value=mock_metric_instance)
-        _install_relevancy_mock(monkeypatch, mock_relevancy_class)
+        _install_ragas_mock(monkeypatch, mock_relevancy_class, "AnswerRelevancy")
 
         sample = _make_sample_with_knowledge()
         dataset = EvalDataset(samples=[sample])


### PR DESCRIPTION
## Summary
- Migrated all 4 Ragas metrics (ContextPrecision, ContextRecall, Faithfulness, AnswerRelevancy) from legacy private API to public `ragas.metrics.collections`
- All metrics now use consistent `ascore()` keyword args instead of legacy `SingleTurnSample`
- Fixed AnswerRelevancy to properly pass `embeddings` parameter (CRITICAL fix caught in review)
- Updated AGENTS.md gotcha #2 and adapter.py docstrings to reflect the new API

Refs #30

## Review
- Python Specialist: 1 CRITICAL (embeddings missing) + 4 IMPORTANT fixed in iteration 2, clean on re-review
- Security Specialist: not applicable
- RAG Specialist: 1 CRITICAL (embeddings missing) + 3 IMPORTANT fixed in iteration 2, clean on re-review

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko