### PR TITLE
feat(cli): add raki report command to re-render from JSON

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,6 +70,20 @@ Key metrics to watch:
 - **Rework cycles** (0.2) -- sessions needed an average of 0.2 review-rework iterations. Lower is better; values above 1.0 mean most sessions require at least one rework round.
 - **Severity score** (0.39) -- weighted severity of review findings, where 1.0 means no findings at all. Higher is better; low values indicate reviewers are catching serious issues.
 
+## Re-rendering Reports
+
+RAKI saves evaluation results as JSON. You can re-render the CLI summary or generate an HTML report from a saved JSON file at any time:
+
+```bash
+# Re-render CLI summary from a saved report
+uv run raki report --input results/raki-report-20260410T120000.json
+
+# Generate an HTML report from the same JSON
+uv run raki report --input results/raki-report-20260410T120000.json --html results/report.html
+```
+
+If the JSON report was generated without `--include-sessions`, RAKI will show aggregate scores only and warn that per-session drill-down is unavailable.
+
 ## Next Steps
 
 - [Results Interpretation Reference](interpretation-reference.md) -- thresholds, patterns, and what to do about low scores

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -1,11 +1,44 @@
 """Click CLI entry points for RAKI — run, validate, adapters."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from rich.console import Console
 
 from raki.adapters.redact import redact_sensitive
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from raki.model import EvalDataset
+    from raki.model.report import EvalReport, MetricResult
+    from raki.metrics.protocol import MetricConfig
+
+
+@dataclass(frozen=True)
+class _MetricStub:
+    """Lightweight stand-in for ``Metric`` when re-rendering from JSON reports.
+
+    Satisfies the full ``Metric`` protocol so that ``print_summary`` can accept
+    these stubs without type errors.
+    """
+
+    name: str
+    display_name: str
+    description: str
+    display_format: str
+    higher_is_better: bool
+    requires_ground_truth: bool = False
+    requires_llm: bool = False
+
+    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:  # noqa: ARG002
+        """Stub — metric stubs are display-only and never compute scores."""
+        raise NotImplementedError("_MetricStub is display-only and cannot compute scores")
+
 
 console = Console()
 
@@ -321,6 +354,120 @@ def adapters() -> None:
             f"  [bold]{adapter.name}[/bold]  {adapter.description}  "
             f"[dim](detects: {adapter.detection_hint})[/dim]"
         )
+
+
+def _is_session_data_stripped(report: EvalReport) -> bool:
+    """Check whether session data in sample_results has been stripped.
+
+    Returns True if any phase output is the ``<stripped>`` sentinel, indicating
+    the report was generated without ``--include-sessions``.
+    """
+    for sample_result in report.sample_results:
+        for phase in sample_result.sample.phases:
+            if phase.output == "<stripped>":
+                return True
+    return False
+
+
+def _metric_stubs_from_metadata(
+    aggregate_scores: dict[str, float],
+) -> Sequence[_MetricStub]:
+    """Build lightweight metric-like objects from METRIC_METADATA for print_summary.
+
+    When re-rendering from JSON, we don't have the original Metric instances.
+    This function creates simple objects that satisfy the display_name,
+    description, display_format, and higher_is_better attributes that
+    ``_MetricMeta`` in ``cli_summary`` looks up.
+    """
+    from raki.report.html_report import METRIC_METADATA
+
+    stubs: list[_MetricStub] = []
+    for metric_name in aggregate_scores:
+        meta = METRIC_METADATA.get(
+            metric_name,
+            {
+                "display_name": metric_name,
+                "description": "",
+                "display_format": "score",
+                "higher_is_better": True,
+            },
+        )
+        stubs.append(
+            _MetricStub(
+                name=metric_name,
+                display_name=str(meta["display_name"]),
+                description=str(meta["description"]),
+                display_format=str(meta["display_format"]),
+                higher_is_better=bool(meta["higher_is_better"]),
+            )
+        )
+    return stubs
+
+
+@main.command()
+@click.option(
+    "-i",
+    "--input",
+    "input_path",
+    required=True,
+    help="Path to JSON report (required)",
+)
+@click.option(
+    "--html",
+    "html_path",
+    default=None,
+    help="Output HTML file path",
+)
+def report(input_path: str, html_path: str | None) -> None:
+    """Re-render CLI summary and HTML from a saved JSON report."""
+    from raki.report.json_report import load_json_report
+
+    path = Path(input_path)
+    if not path.exists():
+        console.print(f"[red]Error: input file not found: {path}[/red]")
+        raise SystemExit(2)
+
+    try:
+        eval_report = load_json_report(path)
+    except Exception as exc:
+        console.print(f"[red]Error loading report: {redact_sensitive(str(exc))}[/red]")
+        raise SystemExit(2) from exc
+
+    session_count = len(eval_report.sample_results)
+    stripped = _is_session_data_stripped(eval_report)
+
+    if stripped:
+        console.print(
+            "[yellow]Warning: Per-session drill-down unavailable — "
+            "original report was generated without --include-sessions[/yellow]"
+        )
+
+    from raki.report.cli_summary import print_summary
+
+    metric_stubs = _metric_stubs_from_metadata(eval_report.aggregate_scores)
+    print_summary(
+        eval_report,
+        session_count=session_count,
+        console=console,
+        metrics=metric_stubs,
+    )
+
+    if html_path is not None:
+        try:
+            from raki.report.html_report import write_html_report
+
+            write_html_report(
+                eval_report,
+                Path(html_path),
+                include_sessions=not stripped,
+                session_count=session_count,
+            )
+            console.print(f"\nHTML report written: {html_path}")
+        except ImportError:
+            console.print(
+                "[yellow]Note: jinja2 not installed — skipping HTML report. "
+                "Install with: uv pip install raki[html][/yellow]"
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 """Tests for CLI commands: raki run, raki validate, raki adapters, raki report."""
 
+import importlib.util
 import json
 
+import pytest
 from click.testing import CliRunner
 
 from raki.cli import main
@@ -579,6 +581,10 @@ class TestCliReport:
         assert result.exit_code == 0
         assert "0.85" in result.output
 
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("jinja2"),
+        reason="jinja2 not installed",
+    )
     def test_report_generates_html(self, tmp_path):
         """raki report --input --html generates an HTML file."""
         report_json = tmp_path / "report.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
-"""Tests for CLI commands: raki run, raki validate, raki adapters."""
+"""Tests for CLI commands: raki run, raki validate, raki adapters, raki report."""
+
+import json
 
 from click.testing import CliRunner
 
@@ -465,3 +467,181 @@ class TestCliSummaryMetricDescription:
         assert result.exit_code == 0
         # Metric descriptions should appear in parentheses
         assert "% sessions passing verify" in result.output
+
+
+def _write_report_json(path, *, include_sessions: bool = False) -> None:
+    """Write a minimal EvalReport JSON file for testing the report command."""
+    from raki.model.report import EvalReport
+
+    report = EvalReport(
+        run_id="test-report-001",
+        aggregate_scores={
+            "first_pass_verify_rate": 0.85,
+            "rework_cycles": 0.3,
+            "cost_efficiency": 7.50,
+        },
+    )
+    data = report.model_dump(mode="json")
+    if include_sessions:
+        # Add a sample_result with non-stripped session data to simulate --include-sessions
+        data["sample_results"] = [
+            {
+                "sample": {
+                    "session": {
+                        "session_id": "session-101",
+                        "started_at": "2026-04-10T00:00:00Z",
+                        "total_phases": 3,
+                        "rework_cycles": 0,
+                        "total_cost_usd": 7.50,
+                    },
+                    "phases": [
+                        {
+                            "name": "implement",
+                            "generation": 1,
+                            "status": "completed",
+                            "output": "full implementation output here",
+                        },
+                        {
+                            "name": "verify",
+                            "generation": 1,
+                            "status": "completed",
+                            "output": "PASS",
+                        },
+                    ],
+                    "findings": [],
+                    "events": [],
+                },
+                "scores": [
+                    {"name": "first_pass_verify_rate", "score": 1.0},
+                ],
+            }
+        ]
+    else:
+        # Simulate a stripped report (the default output of raki run)
+        data["sample_results"] = [
+            {
+                "sample": {
+                    "session": {
+                        "session_id": "session-101",
+                        "started_at": "2026-04-10T00:00:00Z",
+                        "total_phases": 3,
+                        "rework_cycles": 0,
+                        "total_cost_usd": 7.50,
+                    },
+                    "phases": [
+                        {
+                            "name": "implement",
+                            "generation": 1,
+                            "status": "completed",
+                            "output": "<stripped>",
+                        },
+                        {
+                            "name": "verify",
+                            "generation": 1,
+                            "status": "completed",
+                            "output": "<stripped>",
+                        },
+                    ],
+                    "findings": [],
+                    "events": [],
+                },
+                "scores": [
+                    {"name": "first_pass_verify_rate", "score": 1.0},
+                ],
+            }
+        ]
+    path.write_text(json.dumps(data, indent=2, default=str))
+
+
+class TestCliReport:
+    def test_report_command_shows_in_help(self):
+        """The report command should appear in --help output."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "report" in result.output
+
+    def test_report_renders_cli_summary(self, tmp_path):
+        """raki report --input renders CLI summary to terminal."""
+        report_json = tmp_path / "report.json"
+        _write_report_json(report_json, include_sessions=True)
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        assert result.exit_code == 0
+        assert "Operational Health" in result.output
+
+    def test_report_shows_aggregate_scores(self, tmp_path):
+        """raki report should display aggregate metric scores."""
+        report_json = tmp_path / "report.json"
+        _write_report_json(report_json, include_sessions=True)
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        assert result.exit_code == 0
+        assert "0.85" in result.output
+
+    def test_report_generates_html(self, tmp_path):
+        """raki report --input --html generates an HTML file."""
+        report_json = tmp_path / "report.json"
+        _write_report_json(report_json, include_sessions=True)
+        html_path = tmp_path / "output.html"
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["report", "--input", str(report_json), "--html", str(html_path)]
+        )
+        assert result.exit_code == 0
+        assert html_path.exists()
+        content = html_path.read_text()
+        assert "<html" in content.lower()
+
+    def test_report_warns_when_session_data_stripped(self, tmp_path):
+        """Warning shown when session data is stripped (default reports)."""
+        report_json = tmp_path / "report.json"
+        _write_report_json(report_json, include_sessions=False)
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        assert result.exit_code == 0
+        assert "--include-sessions" in result.output
+
+    def test_report_no_warning_when_session_data_present(self, tmp_path):
+        """No warning shown when session data is present."""
+        report_json = tmp_path / "report.json"
+        _write_report_json(report_json, include_sessions=True)
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        assert result.exit_code == 0
+        assert "--include-sessions" not in result.output
+
+    def test_report_exit_code_2_for_missing_input(self, tmp_path):
+        """Exit code 2 when input file does not exist."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--input", str(tmp_path / "nonexistent.json")])
+        assert result.exit_code == 2
+
+    def test_report_short_input_flag(self, tmp_path):
+        """raki report -i works as shorthand for --input."""
+        report_json = tmp_path / "report.json"
+        _write_report_json(report_json, include_sessions=True)
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "-i", str(report_json)])
+        assert result.exit_code == 0
+        assert "Operational Health" in result.output
+
+    def test_report_html_default_alongside_json(self, tmp_path):
+        """When --html is not given, no HTML file is generated."""
+        report_json = tmp_path / "report.json"
+        _write_report_json(report_json, include_sessions=True)
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        assert result.exit_code == 0
+        html_files = list(tmp_path.glob("*.html"))
+        assert len(html_files) == 0
+
+    def test_report_displays_metric_display_names(self, tmp_path):
+        """raki report should show human-readable display names from metadata."""
+        report_json = tmp_path / "report.json"
+        _write_report_json(report_json, include_sessions=True)
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        assert result.exit_code == 0
+        # Should use display names from METRIC_METADATA, not raw metric keys
+        assert "Verify rate" in result.output


### PR DESCRIPTION
## Summary
- Add `raki report --input report.json` command that re-renders CLI summary and HTML report from saved JSON evaluation results
- Gracefully warns when session data was stripped (generated without `--include-sessions`)
- Exit code 2 for missing input file
- Updated getting-started.md with re-render usage examples

Refs #69

## Review
- Python Specialist: 3 findings fixed (type annotations, protocol conformance)
- Security Specialist: not applicable (no adapter/security-sensitive changes)
- RAG Specialist: not applicable (no Ragas/metric changes)

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko