### PR TITLE
docs(examples): add 3 annotated manifest files

### DIFF
--- a/examples/raki-alcove.yaml
+++ b/examples/raki-alcove.yaml
@@ -1,0 +1,8 @@
+# RAKI manifest for Alcove-format sessions.
+# Alcove sessions are single JSON files containing the full transcript
+# with tool calls, token usage, and cost data — as opposed to the
+# session-schema format which uses a directory of separate phase files.
+
+sessions:
+  path: sessions/          # Directory containing alcove-session.json files
+  format: alcove            # Explicitly select the Alcove adapter (skip auto-detection)

--- a/examples/raki-full.yaml
+++ b/examples/raki-full.yaml
@@ -1,0 +1,24 @@
+# Full RAKI manifest — all available options with explanations.
+# Paths are resolved relative to this file's directory.
+
+sessions:
+  path: sessions/          # Directory containing session transcript folders
+  format: auto             # Format detection: "auto", "session-schema", or "alcove"
+  filter:
+    min_phases: 2          # Skip sessions with fewer than this many phases
+
+ground_truth:
+  path: ground-truth/curated.yaml  # Curated question-answer pairs for retrieval evaluation
+
+sources:                   # Reference documents used during retrieval
+  - path: sessions/        # Path to source documents (reusing sessions dir as example)
+    repo: web-api          # Repository or project name for provenance tracking
+    domains:               # Knowledge domains this source covers
+      - api
+      - auth
+
+synthetic:
+  enabled: false           # Whether to generate synthetic test cases via Ragas
+  output: synthetic-out/   # Directory for generated synthetic test data
+  count: 50                # Number of synthetic test cases to generate
+  seed: 42                 # Random seed for reproducible generation

--- a/examples/raki-minimal.yaml
+++ b/examples/raki-minimal.yaml
@@ -1,0 +1,5 @@
+# Minimal RAKI manifest — only the required field.
+# Paths are resolved relative to this file's directory.
+
+sessions:
+  path: sessions/  # Directory containing session transcript folders

--- a/tests/test_example_manifests.py
+++ b/tests/test_example_manifests.py
@@ -1,0 +1,52 @@
+"""Tests that verify example manifest files load correctly."""
+
+from pathlib import Path
+
+import pytest
+
+from raki.ground_truth.manifest import EvalManifest, load_manifest
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+
+MANIFEST_FILES = [
+    "raki-minimal.yaml",
+    "raki-full.yaml",
+    "raki-alcove.yaml",
+]
+
+
+@pytest.fixture(scope="module", params=MANIFEST_FILES)
+def loaded_manifest(request: pytest.FixtureRequest) -> tuple[str, EvalManifest]:
+    """Load each example manifest once per module, returning (filename, manifest)."""
+    manifest_name: str = request.param
+    manifest_path = EXAMPLES_DIR / manifest_name
+    manifest = load_manifest(manifest_path, project_root=EXAMPLES_DIR)
+    return manifest_name, manifest
+
+
+def test_example_manifest_parses(loaded_manifest: tuple[str, EvalManifest]) -> None:
+    """Each example manifest must parse without errors."""
+    manifest_name, manifest = loaded_manifest
+    assert isinstance(manifest, EvalManifest), f"{manifest_name} did not produce an EvalManifest"
+
+
+def test_example_manifest_has_sessions_path(loaded_manifest: tuple[str, EvalManifest]) -> None:
+    """Each example manifest must have a resolved sessions path."""
+    manifest_name, manifest = loaded_manifest
+    assert manifest.sessions.path is not None, f"{manifest_name} missing sessions.path"
+    assert manifest.sessions.path.exists(), f"{manifest_name} sessions.path does not exist"
+
+
+def test_full_manifest_has_ground_truth_path() -> None:
+    """raki-full.yaml must have ground_truth.path set."""
+    manifest = load_manifest(EXAMPLES_DIR / "raki-full.yaml", project_root=EXAMPLES_DIR)
+    assert manifest.ground_truth.path is not None, "raki-full.yaml missing ground_truth.path"
+    assert manifest.ground_truth.path.exists(), "raki-full.yaml ground_truth.path does not exist"
+
+
+def test_alcove_manifest_has_alcove_format() -> None:
+    """raki-alcove.yaml must have format set to 'alcove'."""
+    manifest = load_manifest(EXAMPLES_DIR / "raki-alcove.yaml", project_root=EXAMPLES_DIR)
+    assert manifest.sessions.format == "alcove", (
+        f"Expected format 'alcove', got '{manifest.sessions.format}'"
+    )


### PR DESCRIPTION
## Summary
- Create 3 annotated YAML manifest examples: minimal, full-featured, and Alcove-specific
- Each field has inline YAML comments explaining its purpose
- Full manifest references the curated ground truth from #50

Refs #51

## Review
- Python Specialist: clean (3 MINOR — duplicate loading in 2 tests, synthetic.output docs, format enum docs)
- Security Specialist: not applicable
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko