### PR TITLE
feat(metrics): fix ragas temperature forwarding and Vertex AI embeddings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ ragas = [
     "ragas>=0.4,<0.5",
     "anthropic>=0.40",
     "google-auth>=2.0",
+    "langchain-google-vertexai>=2.0",
 ]
 html = [
     "jinja2>=3.0",

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -27,20 +27,22 @@ def create_ragas_llm(config: MetricConfig):
     return llm_factory(
         config.llm_model,
         client=client,
+        temperature=config.temperature,
     )
 
 
 def create_ragas_embeddings():
     """Create embeddings for answer_relevancy metric.
 
-    Uses the legacy Ragas embedding_factory which returns BaseRagasEmbeddings,
-    compatible with the AnswerRelevancy @dataclass metric.
+    Uses VertexAIEmbeddings from langchain-google-vertexai for consistency
+    with the Vertex AI LLM setup. The previous embedding_factory() defaulted
+    to OpenAI, which was inconsistent with the Anthropic/Vertex AI LLM config.
 
-    Defers ragas imports so this module can be imported without ragas installed.
+    Defers imports so this module can be imported without dependencies installed.
     """
-    from ragas.embeddings import embedding_factory  # ty: ignore[unresolved-import]
+    from langchain_google_vertexai import VertexAIEmbeddings  # ty: ignore[unresolved-import]
 
-    return embedding_factory()
+    return VertexAIEmbeddings(model_name="text-embedding-005")
 
 
 def _validate_judge_log_path(log_path: Path, project_root: Path | None = None) -> Path:

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -989,8 +989,127 @@ class TestAnswerRelevancyMetric:
 
 
 # ---------------------------------------------------------------------------
+# LLM setup tests — verify create_ragas_llm and create_ragas_embeddings
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRagasLlm:
+    def test_passes_temperature_to_llm_factory(self, monkeypatch: pytest.MonkeyPatch):
+        """config.temperature must be forwarded to llm_factory()."""
+        import sys
+
+        mock_llm_factory = MagicMock(return_value=MagicMock())
+        mock_llms = MagicMock()
+        mock_llms.llm_factory = mock_llm_factory
+
+        mock_anthropic = MagicMock()
+        mock_client_instance = MagicMock()
+        mock_anthropic.AsyncAnthropicVertex = MagicMock(return_value=mock_client_instance)
+
+        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+        monkeypatch.setitem(sys.modules, "ragas", MagicMock())
+        monkeypatch.setitem(sys.modules, "ragas.llms", mock_llms)
+
+        from raki.metrics.ragas.llm_setup import create_ragas_llm
+
+        config = MetricConfig(temperature=0.7)
+        create_ragas_llm(config)
+
+        mock_llm_factory.assert_called_once()
+        call_kwargs = mock_llm_factory.call_args
+        assert call_kwargs.kwargs["temperature"] == 0.7
+
+    def test_passes_zero_temperature_by_default(self, monkeypatch: pytest.MonkeyPatch):
+        """Default temperature=0.0 should also be forwarded."""
+        import sys
+
+        mock_llm_factory = MagicMock(return_value=MagicMock())
+        mock_llms = MagicMock()
+        mock_llms.llm_factory = mock_llm_factory
+
+        mock_anthropic = MagicMock()
+        mock_client_instance = MagicMock()
+        mock_anthropic.AsyncAnthropicVertex = MagicMock(return_value=mock_client_instance)
+
+        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+        monkeypatch.setitem(sys.modules, "ragas", MagicMock())
+        monkeypatch.setitem(sys.modules, "ragas.llms", mock_llms)
+
+        from raki.metrics.ragas.llm_setup import create_ragas_llm
+
+        config = MetricConfig()  # default temperature=0.0
+        create_ragas_llm(config)
+
+        call_kwargs = mock_llm_factory.call_args
+        assert call_kwargs.kwargs["temperature"] == 0.0
+
+
+class TestCreateRagasEmbeddings:
+    def test_uses_vertex_ai_embeddings(self, monkeypatch: pytest.MonkeyPatch):
+        """create_ragas_embeddings() should use VertexAIEmbeddings, not OpenAI default."""
+        import sys
+
+        mock_vertex_instance = MagicMock()
+        mock_vertex_class = MagicMock(return_value=mock_vertex_instance)
+
+        mock_langchain_vertex = MagicMock()
+        mock_langchain_vertex.VertexAIEmbeddings = mock_vertex_class
+
+        monkeypatch.setitem(sys.modules, "langchain_google_vertexai", mock_langchain_vertex)
+
+        from raki.metrics.ragas.llm_setup import create_ragas_embeddings
+
+        result = create_ragas_embeddings()
+        mock_vertex_class.assert_called_once_with(model_name="text-embedding-005")
+        assert result is mock_vertex_instance
+
+    def test_does_not_use_openai_default(self, monkeypatch: pytest.MonkeyPatch):
+        """Verify we don't call the OpenAI-defaulting embedding_factory()."""
+        import sys
+
+        mock_embedding_factory = MagicMock()
+        mock_embeddings_module = MagicMock()
+        mock_embeddings_module.embedding_factory = mock_embedding_factory
+
+        mock_vertex_class = MagicMock(return_value=MagicMock())
+        mock_langchain_vertex = MagicMock()
+        mock_langchain_vertex.VertexAIEmbeddings = mock_vertex_class
+
+        monkeypatch.setitem(sys.modules, "ragas", MagicMock())
+        monkeypatch.setitem(sys.modules, "ragas.embeddings", mock_embeddings_module)
+        monkeypatch.setitem(sys.modules, "langchain_google_vertexai", mock_langchain_vertex)
+
+        from raki.metrics.ragas.llm_setup import create_ragas_embeddings
+
+        create_ragas_embeddings()
+        # embedding_factory (which defaults to OpenAI) should NOT be called
+        mock_embedding_factory.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Integration tests (slow, requires LLM) — marked for selective running
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestLlmSetupIntegration:
+    def test_create_ragas_llm_returns_valid_object(self):
+        """Requires anthropic + Vertex AI credentials. Verifies LLM setup works."""
+        pytest.importorskip("ragas")
+        pytest.importorskip("anthropic")
+        from raki.metrics.ragas.llm_setup import create_ragas_llm
+
+        config = MetricConfig(temperature=0.0)
+        llm = create_ragas_llm(config)
+        assert llm is not None
+
+    def test_create_ragas_embeddings_returns_valid_object(self):
+        """Requires langchain-google-vertexai + credentials. Verifies embeddings setup."""
+        pytest.importorskip("langchain_google_vertexai")
+        from raki.metrics.ragas.llm_setup import create_ragas_embeddings
+
+        embeddings = create_ragas_embeddings()
+        assert embeddings is not None
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- Pass `config.temperature` to `llm_factory()` so evaluation temperature is configurable
- Replace OpenAI-defaulting `embedding_factory()` with `VertexAIEmbeddings` from `langchain-google-vertexai`
- Add `langchain-google-vertexai>=2.0` to ragas optional dependencies
- Add 6 new tests: temperature forwarding, Vertex AI embeddings, slow integration smoke tests

Refs #36

## Review
- Python Specialist: 2 IMPORTANT (hardcoded embedding model noted for future enhancement, assertion tightened), 3 MINOR
- Security Specialist: not applicable
- RAG Specialist: clean (3 MINOR)

## Notes
- Embedding model name (`text-embedding-005`) is hardcoded — configurable `embedding_model` field on MetricConfig deferred to a future issue
- Ragas metrics already import from public `ragas.metrics.collections` — no changes needed

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko