### PR TITLE
feat(adapters): add model_id, tokens, recursive loading, generational sorting

### DIFF
--- a/src/raki/adapters/loader.py
+++ b/src/raki/adapters/loader.py
@@ -18,24 +18,46 @@ class DatasetLoader:
         self.errors: list[LoadError] = []
         self.skipped: list[Path] = []
 
-    def load_directory(self, root: Path) -> EvalDataset:
+    def load_directory(self, root: Path, *, recursive: bool = False) -> EvalDataset:
+        """Load sessions from a directory.
+
+        Args:
+            root: Root directory to scan for sessions.
+            recursive: When True, descend into subdirectories to find sessions.
+                Default is False for backward compatibility.
+
+        Returns:
+            EvalDataset containing all successfully loaded sessions.
+        """
         # Resolve to an absolute path to prevent trivial path traversal.
         # Full manifest-level validation is deferred to the CLI/manifest layer (Issues #6/#8).
         root = root.resolve()
         samples: list[EvalSample] = []
         self.errors = []
         self.skipped = []
-        for child in sorted(root.iterdir()):
-            adapter = self._detect_adapter(child)
-            if adapter is None:
-                self.skipped.append(child)
-                continue
-            try:
-                sample = adapter.load(child)
-                samples.append(sample)
-            except Exception as exc:
-                self.errors.append(LoadError(path=child, error=str(exc)))
+        self._scan_directory(root, samples, recursive=recursive)
         return EvalDataset(samples=samples)
+
+    def _scan_directory(
+        self,
+        directory: Path,
+        samples: list[EvalSample],
+        *,
+        recursive: bool,
+    ) -> None:
+        """Scan a directory for sessions, optionally recursing into subdirectories."""
+        for child in sorted(directory.iterdir()):
+            adapter = self._detect_adapter(child)
+            if adapter is not None:
+                try:
+                    sample = adapter.load(child)
+                    samples.append(sample)
+                except Exception as exc:
+                    self.errors.append(LoadError(path=child, error=str(exc)))
+            elif recursive and child.is_dir() and not child.is_symlink():
+                self._scan_directory(child, samples, recursive=True)
+            else:
+                self.skipped.append(child)
 
     def load_session(self, path: Path, adapter_name: str | None = None) -> EvalSample:
         path = path.resolve()

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -33,6 +33,31 @@ def _validate_path(file_path: Path, session_dir: Path) -> None:
         )
 
 
+def _extract_model_id_from_events(events: list[SessionEvent]) -> str | None:
+    """Extract model_id from the first event that has a 'model' key in its data."""
+    for event in events:
+        model = event.data.get("model")
+        if model and isinstance(model, str):
+            return model
+    return None
+
+
+def _extract_token_counts_from_events(
+    events: list[SessionEvent], phase_name: str
+) -> dict[str, int | None]:
+    """Extract tokens_in/tokens_out from phase_completed events for a given phase.
+
+    Returns a dict with 'tokens_in' and 'tokens_out' keys, values may be None.
+    """
+    for event in events:
+        if event.phase == phase_name and event.kind == "phase_completed":
+            tokens_in = event.data.get("tokens_in")
+            tokens_out = event.data.get("tokens_out")
+            if tokens_in is not None or tokens_out is not None:
+                return {"tokens_in": tokens_in, "tokens_out": tokens_out}
+    return {"tokens_in": None, "tokens_out": None}
+
+
 class SessionSchemaAdapter:
     name: str = "session-schema"
     description: str = "Directory-based session format with structured phases"
@@ -51,6 +76,14 @@ class SessionSchemaAdapter:
         meta_raw: dict[str, Any] = json.loads(_read_bounded(meta_path))
         session_id = str(meta_raw.get("ticket", source.name))
         phases_dict = meta_raw.get("phases") or {}
+
+        events = self._load_events(source)
+
+        # Extract model_id: prefer meta.json, fall back to events
+        model_id = meta_raw.get("model_id")
+        if not model_id:
+            model_id = _extract_model_id_from_events(events)
+
         meta = SessionMeta(
             session_id=session_id,
             ticket=str(meta_raw.get("ticket")),
@@ -58,20 +91,29 @@ class SessionSchemaAdapter:
             total_cost_usd=meta_raw.get("total_cost"),
             total_phases=len(phases_dict),
             rework_cycles=meta_raw.get("rework_cycles", 0),
+            model_id=model_id,
         )
-        phases = self._load_phases(source, meta_raw)
+        phases = self._load_phases(source, meta_raw, events)
         findings = self._load_findings(source)
-        events = self._load_events(source)
         return EvalSample(session=meta, phases=phases, findings=findings, events=events)
 
-    def _load_phases(self, source: Path, meta_raw: dict[str, Any]) -> list[PhaseResult]:
+    def _load_phases(
+        self,
+        source: Path,
+        meta_raw: dict[str, Any],
+        events: list[SessionEvent],
+    ) -> list[PhaseResult]:
         phases: list[PhaseResult] = []
         for phase_name in PHASE_NAMES:
-            phases.extend(self._load_phase_files(source, phase_name, meta_raw))
+            phases.extend(self._load_phase_files(source, phase_name, meta_raw, events))
         return phases
 
     def _load_phase_files(
-        self, source: Path, phase_name: str, meta_raw: dict[str, Any]
+        self,
+        source: Path,
+        phase_name: str,
+        meta_raw: dict[str, Any],
+        events: list[SessionEvent],
     ) -> list[PhaseResult]:
         results: list[PhaseResult] = []
         pattern = re.compile(rf"^{re.escape(phase_name)}\.json(\.\d+)?$")
@@ -79,15 +121,41 @@ class SessionSchemaAdapter:
             [file_path for file_path in source.iterdir() if pattern.match(file_path.name)],
             key=lambda file_path: file_path.name,
         )
+
+        # Collect suffixed generation numbers to compute base file generation
+        suffixed_generations: list[int] = []
+        for file_path in matched_files:
+            suffix_match = re.search(r"\.(\d+)$", file_path.name)
+            if suffix_match:
+                suffixed_generations.append(int(suffix_match.group(1)))
+
+        phases_dict = meta_raw.get("phases") or {}
+        phase_meta = phases_dict.get(phase_name) or {}
+
+        # Extract token counts from events as fallback
+        event_tokens = _extract_token_counts_from_events(events, phase_name)
+
+        # Determine tokens_in/tokens_out: prefer phase metadata, fall back to events
+        meta_tokens_in = phase_meta.get("tokens_in")
+        tokens_in = meta_tokens_in if meta_tokens_in is not None else event_tokens["tokens_in"]
+        meta_tokens_out = phase_meta.get("tokens_out")
+        tokens_out = meta_tokens_out if meta_tokens_out is not None else event_tokens["tokens_out"]
+
         for file_path in matched_files:
             _validate_path(file_path, source)
             suffix_match = re.search(r"\.(\d+)$", file_path.name)
-            phases_dict = meta_raw.get("phases") or {}
-            phase_meta = phases_dict.get(phase_name) or {}
             if suffix_match:
                 generation = int(suffix_match.group(1))
             else:
-                generation = phase_meta.get("generation", 1)
+                # Base file = latest generation
+                # Use meta generation if available; otherwise max(suffixed) + 1 or 1
+                meta_generation = phase_meta.get("generation")
+                if meta_generation is not None:
+                    generation = meta_generation
+                elif suffixed_generations:
+                    generation = max(suffixed_generations) + 1
+                else:
+                    generation = 1
             try:
                 raw = json.loads(_read_bounded(file_path))
             except json.JSONDecodeError:
@@ -100,6 +168,8 @@ class SessionSchemaAdapter:
                     status=phase_meta.get("status", "completed"),
                     cost_usd=phase_meta.get("cost"),
                     duration_ms=phase_meta.get("duration_ms"),
+                    tokens_in=tokens_in,
+                    tokens_out=tokens_out,
                     output=output_text,
                     output_structured=redact_dict(raw),
                 )

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -586,3 +586,546 @@ def test_redact_multiline_jwt_across_content_blocks():
     result = redact_sensitive(text)
     assert "eyJhbGciOiJIUzI1NiJ9" not in result
     assert "***REDACTED***" in result
+
+
+# --- Task 10: adapter data completeness tests ---
+
+
+def test_session_schema_extracts_model_id_from_meta(tmp_path):
+    """model_id in meta.json should be populated on SessionMeta."""
+    meta = {
+        "ticket": "200",
+        "summary": "model id test",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+        "model_id": "claude-sonnet-4-20250514",
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    assert sample.session.model_id == "claude-sonnet-4-20250514"
+
+
+def test_session_schema_extracts_model_id_from_events(tmp_path):
+    """model_id should be extracted from events.jsonl when not in meta.json."""
+    meta = {
+        "ticket": "201",
+        "summary": "model from events",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    events = [
+        {
+            "timestamp": "2026-04-10T08:00:00Z",
+            "phase": "implement",
+            "kind": "phase_started",
+            "data": {"generation": 1, "model": "claude-opus-4-20250514"},
+        },
+        {
+            "timestamp": "2026-04-10T08:05:00Z",
+            "phase": "implement",
+            "kind": "phase_completed",
+            "data": {"cost": 3.5},
+        },
+    ]
+    (tmp_path / "events.jsonl").write_text("\n".join(json.dumps(event) for event in events))
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    assert sample.session.model_id == "claude-opus-4-20250514"
+
+
+def test_session_schema_meta_model_id_takes_precedence(tmp_path):
+    """model_id from meta.json should take precedence over events.jsonl."""
+    meta = {
+        "ticket": "202",
+        "summary": "precedence test",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+        "model_id": "claude-sonnet-4-20250514",
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    events = [
+        {
+            "timestamp": "2026-04-10T08:00:00Z",
+            "phase": "implement",
+            "kind": "phase_started",
+            "data": {"generation": 1, "model": "claude-opus-4-20250514"},
+        },
+    ]
+    (tmp_path / "events.jsonl").write_text(json.dumps(events[0]))
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    assert sample.session.model_id == "claude-sonnet-4-20250514"
+
+
+def test_session_schema_extracts_tokens_from_phase_meta(tmp_path):
+    """tokens_in/tokens_out from phase metadata should populate PhaseResult."""
+    meta = {
+        "ticket": "210",
+        "summary": "tokens test",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {
+            "implement": {
+                "status": "completed",
+                "cost": 3.5,
+                "generation": 1,
+                "tokens_in": 15000,
+                "tokens_out": 8000,
+            }
+        },
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    implement_data = {"summary": "implemented feature"}
+    (tmp_path / "implement.json").write_text(json.dumps(implement_data))
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    impl_phases = [phase for phase in sample.phases if phase.name == "implement"]
+    assert len(impl_phases) == 1
+    assert impl_phases[0].tokens_in == 15000
+    assert impl_phases[0].tokens_out == 8000
+
+
+def test_session_schema_extracts_tokens_from_events(tmp_path):
+    """tokens_in/tokens_out should be extracted from phase_completed events."""
+    meta = {
+        "ticket": "211",
+        "summary": "tokens from events",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {
+            "implement": {"status": "completed", "cost": 3.5, "generation": 1},
+        },
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    events = [
+        {
+            "timestamp": "2026-04-10T08:00:00Z",
+            "phase": "implement",
+            "kind": "phase_started",
+            "data": {"generation": 1},
+        },
+        {
+            "timestamp": "2026-04-10T08:05:00Z",
+            "phase": "implement",
+            "kind": "phase_completed",
+            "data": {"cost": 3.5, "tokens_in": 12000, "tokens_out": 6000},
+        },
+    ]
+    (tmp_path / "events.jsonl").write_text("\n".join(json.dumps(event) for event in events))
+    implement_data = {"summary": "implemented feature"}
+    (tmp_path / "implement.json").write_text(json.dumps(implement_data))
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    impl_phases = [phase for phase in sample.phases if phase.name == "implement"]
+    assert len(impl_phases) == 1
+    assert impl_phases[0].tokens_in == 12000
+    assert impl_phases[0].tokens_out == 6000
+
+
+def test_session_schema_phase_meta_tokens_take_precedence(tmp_path):
+    """Phase metadata tokens should take precedence over event tokens."""
+    meta = {
+        "ticket": "212",
+        "summary": "token precedence",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {
+            "implement": {
+                "status": "completed",
+                "cost": 3.5,
+                "generation": 1,
+                "tokens_in": 15000,
+                "tokens_out": 8000,
+            },
+        },
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    events = [
+        {
+            "timestamp": "2026-04-10T08:00:00Z",
+            "phase": "implement",
+            "kind": "phase_started",
+            "data": {"generation": 1},
+        },
+        {
+            "timestamp": "2026-04-10T08:05:00Z",
+            "phase": "implement",
+            "kind": "phase_completed",
+            "data": {"cost": 3.5, "tokens_in": 12000, "tokens_out": 6000},
+        },
+    ]
+    (tmp_path / "events.jsonl").write_text("\n".join(json.dumps(event) for event in events))
+    implement_data = {"summary": "implemented feature"}
+    (tmp_path / "implement.json").write_text(json.dumps(implement_data))
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    impl_phases = [phase for phase in sample.phases if phase.name == "implement"]
+    assert len(impl_phases) == 1
+    assert impl_phases[0].tokens_in == 15000
+    assert impl_phases[0].tokens_out == 8000
+
+
+# --- Recursive DatasetLoader tests ---
+
+
+def test_dataset_loader_recursive_finds_nested_sessions(tmp_path):
+    """DatasetLoader in recursive mode should find sessions in subdirectories."""
+    # Create nested structure: root/project-a/session-1/
+    project_dir = tmp_path / "project-a"
+    project_dir.mkdir()
+    session_dir = project_dir / "session-1"
+    session_dir.mkdir()
+    meta = {
+        "ticket": "300",
+        "summary": "nested session",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (session_dir / "meta.json").write_text(json.dumps(meta))
+    (session_dir / "events.jsonl").write_text("")
+
+    registry = AdapterRegistry()
+    registry.register(SessionSchemaAdapter())
+    loader = DatasetLoader(registry)
+    dataset = loader.load_directory(tmp_path, recursive=True)
+    assert len(dataset.samples) == 1
+    assert dataset.samples[0].session.session_id == "300"
+
+
+def test_dataset_loader_non_recursive_skips_nested_sessions(tmp_path):
+    """DatasetLoader in non-recursive (default) mode should not descend into subdirs."""
+    project_dir = tmp_path / "project-a"
+    project_dir.mkdir()
+    session_dir = project_dir / "session-1"
+    session_dir.mkdir()
+    meta = {
+        "ticket": "301",
+        "summary": "nested session",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (session_dir / "meta.json").write_text(json.dumps(meta))
+    (session_dir / "events.jsonl").write_text("")
+
+    registry = AdapterRegistry()
+    registry.register(SessionSchemaAdapter())
+    loader = DatasetLoader(registry)
+    # Default: non-recursive
+    dataset = loader.load_directory(tmp_path)
+    assert len(dataset.samples) == 0
+
+
+def test_dataset_loader_recursive_finds_both_levels(tmp_path):
+    """Recursive mode should find sessions at root and nested levels."""
+    # Direct child session
+    direct_session = tmp_path / "session-direct"
+    direct_session.mkdir()
+    meta_direct = {
+        "ticket": "310",
+        "summary": "direct session",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (direct_session / "meta.json").write_text(json.dumps(meta_direct))
+    (direct_session / "events.jsonl").write_text("")
+
+    # Nested session
+    nested_dir = tmp_path / "project-a"
+    nested_dir.mkdir()
+    nested_session = nested_dir / "session-nested"
+    nested_session.mkdir()
+    meta_nested = {
+        "ticket": "311",
+        "summary": "nested session",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (nested_session / "meta.json").write_text(json.dumps(meta_nested))
+    (nested_session / "events.jsonl").write_text("")
+
+    registry = AdapterRegistry()
+    registry.register(SessionSchemaAdapter())
+    loader = DatasetLoader(registry)
+    dataset = loader.load_directory(tmp_path, recursive=True)
+    session_ids = {sample.session.session_id for sample in dataset.samples}
+    assert session_ids == {"310", "311"}
+
+
+def test_dataset_loader_recursive_deeply_nested(tmp_path):
+    """Recursive mode should find sessions multiple levels deep."""
+    deep_dir = tmp_path / "a" / "b" / "c"
+    deep_dir.mkdir(parents=True)
+    session_dir = deep_dir / "deep-session"
+    session_dir.mkdir()
+    meta = {
+        "ticket": "320",
+        "summary": "deep session",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (session_dir / "meta.json").write_text(json.dumps(meta))
+    (session_dir / "events.jsonl").write_text("")
+
+    registry = AdapterRegistry()
+    registry.register(SessionSchemaAdapter())
+    loader = DatasetLoader(registry)
+    dataset = loader.load_directory(tmp_path, recursive=True)
+    assert len(dataset.samples) == 1
+    assert dataset.samples[0].session.session_id == "320"
+
+
+# --- Generational file sorting tests ---
+
+
+def test_generational_sorting_base_file_is_latest(tmp_path):
+    """Base file (implement.json) should be assigned highest generation (latest)."""
+    meta = {
+        "ticket": "400",
+        "summary": "generational sorting",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 10.0,
+        "rework_cycles": 2,
+        "phases": {
+            "implement": {"status": "completed", "cost": 3.5, "generation": 3},
+        },
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    # .1 = generation 1, .2 = generation 2, base = latest (generation 3 from meta)
+    (tmp_path / "implement.json.1").write_text(json.dumps({"gen": "first"}))
+    (tmp_path / "implement.json.2").write_text(json.dumps({"gen": "second"}))
+    (tmp_path / "implement.json").write_text(json.dumps({"gen": "latest"}))
+
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    impl_phases = [phase for phase in sample.phases if phase.name == "implement"]
+    assert len(impl_phases) == 3
+
+    # Sort by generation for predictable assertions
+    impl_phases.sort(key=lambda phase: phase.generation)
+    assert impl_phases[0].generation == 1
+    assert impl_phases[1].generation == 2
+    assert impl_phases[2].generation == 3
+
+
+def test_generational_sorting_single_base_file_gen_1(tmp_path):
+    """A single base file with no suffixed files should be generation 1."""
+    meta = {
+        "ticket": "401",
+        "summary": "single base file",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {
+            "implement": {"status": "completed", "cost": 3.5, "generation": 1},
+        },
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    (tmp_path / "implement.json").write_text(json.dumps({"gen": "only"}))
+
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    impl_phases = [phase for phase in sample.phases if phase.name == "implement"]
+    assert len(impl_phases) == 1
+    assert impl_phases[0].generation == 1
+
+
+def test_generational_sorting_base_file_gen_from_meta(tmp_path):
+    """Base file generation should use the meta.json phases generation value."""
+    meta = {
+        "ticket": "402",
+        "summary": "gen from meta",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 1,
+        "phases": {
+            "implement": {"status": "completed", "cost": 3.5, "generation": 4},
+        },
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    (tmp_path / "implement.json.1").write_text(json.dumps({"gen": "first"}))
+    (tmp_path / "implement.json").write_text(json.dumps({"gen": "latest"}))
+
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    impl_phases = sorted(
+        [phase for phase in sample.phases if phase.name == "implement"],
+        key=lambda phase: phase.generation,
+    )
+    assert len(impl_phases) == 2
+    assert impl_phases[0].generation == 1
+    assert impl_phases[1].generation == 4
+
+
+def test_generational_sorting_no_meta_generation_defaults(tmp_path):
+    """Without meta generation, base file with suffixed files gets max(suffixed) + 1."""
+    meta = {
+        "ticket": "403",
+        "summary": "no meta generation",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 1,
+        "phases": {
+            "implement": {"status": "completed", "cost": 3.5},
+        },
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    (tmp_path / "implement.json.1").write_text(json.dumps({"gen": "first"}))
+    (tmp_path / "implement.json.2").write_text(json.dumps({"gen": "second"}))
+    (tmp_path / "implement.json").write_text(json.dumps({"gen": "latest"}))
+
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    impl_phases = sorted(
+        [phase for phase in sample.phases if phase.name == "implement"],
+        key=lambda phase: phase.generation,
+    )
+    assert len(impl_phases) == 3
+    assert impl_phases[0].generation == 1
+    assert impl_phases[1].generation == 2
+    # Base file should be latest: max(1, 2) + 1 = 3
+    assert impl_phases[2].generation == 3
+
+
+# --- Zero-token and missing-data edge-case tests (issue #37) ---
+
+
+def test_session_schema_zero_tokens_in_meta_wins_over_event(tmp_path):
+    """Phase metadata tokens_in=0 must win over event tokens_in=100 (not treated as falsy)."""
+    meta = {
+        "ticket": "500",
+        "summary": "zero token edge case",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {
+            "implement": {
+                "status": "completed",
+                "cost": 2.0,
+                "generation": 1,
+                "tokens_in": 0,
+                "tokens_out": 0,
+            },
+        },
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    events = [
+        {
+            "timestamp": "2026-04-10T08:00:00Z",
+            "phase": "implement",
+            "kind": "phase_started",
+            "data": {"generation": 1},
+        },
+        {
+            "timestamp": "2026-04-10T08:05:00Z",
+            "phase": "implement",
+            "kind": "phase_completed",
+            "data": {"cost": 2.0, "tokens_in": 100, "tokens_out": 200},
+        },
+    ]
+    (tmp_path / "events.jsonl").write_text("\n".join(json.dumps(e) for e in events))
+    (tmp_path / "implement.json").write_text(json.dumps({"summary": "impl"}))
+
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    impl_phases = [p for p in sample.phases if p.name == "implement"]
+    assert len(impl_phases) == 1
+    # The metadata value (0) must be used, NOT the event value (100/200)
+    assert impl_phases[0].tokens_in == 0
+    assert impl_phases[0].tokens_out == 0
+
+
+def test_session_schema_no_model_id_from_either_source(tmp_path):
+    """When neither meta.json nor events provide a model_id, it should be None."""
+    meta = {
+        "ticket": "501",
+        "summary": "no model id anywhere",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 3.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    events = [
+        {
+            "timestamp": "2026-04-10T08:00:00Z",
+            "phase": "triage",
+            "kind": "phase_started",
+            "data": {"generation": 1},
+        },
+        {
+            "timestamp": "2026-04-10T08:01:00Z",
+            "phase": "triage",
+            "kind": "phase_completed",
+            "data": {"cost": 1.0},
+        },
+    ]
+    (tmp_path / "events.jsonl").write_text("\n".join(json.dumps(e) for e in events))
+
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    assert sample.session.model_id is None
+
+
+def test_session_schema_no_token_counts_from_either_source(tmp_path):
+    """When neither phase meta nor events provide token counts, they should be None."""
+    meta = {
+        "ticket": "502",
+        "summary": "no tokens anywhere",
+        "started_at": "2026-04-10T08:00:00Z",
+        "total_cost": 4.0,
+        "rework_cycles": 0,
+        "phases": {
+            "implement": {"status": "completed", "cost": 2.0, "generation": 1},
+        },
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    events = [
+        {
+            "timestamp": "2026-04-10T08:00:00Z",
+            "phase": "implement",
+            "kind": "phase_started",
+            "data": {"generation": 1},
+        },
+        {
+            "timestamp": "2026-04-10T08:05:00Z",
+            "phase": "implement",
+            "kind": "phase_completed",
+            "data": {"cost": 2.0},
+        },
+    ]
+    (tmp_path / "events.jsonl").write_text("\n".join(json.dumps(e) for e in events))
+    (tmp_path / "implement.json").write_text(json.dumps({"summary": "impl"}))
+
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    impl_phases = [p for p in sample.phases if p.name == "implement"]
+    assert len(impl_phases) == 1
+    assert impl_phases[0].tokens_in is None
+    assert impl_phases[0].tokens_out is None


### PR DESCRIPTION
## Summary
- Extract `model_id` from meta.json (primary) or events.jsonl (fallback) in session-schema adapter
- Extract `tokens_in`/`tokens_out` from phase metadata or events with correct `is not None` fallback (avoids treating `0` as falsy)
- Add optional `recursive=True` mode to `DatasetLoader.load_directory()` for nested directory structures, with symlink rejection
- Fix generational file sorting: base file is latest generation, suffixed files (.1, .2) keep their literal number
- 17 new tests including zero-token edge case, missing-data paths, recursive loading, and generational sorting

Refs #37

## Review
- Python Specialist: clean after 1 fix iteration (CRITICAL falsy-value bug in token fallback fixed)
- Security Specialist: clean (3 MINOR observations)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko