### PR TITLE
feat(security): harden symlinks, encoding, redaction, size limits

### DIFF
--- a/src/raki/adapters/alcove.py
+++ b/src/raki/adapters/alcove.py
@@ -16,10 +16,12 @@ class AlcoveAdapter:
 
     def detect(self, source: Path) -> bool:
         """Detect Alcove format via substring search of first 4KB."""
+        if source.is_symlink():
+            return False
         if not source.is_file() or source.suffix != ".json":
             return False
         try:
-            with source.open(errors="replace") as file_handle:
+            with source.open(encoding="utf-8", errors="replace") as file_handle:
                 header = file_handle.read(DETECT_READ_SIZE)
             return '"session_id"' in header and '"transcript"' in header
         except OSError:

--- a/src/raki/adapters/redact.py
+++ b/src/raki/adapters/redact.py
@@ -6,9 +6,16 @@ PATTERNS = [
     re.compile(r'(?i)(token[=:]\s*)(?:[^\s"]+|"[^"]+")'),
     re.compile(r'(?i)(password[=:]\s*)(?:[^\s"]+|"[^"]+")'),
     re.compile(r'(?i)(api[_-]?key[=:]\s*)(?:[^\s"]+|"[^"]+")'),
-    re.compile(r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"),  # JWT
+    # JWT -- including multi-line where header.payload.signature may span lines
+    re.compile(r"eyJ[A-Za-z0-9_-]+\s*\.\s*eyJ[A-Za-z0-9_-]+\s*\.\s*[A-Za-z0-9_-]+", re.DOTALL),
     re.compile(r"AKIA[0-9A-Z]{16}"),  # AWS access keys
     re.compile(r"(?:ghp|gho|ghs|ghr|glpat)_[A-Za-z0-9_]{20,}"),  # GitHub/GitLab tokens
+    # Specific env var patterns: AWS_SECRET_ACCESS_KEY, GITHUB_TOKEN, GH_TOKEN
+    re.compile(r'(?i)(AWS_SECRET_ACCESS_KEY[=:]\s*)(?:[^\s"]+|"[^"]+")'),
+    re.compile(r'(?i)(GITHUB_TOKEN[=:]\s*)(?:[^\s"]+|"[^"]+")'),
+    re.compile(r'(?i)(GH_TOKEN[=:]\s*)(?:[^\s"]+|"[^"]+")'),
+    # Generic *_SECRET*= env vars (e.g. MY_SECRET_KEY=..., DB_SECRET_TOKEN=...)
+    re.compile(r'(?i)([A-Z_]*SECRET[A-Z_]*[=:]\s*)(?:[^\s"]+|"[^"]+")'),
     re.compile(r'(?i)(secret[=:]\s*)(?:[^\s"]+|"[^"]+")'),  # Generic secret keyword
     re.compile(
         r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----"

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -20,7 +20,7 @@ def _read_bounded(path: Path) -> str:
         raise ValueError(
             f"File {path} is {file_size} bytes, exceeding the {MAX_SESSION_FILE_SIZE} byte limit"
         )
-    return path.read_text()
+    return path.read_text(encoding="utf-8")
 
 
 def _validate_path(file_path: Path, session_dir: Path) -> None:
@@ -39,9 +39,13 @@ class SessionSchemaAdapter:
     detection_hint: str = "meta.json + events.jsonl"
 
     def detect(self, source: Path) -> bool:
+        if source.is_symlink():
+            return False
         return (source / "meta.json").exists() and (source / "events.jsonl").exists()
 
     def load(self, source: Path) -> EvalSample:
+        if source.is_symlink():
+            raise ValueError(f"Refusing to load symlink: {source}")
         meta_path = source / "meta.json"
         _validate_path(meta_path, source)
         meta_raw: dict[str, Any] = json.loads(_read_bounded(meta_path))

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -173,6 +173,7 @@ def run(
     config = MetricConfig(
         llm_model=judge_model,
         batch_size=parallel_count,
+        project_root=manifest_file.parent.resolve(),
     )
 
     all_metrics: list[Metric] = list(ALL_OPERATIONAL)

--- a/src/raki/ground_truth/manifest.py
+++ b/src/raki/ground_truth/manifest.py
@@ -120,7 +120,7 @@ def load_manifest(path: Path, *, project_root: Path | None = None) -> EvalManife
         ValueError: If the YAML content is not a mapping, referenced paths
             do not exist, or paths escape the project root.
     """
-    raw = yaml.safe_load(path.read_text())
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
 
     if not isinstance(raw, dict):
         raise ValueError("Manifest must contain a YAML mapping")

--- a/src/raki/ground_truth/matcher.py
+++ b/src/raki/ground_truth/matcher.py
@@ -22,7 +22,7 @@ def load_ground_truth(path: Path) -> list[GroundTruth]:
         A list of validated GroundTruth instances.  Returns an empty list
         when the file is empty or does not contain a YAML list.
     """
-    raw = yaml.safe_load(path.read_text())
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(raw, list):
         return []
     entries: list[GroundTruth] = []

--- a/src/raki/metrics/protocol.py
+++ b/src/raki/metrics/protocol.py
@@ -13,6 +13,7 @@ class MetricConfig(BaseModel):
     temperature: float = 0.0
     batch_size: int = 4
     judge_log_path: Path | None = None  # path to judge_log.jsonl for audit logging
+    project_root: Path | None = None  # root directory for path validation
 
 
 @runtime_checkable

--- a/src/raki/metrics/ragas/faithfulness.py
+++ b/src/raki/metrics/ragas/faithfulness.py
@@ -55,7 +55,7 @@ class FaithfulnessMetric:
 
         judge_logger: JudgeLogger | None = None
         if config.judge_log_path is not None:
-            judge_logger = JudgeLogger(config.judge_log_path)
+            judge_logger = JudgeLogger(config.judge_log_path, config.project_root)
 
         sample_scores: dict[str, float] = {}
         scores: list[float] = []

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -43,16 +43,21 @@ def create_ragas_embeddings():
     return embedding_factory()
 
 
-def _validate_judge_log_path(log_path: Path) -> Path:
-    """Validate that the judge log path is under the current working directory.
+def _validate_judge_log_path(log_path: Path, project_root: Path | None = None) -> Path:
+    """Validate that the judge log path is under the project root.
 
     Follows the same path traversal guard pattern used by the session schema
     adapter and manifest loader.
+
+    Args:
+        log_path: Path to the judge log file.
+        project_root: Root directory to validate against. Falls back to
+            Path.cwd() if not provided (for backward compatibility).
     """
     resolved = log_path.resolve()
-    cwd = Path.cwd().resolve()
-    if not resolved.is_relative_to(cwd):
-        raise ValueError(f"judge_log_path escapes project root: {resolved} is not under {cwd}")
+    root = (project_root or Path.cwd()).resolve()
+    if not resolved.is_relative_to(root):
+        raise ValueError(f"judge_log_path escapes project root: {resolved} is not under {root}")
     return resolved
 
 
@@ -63,8 +68,8 @@ class JudgeLogger:
     user_input, score, and optional reason.
     """
 
-    def __init__(self, log_path: Path):
-        self.log_path = _validate_judge_log_path(log_path)
+    def __init__(self, log_path: Path, project_root: Path | None = None):
+        self.log_path = _validate_judge_log_path(log_path, project_root)
         self.log_path.parent.mkdir(parents=True, exist_ok=True)
 
     def log(
@@ -75,7 +80,7 @@ class JudgeLogger:
         result_reason: str | None,
     ) -> None:
         """Append a judge call record to the JSONL log file."""
-        with self.log_path.open("a") as log_file:
+        with self.log_path.open("a", encoding="utf-8") as log_file:
             log_file.write(
                 json.dumps(
                     {

--- a/src/raki/metrics/ragas/precision.py
+++ b/src/raki/metrics/ragas/precision.py
@@ -48,7 +48,7 @@ class ContextPrecisionMetric:
 
         judge_logger: JudgeLogger | None = None
         if config.judge_log_path is not None:
-            judge_logger = JudgeLogger(config.judge_log_path)
+            judge_logger = JudgeLogger(config.judge_log_path, config.project_root)
 
         sample_scores: dict[str, float] = {}
         scores: list[float] = []

--- a/src/raki/metrics/ragas/recall.py
+++ b/src/raki/metrics/ragas/recall.py
@@ -48,7 +48,7 @@ class ContextRecallMetric:
 
         judge_logger: JudgeLogger | None = None
         if config.judge_log_path is not None:
-            judge_logger = JudgeLogger(config.judge_log_path)
+            judge_logger = JudgeLogger(config.judge_log_path, config.project_root)
 
         sample_scores: dict[str, float] = {}
         scores: list[float] = []

--- a/src/raki/metrics/ragas/relevancy.py
+++ b/src/raki/metrics/ragas/relevancy.py
@@ -56,7 +56,7 @@ class AnswerRelevancyMetric:
 
         judge_logger: JudgeLogger | None = None
         if config.judge_log_path is not None:
-            judge_logger = JudgeLogger(config.judge_log_path)
+            judge_logger = JudgeLogger(config.judge_log_path, config.project_root)
 
         sample_scores: dict[str, float] = {}
         scores: list[float] = []

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -284,7 +284,7 @@ def write_html_report(
         color_name=color_name_fn,
     )
 
-    output.write_text(html_content)
+    output.write_text(html_content, encoding="utf-8")
 
 
 def html_timestamp_filename(report: EvalReport) -> str:

--- a/src/raki/report/json_report.py
+++ b/src/raki/report/json_report.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from raki.model.report import EvalReport
 
+MAX_REPORT_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+
 
 def write_json_report(report: EvalReport, output: Path, include_sessions: bool = False) -> None:
     """Write JSON report. By default strips large session data fields to keep reports compact.
@@ -21,7 +23,7 @@ def write_json_report(report: EvalReport, output: Path, include_sessions: bool =
     data = report.model_dump(mode="json")
     if not include_sessions:
         strip_session_data(data)
-    output.write_text(json.dumps(data, indent=2, default=str))
+    output.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
 
 
 def strip_session_data(data: dict) -> None:
@@ -42,8 +44,16 @@ def strip_session_data(data: dict) -> None:
 
 
 def load_json_report(path: Path) -> EvalReport:
-    """Load an EvalReport from a JSON file."""
-    raw = json.loads(path.read_text())
+    """Load an EvalReport from a JSON file, enforcing a 50MB size limit."""
+    if path.is_symlink():
+        raise ValueError(f"Refusing to load symlink: {path}")
+    file_size = path.stat().st_size
+    if file_size > MAX_REPORT_FILE_SIZE:
+        raise ValueError(
+            f"Report file {path} is {file_size} bytes, "
+            f"exceeding the {MAX_REPORT_FILE_SIZE} byte limit"
+        )
+    raw = json.loads(path.read_text(encoding="utf-8"))
     return EvalReport.model_validate(raw)
 
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -492,3 +492,97 @@ def test_session_schema_handles_null_phase_metadata(tmp_path):
     # With null phase metadata, defaults should be used
     assert sample.phases[0].generation == 1
     assert sample.phases[0].status == "completed"
+
+
+# --- Security hardening tests (issue #35) ---
+
+
+def test_session_schema_detect_rejects_symlink(tmp_path):
+    """SessionSchemaAdapter.detect() must reject symlinked directories."""
+    real_dir = tmp_path / "real-session"
+    real_dir.mkdir()
+    (real_dir / "meta.json").write_text('{"ticket": "1", "started_at": "2026-04-10T08:00:00Z"}')
+    (real_dir / "events.jsonl").write_text("")
+    link_dir = tmp_path / "link-session"
+    link_dir.symlink_to(real_dir)
+    adapter = SessionSchemaAdapter()
+    assert not adapter.detect(link_dir)
+
+
+def test_session_schema_load_rejects_symlink(tmp_path):
+    """SessionSchemaAdapter.load() must reject symlinked directories."""
+    real_dir = tmp_path / "real-session"
+    real_dir.mkdir()
+    (real_dir / "meta.json").write_text('{"ticket": "1", "started_at": "2026-04-10T08:00:00Z"}')
+    (real_dir / "events.jsonl").write_text("")
+    link_dir = tmp_path / "link-session"
+    link_dir.symlink_to(real_dir)
+    adapter = SessionSchemaAdapter()
+    with pytest.raises(ValueError, match="symlink"):
+        adapter.load(link_dir)
+
+
+def test_alcove_detect_rejects_symlink(tmp_path):
+    """AlcoveAdapter.detect() must reject symlinked files."""
+    real_file = tmp_path / "real.json"
+    real_file.write_text('{"session_id": "x", "transcript": []}')
+    link_file = tmp_path / "link.json"
+    link_file.symlink_to(real_file)
+    adapter = AlcoveAdapter()
+    assert not adapter.detect(link_file)
+
+
+def test_redact_aws_secret_access_key():
+    """AWS_SECRET_ACCESS_KEY=... should be redacted."""
+    text = "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    result = redact_sensitive(text)
+    assert "wJalrXUtnFEMI" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_github_token_env_var():
+    """GITHUB_TOKEN=... should be redacted."""
+    text = "GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    result = redact_sensitive(text)
+    assert "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_gh_token_env_var():
+    """GH_TOKEN=... should be redacted."""
+    text = "GH_TOKEN=ghp_yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+    result = redact_sensitive(text)
+    assert "ghp_yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_generic_secret_env_var():
+    """Generic *_SECRET*= env vars should be redacted (e.g. MY_SECRET_KEY=...)."""
+    text = "MY_SECRET_KEY=super-secret-value-123"
+    result = redact_sensitive(text)
+    assert "super-secret-value-123" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_generic_secret_env_var_with_underscore():
+    """DB_SECRET_TOKEN=... should be redacted."""
+    text = "DB_SECRET_TOKEN=another-secret"
+    result = redact_sensitive(text)
+    assert "another-secret" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_multiline_jwt():
+    """JWT split across multiple lines should be redacted."""
+    text = "header: eyJhbGciOiJIUzI1NiJ9.\neyJzdWIiOiJ1c2VyIn0.\nabcdef123456"
+    result = redact_sensitive(text)
+    assert "eyJhbGciOiJIUzI1NiJ9" not in result
+    assert "***REDACTED***" in result
+
+
+def test_redact_multiline_jwt_across_content_blocks():
+    """JWT header+payload split across content blocks with whitespace should be redacted."""
+    text = "eyJhbGciOiJIUzI1NiJ9\n.eyJzdWIiOiJ1c2VyIn0\n.abcdef123456"
+    result = redact_sensitive(text)
+    assert "eyJhbGciOiJIUzI1NiJ9" not in result
+    assert "***REDACTED***" in result

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -212,10 +212,9 @@ class TestToRagasRows:
 
 
 class TestJudgeLogger:
-    def test_logs_to_jsonl(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.chdir(tmp_path)
+    def test_logs_to_jsonl(self, tmp_path: Path):
         log_path = tmp_path / "subdir" / "judge_log.jsonl"
-        judge_logger = JudgeLogger(log_path)
+        judge_logger = JudgeLogger(log_path, project_root=tmp_path)
         judge_logger.log("context_precision", "How to validate?", 0.85, "Good precision")
         judge_logger.log("context_recall", "How to test?", 0.72, None)
 
@@ -232,23 +231,30 @@ class TestJudgeLogger:
         assert entry2["score"] == 0.72
         assert entry2["reason"] is None
 
-    def test_truncates_long_user_input(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.chdir(tmp_path)
+    def test_truncates_long_user_input(self, tmp_path: Path):
         log_path = tmp_path / "judge_log.jsonl"
-        judge_logger = JudgeLogger(log_path)
+        judge_logger = JudgeLogger(log_path, project_root=tmp_path)
         long_input = "x" * 500
         judge_logger.log("test_metric", long_input, 0.5, None)
 
         entry = json.loads(log_path.read_text().strip())
         assert len(entry["user_input"]) == 200
 
-    def test_rejects_path_outside_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-        subdir = tmp_path / "project"
-        subdir.mkdir()
-        monkeypatch.chdir(subdir)
+    def test_rejects_path_outside_project_root(self, tmp_path: Path):
+        """_validate_judge_log_path should use project_root, not Path.cwd()."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
         outside_path = tmp_path / "outside" / "judge.jsonl"
         with pytest.raises(ValueError, match="escapes project root"):
-            JudgeLogger(outside_path)
+            JudgeLogger(outside_path, project_root=project_dir)
+
+    def test_accepts_path_inside_project_root(self, tmp_path: Path):
+        """Log path under project_root should be accepted without needing monkeypatch.chdir."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        log_path = project_dir / "logs" / "judge.jsonl"
+        judge_logger = JudgeLogger(log_path, project_root=project_dir)
+        assert judge_logger.log_path == log_path.resolve()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -4,6 +4,8 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from raki.model.report import EvalReport, MetricResult, SampleResult
 from raki.report.cli_summary import color_for_score, format_metric_line, print_summary
 from raki.report.json_report import load_json_report, write_json_report
@@ -42,6 +44,35 @@ def _make_report_with_samples() -> EvalReport:
 
 
 # --- JSON round-trip tests ---
+
+
+class TestJsonReportSizeLimit:
+    def test_load_json_report_rejects_oversized_file(self, tmp_path: Path) -> None:
+        """load_json_report() should reject files exceeding 50MB."""
+        big_file = tmp_path / "big-report.json"
+        big_file.write_text('{"run_id": "x"}' + " " * (50 * 1024 * 1024))
+        with pytest.raises(ValueError, match="exceeding"):
+            load_json_report(big_file)
+
+    def test_load_json_report_accepts_normal_file(self, tmp_path: Path) -> None:
+        """load_json_report() should accept files under the 50MB limit."""
+        report = _make_report()
+        output_path = tmp_path / "normal.json"
+        write_json_report(report, output_path)
+        loaded = load_json_report(output_path)
+        assert loaded.run_id == report.run_id
+
+
+class TestJsonReportSymlinkCheck:
+    def test_load_json_report_rejects_symlink(self, tmp_path: Path) -> None:
+        """load_json_report() should reject symlinked files."""
+        report = _make_report()
+        real_file = tmp_path / "real-report.json"
+        write_json_report(report, real_file)
+        link_file = tmp_path / "link-report.json"
+        link_file.symlink_to(real_file)
+        with pytest.raises(ValueError, match="symlink"):
+            load_json_report(link_file)
 
 
 class TestJsonReportRoundTrip:


### PR DESCRIPTION
## Summary
- Add symlink rejection in adapter detect/load methods to prevent symlink-following attacks
- Enforce explicit `encoding="utf-8"` on all file I/O across adapters, reports, ground truth, and judge logging
- Expand redaction patterns: AWS_SECRET_ACCESS_KEY, GITHUB_TOKEN, GH_TOKEN, generic `*_SECRET*=`, multi-line JWTs
- Add 50MB size limit on JSON report loading via `load_json_report()`
- Pass explicit `project_root` to judge log path validation instead of relying on `Path.cwd()`

Refs #35

## Review
- Python Specialist: clean (4 MINOR observations, no blockers)
- Security Specialist: clean after 1 fix iteration (6 encoding consistency fixes applied)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko