### PR TITLE
feat(report): comprehensive HTML report UX fixes

### DIFF
--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -221,7 +221,12 @@ def run(
         from raki.report.html_report import html_timestamp_filename, write_html_report
 
         html_file = output_path / html_timestamp_filename(report)
-        write_html_report(report, html_file, include_sessions=include_sessions)
+        write_html_report(
+            report,
+            html_file,
+            include_sessions=include_sessions,
+            session_count=len(dataset.samples),
+        )
     except ImportError:
         html_file = None
         if not quiet:

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -8,6 +8,80 @@ from typing import Literal
 from raki.model.report import EvalReport
 from raki.report.cli_summary import EXPERIMENTAL_METRICS, OPERATIONAL_METRICS
 
+# Metric metadata registry — maps raw metric names to display properties.
+# This mirrors the class-level attributes from each Metric implementation
+# so the HTML report can render display_name, format values, and pick colors
+# without importing the metric classes directly.
+METRIC_METADATA: dict[str, dict[str, str | bool]] = {
+    "first_pass_verify_rate": {
+        "display_name": "Verify rate",
+        "higher_is_better": True,
+        "display_format": "percent",
+        "description": "% sessions passing verify on first try",
+    },
+    "rework_cycles": {
+        "display_name": "Rework cycles",
+        "higher_is_better": False,
+        "display_format": "count",
+        "description": "Average review-fix iterations per session",
+    },
+    "review_severity_distribution": {
+        "display_name": "Severity score",
+        "higher_is_better": True,
+        "display_format": "score",
+        "description": "Weighted severity of review findings (1.0 = no findings)",
+    },
+    "cost_efficiency": {
+        "display_name": "Cost / session",
+        "higher_is_better": False,
+        "display_format": "currency",
+        "description": "Average LLM cost per session in USD",
+    },
+    "knowledge_retrieval_miss_rate": {
+        "display_name": "Knowledge miss rate",
+        "higher_is_better": False,
+        "display_format": "score",
+        "description": "Fraction of rework caused by missing retrieval context",
+    },
+    "faithfulness": {
+        "display_name": "Faithfulness",
+        "higher_is_better": True,
+        "display_format": "score",
+        "description": "Fraction of claims supported by retrieved context",
+    },
+    "answer_relevancy": {
+        "display_name": "Answer relevancy",
+        "higher_is_better": True,
+        "display_format": "score",
+        "description": "How relevant the response is to the user query",
+    },
+    "context_precision": {
+        "display_name": "Context precision",
+        "higher_is_better": True,
+        "display_format": "score",
+        "description": "Precision of retrieved context relative to ground truth",
+    },
+    "context_recall": {
+        "display_name": "Context recall",
+        "higher_is_better": True,
+        "display_format": "score",
+        "description": "Recall of retrieved context relative to ground truth",
+    },
+}
+
+
+def _get_metric_meta(name: str) -> dict[str, str | bool]:
+    """Look up metadata for a metric, falling back to sensible defaults."""
+    return METRIC_METADATA.get(
+        name,
+        {
+            "display_name": name,
+            "higher_is_better": True,
+            "display_format": "score",
+            "description": "",
+        },
+    )
+
 
 @dataclass(frozen=True)
 class RecurringFailure:
@@ -27,11 +101,19 @@ class WorstSessionEntry:
     avg_score: float
 
 
-def html_color_for_score(score: float, higher_is_better: bool = True) -> str:
+def html_color_for_score(
+    score: float,
+    higher_is_better: bool = True,
+    display_format: str = "score",
+) -> str:
     """Return a CSS color class name for a score value.
 
     Matches the CLI color_for_score semantics: green >= 0.8, yellow >= 0.6, red below.
+    Skip color for non-ratio metrics (currency, count) where higher_is_better
+    is False -- those values are not on a 0-1 scale.
     """
+    if not higher_is_better and display_format in ("currency", "count"):
+        return "white"
     if higher_is_better:
         if score >= 0.8:
             return "green"
@@ -137,7 +219,12 @@ def _build_jinja_env():  # type: ignore[no-any-return]
     )
 
 
-def write_html_report(report: EvalReport, output: Path, include_sessions: bool = False) -> None:
+def write_html_report(
+    report: EvalReport,
+    output: Path,
+    include_sessions: bool = False,
+    session_count: int | None = None,
+) -> None:
     """Render and write a self-contained HTML report.
 
     All CSS and JavaScript are inlined in the template — no external dependencies.
@@ -145,6 +232,9 @@ def write_html_report(report: EvalReport, output: Path, include_sessions: bool =
 
     When include_sessions is False (the default), raw session data is stripped
     from the report before rendering to avoid leaking sensitive information.
+
+    session_count is passed as a separate template variable so the header shows
+    the correct count even when sample_results is empty.
     """
     from raki.report.json_report import strip_session_data
 
@@ -157,12 +247,28 @@ def write_html_report(report: EvalReport, output: Path, include_sessions: bool =
         strip_session_data(data)
         report = EvalReport.model_validate(data)
 
+    resolved_session_count = (
+        session_count if session_count is not None else len(report.sample_results)
+    )
+
     operational_scores, retrieval_scores = _split_scores(report.aggregate_scores)
     recurring_failures = _collect_recurring_failures(report)
     worst_sessions = compute_worst_sessions(report, limit=5)
 
     env = _build_jinja_env()
     template = env.get_template("report.html.j2")
+
+    def color_class_fn(score: float, metric_name: str = "") -> str:
+        meta = _get_metric_meta(metric_name)
+        higher = bool(meta["higher_is_better"])
+        fmt = str(meta["display_format"])
+        return f"color-{html_color_for_score(score, higher, fmt)}"
+
+    def color_name_fn(score: float, metric_name: str = "") -> str:
+        meta = _get_metric_meta(metric_name)
+        higher = bool(meta["higher_is_better"])
+        fmt = str(meta["display_format"])
+        return html_color_for_score(score, higher, fmt)
 
     html_content = template.render(
         report=report,
@@ -171,8 +277,11 @@ def write_html_report(report: EvalReport, output: Path, include_sessions: bool =
         experimental_metrics=EXPERIMENTAL_METRICS,
         recurring_failures=recurring_failures,
         worst_sessions=worst_sessions,
-        color_class=lambda score: f"color-{html_color_for_score(score)}",
-        color_name=html_color_for_score,
+        session_count=resolved_session_count,
+        metric_metadata=METRIC_METADATA,
+        get_metric_meta=_get_metric_meta,
+        color_class=color_class_fn,
+        color_name=color_name_fn,
     )
 
     output.write_text(html_content)

--- a/src/raki/report/templates/report.html.j2
+++ b/src/raki/report/templates/report.html.j2
@@ -99,6 +99,13 @@
     margin-bottom: 0.4rem;
   }
 
+  .score-card .metric-description {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-bottom: 0.4rem;
+    font-style: italic;
+  }
+
   .score-card .metric-value {
     font-size: 1.8rem;
     font-weight: 700;
@@ -202,9 +209,11 @@
     border-radius: 6px;
     margin-bottom: 0.5rem;
     cursor: pointer;
-    text-decoration: none;
     color: var(--text-primary);
     transition: background-color 0.15s;
+    width: 100%;
+    font-family: inherit;
+    font-size: inherit;
   }
 
   .worst-session-row:hover {
@@ -411,10 +420,11 @@
     <div class="meta">
       <span><strong>Run:</strong> {{ report.run_id }}</span>
       <span><strong>Timestamp:</strong> {{ report.timestamp.strftime('%Y-%m-%d %H:%M:%S UTC') }}</span>
-      <span><strong>Sessions:</strong> {{ report.sample_results | length }}</span>
+      <span><strong>Sessions:</strong> {{ session_count }}</span>
     </div>
   </header>
 
+  <main>
   {# --- Aggregate Scores --- #}
   <section>
     <h2>Aggregate Scores</h2>
@@ -424,12 +434,14 @@
       <div class="category-label">Operational Health</div>
       <div class="score-grid">
         {% for name, score in operational_scores.items() %}
+        {% set meta = get_metric_meta(name) %}
         <div class="score-card">
-          <div class="metric-name">{{ name }}</div>
-          <div class="metric-value {{ color_class(score) }}">{{ "%.2f"|format(score) }}</div>
-          {% if score <= 1.0 and score >= 0.0 %}
+          <div class="metric-name">{{ meta.display_name }}</div>
+          {% if meta.description %}<div class="metric-description">{{ meta.description }}</div>{% endif %}
+          <div class="metric-value {{ color_class(score, name) }}">{% if meta.display_format == "currency" %}${{ "%.2f"|format(score) }}{% elif meta.display_format == "count" %}{{ "%.1f"|format(score) }}{% elif meta.display_format == "percent" %}{{ "%.0f"|format(score * 100) }}%{% else %}{{ "%.2f"|format(score) }}{% endif %}</div>
+          {% if meta.display_format not in ("currency", "count") and score <= 1.0 and score >= 0.0 %}
           <div class="metric-bar">
-            <div class="metric-bar-fill bg-{{ color_name(score) }}" style="width: {{ (score * 100)|int }}%"></div>
+            <div class="metric-bar-fill bg-{{ color_name(score, name) }}" style="width: {{ (score * 100)|int }}%"></div>
           </div>
           {% endif %}
         </div>
@@ -443,25 +455,32 @@
       <div class="category-label">Retrieval Quality</div>
       <div class="score-grid">
         {% for name, score in retrieval_scores.items() %}
+        {% set meta = get_metric_meta(name) %}
         <div class="score-card">
-          <div class="metric-name">{{ name }}{% if name in experimental_metrics %} <span class="metric-tag">[experimental]</span>{% endif %}</div>
-          <div class="metric-value {{ color_class(score) }}">{{ "%.2f"|format(score) }}</div>
+          <div class="metric-name">{{ meta.display_name }}{% if name in experimental_metrics %} <span class="metric-tag">[experimental]</span>{% endif %}</div>
+          {% if meta.description %}<div class="metric-description">{{ meta.description }}</div>{% endif %}
+          <div class="metric-value {{ color_class(score, name) }}">{{ "%.2f"|format(score) }}</div>
           {% if score <= 1.0 and score >= 0.0 %}
           <div class="metric-bar">
-            <div class="metric-bar-fill bg-{{ color_name(score) }}" style="width: {{ (score * 100)|int }}%"></div>
+            <div class="metric-bar-fill bg-{{ color_name(score, name) }}" style="width: {{ (score * 100)|int }}%"></div>
           </div>
           {% endif %}
         </div>
         {% endfor %}
       </div>
     </div>
+    {% else %}
+    <div class="category-section">
+      <div class="category-label">Retrieval Quality</div>
+      <p class="empty-state">Retrieval metrics require LLM judge &mdash; run without --no-llm to enable.</p>
+    </div>
     {% endif %}
   </section>
 
   {# --- Recurring Failures --- #}
-  {% if recurring_failures %}
   <section>
     <h2>Recurring Failures</h2>
+    {% if recurring_failures %}
     <table class="failures-table">
       <thead>
         <tr>
@@ -482,30 +501,34 @@
         {% endfor %}
       </tbody>
     </table>
+    {% else %}
+    <p class="empty-state">No recurring failures detected across sessions.</p>
+    {% endif %}
   </section>
-  {% endif %}
 
   {# --- Worst 5 Sessions --- #}
-  {% if worst_sessions %}
   <section class="worst-sessions">
-    <h2>Worst {{ worst_sessions | length }} Sessions</h2>
+    <h2>Worst {{ worst_sessions | length if worst_sessions else 0 }} Sessions</h2>
+    {% if worst_sessions %}
     {% for entry in worst_sessions %}
-    <a class="worst-session-row" href="#session-{{ entry.session_id }}">
+    <button class="worst-session-row" type="button" data-target="session-{{ entry.session_id }}" aria-label="Jump to session {{ entry.session_id }}">
       <span class="session-id">{{ entry.session_id }}</span>
-      <span class="session-score {{ color_class(entry.avg_score) }}">{{ "%.2f"|format(entry.avg_score) }}</span>
-    </a>
+      <span class="session-score {{ color_class(entry.avg_score, "") }}">{{ "%.2f"|format(entry.avg_score) }}</span>
+    </button>
     {% endfor %}
+    {% else %}
+    <p class="empty-state">No session ranking available (requires retrieval metrics).</p>
+    {% endif %}
   </section>
-  {% endif %}
 
   {# --- Per-Session Drill-Down --- #}
-  {% if report.sample_results %}
   <section class="drilldown-section">
     <h2>Per-Session Drill-Down</h2>
+    {% if report.sample_results %}
     {% for sample_result in report.sample_results %}
     {% set sample = sample_result.sample %}
     {% set session_id = sample.session.session_id %}
-    <details id="session-{{ session_id }}">
+    <details id="session-{{ session_id }}" aria-expanded="false">
       <summary>
         <span>{{ session_id }}</span>
         <span class="score-chips">
@@ -514,7 +537,7 @@
           {% set session_score = metric_result.sample_scores[session_id] %}
           <span class="score-chip">
             <span class="chip-name">{{ metric_result.name }}</span>
-            <span class="chip-value {{ color_class(session_score) }}">{{ "%.2f"|format(session_score) }}</span>
+            <span class="chip-value {{ color_class(session_score, metric_result.name) }}">{{ "%.2f"|format(session_score) }}</span>
           </span>
           {% endif %}
           {% endfor %}
@@ -589,8 +612,11 @@
       </div>
     </details>
     {% endfor %}
+    {% else %}
+    <p class="empty-state">No per-session data available.</p>
+    {% endif %}
   </section>
-  {% endif %}
+  </main>
 
   <footer>
     Generated by RAKI &mdash; Retrieval Assessment for Knowledge Impact
@@ -598,17 +624,23 @@
 </div>
 
 <script>
-/* Toggle all sessions open/closed */
+/* Navigate to session details when worst-session button is clicked */
 (function() {
-  document.querySelectorAll('.worst-session-row').forEach(function(row) {
-    row.addEventListener('click', function(event) {
-      event.preventDefault();
-      var targetId = this.getAttribute('href').substring(1);
+  document.querySelectorAll('.worst-session-row').forEach(function(btn) {
+    btn.addEventListener('click', function(event) {
+      var targetId = this.getAttribute('data-target');
       var target = document.getElementById(targetId);
       if (target) {
         target.setAttribute('open', '');
+        target.setAttribute('aria-expanded', 'true');
         target.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }
+    });
+  });
+  /* Update aria-expanded on details toggle */
+  document.querySelectorAll('details').forEach(function(detail) {
+    detail.addEventListener('toggle', function() {
+      this.setAttribute('aria-expanded', this.open ? 'true' : 'false');
     });
   });
 })();

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -264,15 +264,15 @@ class TestHtmlSections:
         assert "Aggregate" in content or "aggregate" in content
 
     def test_operational_health_displayed(self, tmp_path: Path) -> None:
-        """Operational metrics should appear in the report."""
+        """Operational metrics should appear in the report using display names."""
         from raki.report.html_report import write_html_report
 
         report = _make_report_with_samples()
         output = tmp_path / "report.html"
         write_html_report(report, output)
         content = output.read_text()
-        assert "first_pass_verify_rate" in content
-        assert "rework_cycles" in content
+        assert "Verify rate" in content
+        assert "Rework cycles" in content
 
     def test_retrieval_quality_displayed(self, tmp_path: Path) -> None:
         """Retrieval metrics should appear when present."""
@@ -589,3 +589,399 @@ class TestComputeWorstSessionsRetrieval:
         assert len(worst) == 1
         # Should use faithfulness (0.70), not the blended avg of (2.0 + 0.70) / 2
         assert worst[0].avg_score == pytest.approx(0.70)
+
+
+# --- Issue #33: HTML report fixes ---
+
+
+class TestHtmlColorHigherIsBetter:
+    """html_color_for_score respects higher_is_better for inverted metrics."""
+
+    def test_inverted_metric_low_score_is_green(self) -> None:
+        """For inverted metrics (higher_is_better=False), low scores should be green."""
+        from raki.report.html_report import html_color_for_score
+
+        assert html_color_for_score(0.1, higher_is_better=False) == "green"
+
+    def test_inverted_metric_high_score_is_red(self) -> None:
+        """For inverted metrics (higher_is_better=False), high scores should be red."""
+        from raki.report.html_report import html_color_for_score
+
+        assert html_color_for_score(0.8, higher_is_better=False) == "red"
+
+    def test_inverted_metric_mid_score_is_yellow(self) -> None:
+        """For inverted metrics (higher_is_better=False), mid scores should be yellow."""
+        from raki.report.html_report import html_color_for_score
+
+        assert html_color_for_score(0.3, higher_is_better=False) == "yellow"
+
+    def test_non_normalized_currency_returns_white(self) -> None:
+        """Non-normalized metrics (currency) should return white, not a color band."""
+        from raki.report.html_report import html_color_for_score
+
+        assert (
+            html_color_for_score(18.4, higher_is_better=False, display_format="currency") == "white"
+        )
+
+    def test_non_normalized_count_returns_white(self) -> None:
+        """Non-normalized metrics (count) should return white, not a color band."""
+        from raki.report.html_report import html_color_for_score
+
+        assert html_color_for_score(3.0, higher_is_better=False, display_format="count") == "white"
+
+    def test_inverted_metric_colors_in_report(self, tmp_path: Path) -> None:
+        """Inverted metrics like knowledge_retrieval_miss_rate should show correct colors."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-inverted",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={
+                "knowledge_retrieval_miss_rate": 0.1,  # Low miss rate = good = green
+            },
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Miss rate 0.1 with higher_is_better=False should be green
+        assert "color-green" in content
+
+
+class TestProgressBarOmission:
+    """Progress bars omitted for non-normalized metrics (cost, rework count)."""
+
+    def test_no_progress_bar_for_cost(self, tmp_path: Path) -> None:
+        """Cost metric should not have a progress bar since it's not 0-1 normalized."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-cost",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"cost_efficiency": 18.4},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # The cost card should not have a metric-bar element
+        # Look for the display name "Cost / session" which is now used in the template
+        cost_idx = content.find("Cost / session")
+        assert cost_idx != -1, "Expected 'Cost / session' display name in HTML"
+        # Find the end of this score-card div
+        card_end = content.find("</div>", cost_idx + 50)
+        next_card_end = content.find("</div>", card_end + 1)
+        cost_section = (
+            content[cost_idx:next_card_end] if next_card_end != -1 else content[cost_idx:]
+        )
+        assert "metric-bar" not in cost_section
+
+    def test_no_progress_bar_for_rework_count(self, tmp_path: Path) -> None:
+        """Rework cycles metric should not have a progress bar since it's a count."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-rework",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"rework_cycles": 1.3},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # rework_cycles card should not have a metric-bar — uses display name "Rework cycles"
+        rework_idx = content.find("Rework cycles")
+        assert rework_idx != -1, "Expected 'Rework cycles' display name in HTML"
+        card_end = content.find("</div>", rework_idx + 50)
+        next_card_end = content.find("</div>", card_end + 1)
+        rework_section = (
+            content[rework_idx:next_card_end] if next_card_end != -1 else content[rework_idx:]
+        )
+        assert "metric-bar" not in rework_section
+
+    def test_progress_bar_present_for_normalized_metric(self, tmp_path: Path) -> None:
+        """Normalized metrics (like verify rate, 0-1) should still have progress bars."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-verify",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"first_pass_verify_rate": 0.85},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "metric-bar" in content
+
+
+class TestSessionCount:
+    """session_count passed as separate template variable, not derived from sample_results."""
+
+    def test_session_count_in_header(self, tmp_path: Path) -> None:
+        """Session count should appear in the header from the session_count variable."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-count",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"first_pass_verify_rate": 0.85},
+            config={"session_count": 42},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output, session_count=42)
+        content = output.read_text()
+        assert "42" in content
+
+    def test_session_count_defaults_to_sample_results_length(self, tmp_path: Path) -> None:
+        """When session_count not provided, it should fall back to sample_results length."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # 3 sample results in _make_report_with_samples
+        assert ">3<" in content or ">3 " in content or "Sessions:</strong> 3" in content
+
+
+class TestEmptyStates:
+    """All conditional sections have .empty-state messages when data is empty."""
+
+    def test_no_retrieval_metrics_shows_empty_state(self, tmp_path: Path) -> None:
+        """When there are no retrieval metrics, show an empty-state message."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-no-retrieval",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={
+                "first_pass_verify_rate": 0.85,
+                "rework_cycles": 1.0,
+            },
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "empty-state" in content
+        assert "Retrieval metrics require LLM judge" in content
+
+    def test_no_recurring_failures_shows_empty_state(self, tmp_path: Path) -> None:
+        """When there are no recurring failures, show an empty-state message."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "empty-state" in content
+        # Should have some message about no recurring failures
+        assert "No recurring" in content or "no recurring" in content
+
+    def test_no_drilldown_shows_empty_state(self, tmp_path: Path) -> None:
+        """When sample_results is empty, the drill-down section should show empty-state."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "empty-state" in content
+
+    def test_no_worst_sessions_shows_empty_state(self, tmp_path: Path) -> None:
+        """When there are no worst sessions, show an empty-state message."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "empty-state" in content
+
+
+class TestDisplayNames:
+    """display_name used on score cards, raw metric names in JSON only."""
+
+    def test_display_name_on_score_card(self, tmp_path: Path) -> None:
+        """Score cards should show display_name (e.g., 'Verify rate') not raw name."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-display",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={
+                "first_pass_verify_rate": 0.85,
+                "cost_efficiency": 7.74,
+            },
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Should show display names
+        assert "Verify rate" in content
+        assert "Cost / session" in content
+
+    def test_metric_description_subtitle(self, tmp_path: Path) -> None:
+        """Score cards should show metric description as a subtitle."""
+        from raki.report.html_report import METRIC_METADATA, write_html_report
+
+        report = EvalReport(
+            run_id="eval-desc",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"first_pass_verify_rate": 0.85},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Should contain the description from METRIC_METADATA
+        meta = METRIC_METADATA["first_pass_verify_rate"]
+        assert meta["description"] in content
+
+
+class TestAccessibility:
+    """Accessibility improvements: button, aria-expanded, main landmark."""
+
+    def test_main_landmark_present(self, tmp_path: Path) -> None:
+        """HTML should use a <main> landmark for the main content area."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "<main" in content
+        assert "</main>" in content
+
+    def test_button_for_worst_session_rows(self, tmp_path: Path) -> None:
+        """Worst session rows should use <button> instead of <a> for clickable rows."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_many_sessions()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Should use button, not anchor
+        assert "<button" in content
+        assert 'class="worst-session-row"' in content or "worst-session-row" in content
+        # Should NOT use <a> for worst session rows
+        assert '<a class="worst-session-row"' not in content
+
+    def test_aria_expanded_on_collapsibles(self, tmp_path: Path) -> None:
+        """Collapsible sections should have aria-expanded attributes."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "aria-expanded" in content
+
+
+class TestCostFormatting:
+    """Cost should display as $7.74, not 7.74."""
+
+    def test_cost_displays_with_dollar_sign(self, tmp_path: Path) -> None:
+        """Cost values should be formatted with a dollar sign prefix."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-cost-fmt",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"cost_efficiency": 7.74},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "$7.74" in content
+
+    def test_cost_in_drilldown_has_dollar_sign(self, tmp_path: Path) -> None:
+        """Cost in the per-session drill-down should also show dollar sign."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # The drill-down already shows $25.00 etc. - verify this is still the case
+        assert "$25.00" in content or "$15.00" in content
+
+
+class TestMetricMetadataSync:
+    """METRIC_METADATA stays in sync with actual metric class attributes."""
+
+    def test_metadata_matches_metric_classes(self) -> None:
+        """Every metric class's display_name, higher_is_better, and display_format
+        must match the corresponding entry in METRIC_METADATA."""
+        from raki.metrics.operational import ALL_OPERATIONAL
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+        from raki.metrics.ragas.recall import ContextRecallMetric
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+        from raki.report.html_report import METRIC_METADATA
+
+        all_metrics = list(ALL_OPERATIONAL) + [
+            FaithfulnessMetric(),
+            AnswerRelevancyMetric(),
+            ContextPrecisionMetric(),
+            ContextRecallMetric(),
+        ]
+
+        for metric in all_metrics:
+            meta = METRIC_METADATA.get(metric.name)
+            assert meta is not None, f"Metric '{metric.name}' missing from METRIC_METADATA"
+            assert meta["display_name"] == metric.display_name, (
+                f"display_name mismatch for '{metric.name}': "
+                f"metadata={meta['display_name']!r}, class={metric.display_name!r}"
+            )
+            assert meta["higher_is_better"] == metric.higher_is_better, (
+                f"higher_is_better mismatch for '{metric.name}': "
+                f"metadata={meta['higher_is_better']!r}, class={metric.higher_is_better!r}"
+            )
+            assert meta["display_format"] == metric.display_format, (
+                f"display_format mismatch for '{metric.name}': "
+                f"metadata={meta['display_format']!r}, class={metric.display_format!r}"
+            )
+
+    def test_all_metadata_entries_have_metric_class(self) -> None:
+        """Every key in METRIC_METADATA must correspond to an actual metric class."""
+        from raki.metrics.operational import ALL_OPERATIONAL
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+        from raki.metrics.ragas.recall import ContextRecallMetric
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+        from raki.report.html_report import METRIC_METADATA
+
+        all_metrics = list(ALL_OPERATIONAL) + [
+            FaithfulnessMetric(),
+            AnswerRelevancyMetric(),
+            ContextPrecisionMetric(),
+            ContextRecallMetric(),
+        ]
+        metric_names = {metric.name for metric in all_metrics}
+
+        for metadata_key in METRIC_METADATA:
+            assert metadata_key in metric_names, (
+                f"METRIC_METADATA key '{metadata_key}' has no corresponding metric class"
+            )
+
+
+class TestPercentFormat:
+    """display_format='percent' renders as '85%' not '0.85'."""
+
+    def test_verify_rate_shows_percentage(self, tmp_path: Path) -> None:
+        """first_pass_verify_rate (display_format=percent) should render as percentage."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-percent",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"first_pass_verify_rate": 0.85},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "85%" in content
+        # Should NOT show raw 0.85 in the metric value
+        # (0.85 may appear elsewhere, e.g. in a bar width, so we check the metric-value div)
+        verify_idx = content.find("Verify rate")
+        assert verify_idx != -1
+        value_start = content.find("metric-value", verify_idx)
+        value_end = content.find("</div>", value_start)
+        value_section = content[value_start:value_end]
+        assert "85%" in value_section


### PR DESCRIPTION
## Summary
- Color logic respects `higher_is_better` for inverted metrics (rework, miss rate)
- Percent format for verify rate (85% not 0.85), currency for cost ($7.74)
- Progress bars omitted for non-normalized metrics (cost, rework count)
- Display names and descriptions on score cards
- Empty-state messages for all conditional sections
- Accessibility: `<main>` landmark, `<button>` for clickable rows, `aria-expanded`
- Session count passed from CLI for accurate header display
- METRIC_METADATA sync guard test ensures registry stays in sync with metric classes

Refs #33
Closes #25
Closes #26
Closes #28

## Review
- Python Specialist: 4 IMPORTANT fixed in iteration 2, clean on re-review
- Security Specialist: clean (XSS safe via autoescape, no data exposure)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko