### PR TITLE
docs: project housekeeping — README, CONTRIBUTING, CHANGELOG, index, schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## [Unreleased] (v0.4.0) — Security & Data Completeness
+- Security hardening: symlinks, encoding, redaction, size limits
+- Adapter completeness: model_id, tokens, recursive loading, generational sorting
+
+## [Unreleased] (v0.3.0) — Report & CLI Polish
+- Comprehensive HTML report UX improvements (colors, sessions count, display names)
+- CLI fixes: descriptions, display names, threshold test, quiet validate
+- Sample-level results in reports
+- NoneType fix for SODA metrics
+
+## v0.2.1
+- Ragas temperature forwarding and Vertex AI embedding fixes
+- Except syntax fix for Python 3.14
+- Ragas SingleTurnSample compatibility fix
+- JSON stdout output fix
+
+## v0.1.0
+- Core Pydantic models (EvalSample, SessionMeta, PhaseResult, etc.)
+- Adapter protocol with session-schema and Alcove adapters
+- Operational metrics (verify rate, rework cycles, severity, cost, knowledge miss rate)
+- Ragas integration (context precision/recall, faithfulness, answer relevancy)
+- Ground truth loader and domain-based matcher
+- Manifest loader with path traversal protection
+- CLI with run, validate, and adapters commands
+- HTML report generation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to RAKI
+
+Thanks for your interest in RAKI! This guide covers the workflow for contributing changes.
+
+## Getting Started
+
+1. Fork the repository and clone your fork.
+2. Set up your development environment:
+
+```bash
+uv sync --python 3.14 --all-extras
+```
+
+## Branch Naming
+
+Create a branch from `main` using the pattern:
+
+```
+task/<issue-number>-<short-name>
+```
+
+For example: `task/42-fix-verify-rate`
+
+## Making Changes
+
+RAKI follows test-driven development. Write a failing test first, then implement.
+
+### Running Tests
+
+```bash
+uv run pytest tests/ -v
+```
+
+### Code Style
+
+Lint and format with ruff (line-length 100):
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format src/ tests/
+```
+
+### Type Checking
+
+```bash
+uv run ty check src/raki/
+```
+
+## Pull Request Process
+
+1. Ensure all tests pass and linting is clean before opening a PR.
+2. Write a clear PR description explaining **what** changed and **why**.
+3. Reference the related issue (e.g., "Closes #42").
+4. Keep changes small and focused — one concern per PR.
+
+## Conventions
+
+- **Models**: Pydantic 2 with `Field(default_factory=...)` for mutable defaults.
+- **Security**: all adapters must call `redact_sensitive()` before populating `EvalSample`.
+- **YAML**: use `yaml.safe_load` only, never `yaml.load`.
+- **Variable names**: no single-character variables, even in loops.
+- **Metrics**: operational and retrieval metrics are never blended into a single score.
+
+## Commit Format
+
+```
+<type>(<scope>): <subject>
+```
+
+Include a body explaining *why* the change was made, not just what changed.
+
+## Questions?
+
+Open an issue or start a discussion — we are happy to help.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,37 @@
 # RAKI — Retrieval Assessment for Knowledge Impact
 
-Evaluate agentic RAG quality from session transcripts.
+A CLI tool that evaluates agentic RAG quality from session transcripts.
 
 ## Report Preview
 
 ![RAKI HTML Report](docs/images/report-screenshot.png)
 
-## Install
+## Features
+
+- **Operational metrics** — verify rate, rework cycles, severity distribution, cost analysis (no LLM required)
+- **Ragas retrieval metrics** — context precision/recall, faithfulness, answer relevancy
+- **HTML reports** — interactive reports with session-level detail and color-coded thresholds
+- **Pluggable adapters** — bring any session format; built-in support for session-schema and Alcove
+- **Ground truth matching** — curated YAML entries matched by domain for retrieval evaluation
+
+## Quick Start
 
 ```bash
-uv sync --python 3.14 --all-extras
+uv pip install raki --extra html
+uv run raki validate --manifest raki.yaml
+uv run raki run --manifest raki.yaml --no-llm
 ```
+
+The `--no-llm` flag runs operational metrics only (no API keys needed).
+To include Ragas retrieval metrics, omit the flag and configure an LLM provider.
 
 ## Usage
 
 ```bash
-# Run operational metrics (no LLM calls)
+# Run all metrics (requires LLM provider)
+uv run raki run --manifest raki.yaml
+
+# Run operational metrics only
 uv run raki run --manifest raki.yaml --no-llm
 
 # Validate manifest and session data
@@ -25,19 +41,26 @@ uv run raki validate --manifest raki.yaml
 uv run raki adapters
 ```
 
+## Documentation
+
+- [Getting Started](docs/getting-started.md) — install, run, and understand your first report
+- [Interpretation Reference](docs/interpretation-reference.md) — what each metric means and when to act
+- [Ground Truth Curation Guide](docs/curation-guide.md) — write effective ground truth entries
+- [Adapter Guide](docs/adapter-guide.md) — integrate custom session formats
+- [Session Schema Reference](docs/session-schema.md) — field definitions for session-schema format
+
 ## Development
 
 ```bash
-# Install with dev deps
 uv sync --python 3.14 --all-extras
-
-# Run tests
-uv run pytest
-
-# Lint and format
-uv run ruff check .
-uv run ruff format .
-
-# Type check
+uv run pytest tests/ -v
+uv run ruff check src/ tests/
+uv run ruff format src/ tests/
 uv run ty check src/raki/
 ```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution workflow.
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE) for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# RAKI Documentation
+
+Welcome to the RAKI documentation. These guides cover everything from first install to writing custom adapters.
+
+## Guides
+
+- [Getting Started](getting-started.md) — install RAKI, run your first evaluation, and understand the output
+- [Interpretation Reference](interpretation-reference.md) — what each metric measures, threshold guidance, and common patterns
+- [Ground Truth Curation Guide](curation-guide.md) — how to write effective ground truth entries for retrieval evaluation
+- [Adapter Guide](adapter-guide.md) — integrate a custom session format with the adapter protocol
+- [Session Schema Reference](session-schema.md) — field definitions for meta.json, phase files, review.json, and events.jsonl

--- a/docs/session-schema.md
+++ b/docs/session-schema.md
@@ -1,0 +1,120 @@
+# Session Schema Reference
+
+The session-schema format represents an agentic session as a directory containing structured JSON files. Each session directory must contain `meta.json` and `events.jsonl`; phase files are optional.
+
+## meta.json
+
+Top-level session metadata.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ticket` | string | Yes | Ticket or issue identifier for the session |
+| `summary` | string | No | Brief description of the ticket |
+| `branch` | string | No | Git branch associated with the work |
+| `started_at` | ISO 8601 datetime | Yes | When the session began |
+| `total_cost` | float | No | Total cost in USD across all phases |
+| `rework_cycles` | integer | No | Number of rework iterations (default 0) |
+| `model_id` | string | No | LLM model used for the session |
+| `phases` | object | No | Per-phase metadata (see below) |
+
+### phases (nested in meta.json)
+
+Each key in `phases` is a phase name (e.g., `triage`, `implement`). Values are objects with:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | string | No | Phase outcome: `completed`, `failed`, or `skipped` |
+| `cost` | float | No | Phase cost in USD |
+| `duration_ms` | integer | No | Phase duration in milliseconds |
+| `tokens_in` | integer | No | Input tokens consumed |
+| `tokens_out` | integer | No | Output tokens generated |
+| `generation` | integer | No | Generation number for the base phase file |
+
+## triage.json
+
+Output from the triage phase, assessing ticket complexity.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ticket_key` | string | Yes | Ticket identifier |
+| `complexity` | string | No | Estimated complexity (e.g., `low`, `medium`, `high`) |
+| `approach` | string | No | Planned implementation approach |
+| `automatable` | boolean | No | Whether the task can be fully automated |
+
+## plan.json
+
+Output from the planning phase. Like `triage.json`, this is a freeform JSON object capturing the implementation plan.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ticket_key` | string | Yes | Ticket identifier |
+| `approach` | string | No | Planned implementation approach |
+| `steps` | array of strings | No | Planned implementation steps |
+| `estimated_complexity` | string | No | Estimated complexity (e.g., `low`, `medium`, `high`) |
+
+## implement.json
+
+Output from the implementation phase. Suffixed files (e.g., `implement.json.1`, `implement.json.2`) represent earlier generations in rework cycles; the unsuffixed file is the latest generation.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ticket_key` | string | Yes | Ticket identifier |
+| `commits` | array of strings | No | Commit hashes produced |
+| `files_changed` | array of strings | No | Files modified during implementation |
+| `tests_passed` | boolean | No | Whether tests passed after implementation |
+
+## verify.json
+
+Output from the verification phase.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ticket_key` | string | Yes | Ticket identifier |
+| `verdict` | string | No | Verification result (e.g., `pass`, `fail`) |
+| `command_results` | array of objects | No | Results from verification commands |
+| `criteria_results` | array of objects | No | Results per acceptance criterion |
+
+## review.json
+
+Output from the review phase. Suffixed files (e.g., `review.json.1`) represent earlier review generations.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ticket_key` | string | Yes | Ticket identifier |
+| `verdict` | string | No | Review outcome (e.g., `approved`, `changes_requested`) |
+| `findings` | array of objects | No | List of review findings (see below) |
+
+### findings (nested in review.json)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `source` | string | No | Reviewer identifier (defaults to `unknown`) |
+| `severity` | string | Yes | Finding severity: `critical`, `major`, or `minor` |
+| `file` | string | No | File path related to the finding |
+| `line` | integer | No | Line number related to the finding |
+| `issue` | string | Yes | Description of the issue found |
+| `suggestion` | string | No | Suggested fix or improvement |
+
+## events.jsonl
+
+Newline-delimited JSON log of session events. Each line is a JSON object.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `timestamp` | ISO 8601 datetime | Yes | When the event occurred |
+| `phase` | string | No | Phase the event belongs to (null for session-level events) |
+| `kind` | string (Literal) | Yes | Event type (see values below) |
+| `data` | object | No | Event-specific payload (default `{}`) |
+
+### kind values
+
+| Value | Description |
+|---|---|
+| `phase_started` | A phase has begun execution |
+| `phase_completed` | A phase finished successfully |
+| `phase_failed` | A phase finished with an error |
+| `review_merged` | Multiple reviewer outputs were merged |
+| `review_rework_routed` | Review findings routed back for rework |
+| `rework_feedback_injected` | Rework feedback was injected into the next iteration |
+| `reviewer_started` | A reviewer agent started its review |
+| `reviewer_completed` | A reviewer agent completed its review |


### PR DESCRIPTION
## Summary
- Rewrite README.md with feature list, quick start, screenshot, and doc links (66 lines)
- Add CONTRIBUTING.md with fork/branch/test/PR workflow
- Add CHANGELOG.md covering v0.1.0 through unreleased v0.4.0
- Create docs/index.md linking all user-facing guides
- Create docs/session-schema.md with field tables for all JSON files (meta, triage, plan, implement, verify, review, events)

Refs #57

## Review
- Python Specialist: 1 high (CHANGELOG ordering) + 1 medium (missing plan.json) fixed
- Security Specialist: not applicable
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko