### PR TITLE
feat(report): redesign HTML score cards with subtitles, badges, and severity bar

### DIFF
--- a/docs/interpreting-results.md
+++ b/docs/interpreting-results.md
@@ -1,0 +1,98 @@
+# Interpreting Results
+
+How to read the RAKI HTML report and understand what the metrics mean.
+
+For the full metric reference with zone tables and red-zone actions, see
+[interpretation-reference.md](interpretation-reference.md).
+
+## Operational Health
+
+### Verify Rate
+
+**What it measures:** The fraction of sessions where the agent's work passed
+all verification checks on the first attempt.
+
+- **Target:** >85%
+- **Direction:** Higher is better
+- A high verify rate means the agent consistently delivers correct work
+  without needing rework.
+
+### Rework Cycles
+
+**What it measures:** The average number of review-fix iterations per session.
+
+- **Good:** <1.0
+- **Direction:** Lower is better
+- **Color thresholds:** Green (<1.0), Yellow (1.0--2.0), Red (>2.0)
+
+### Cost per Session
+
+**What it measures:** The average LLM API cost per session in USD.
+
+- The score card shows the average cost and, when per-session data is
+  available, the min--max range across all sessions.
+
+### Review Findings
+
+**What it measures:** The number and severity of issues found by reviewers
+across all evaluated sessions.
+
+#### Severity Distribution
+
+Instead of a single numeric score, the report shows a **stacked distribution
+bar** with counts for each severity level (critical, major, minor) and a
+traffic-light label:
+
+| Label | Condition |
+|-------|-----------|
+| **Clean** | 0 critical + 0 major findings |
+| **Minor** | 0 critical, but some major findings |
+| **Moderate** | Some critical findings, but weighted severity <= 0.5 |
+| **Severe** | Weighted severity > 0.5 |
+
+The **weighted severity** formula is:
+
+    weighted = (3 * critical + 2 * major + 1 * minor) / (3 * total)
+
+This weights critical findings three times more than minor ones. A "Severe"
+label means a disproportionate number of findings are critical or major.
+
+### Knowledge Miss Rate
+
+**What it measures:** How often rework happened because the agent lacked the
+right reference material in its retrieved context.
+
+- **Target:** <0.20
+- **Direction:** Lower is better
+- This metric is **hidden** when no sessions have `knowledge_context` data.
+  A footnote explains: "Knowledge Miss Rate omitted -- no retrieval context
+  available in sessions."
+
+## Retrieval Quality
+
+These metrics require LLM-backed evaluation (they are hidden in `--no-llm`
+mode, with a footnote explaining why).
+
+### Context Precision
+
+**What it measures:** How much of what the retriever pulled in was actually
+relevant to the question.
+
+- **Target:** >0.80
+- **Direction:** Higher is better
+
+### Context Recall
+
+**What it measures:** How much of the needed information the retriever
+successfully found.
+
+- **Target:** >0.80
+- **Direction:** Higher is better
+
+### Faithfulness
+
+**What it measures:** How closely the agent's output sticks to the facts in
+its source material.
+
+- **Direction:** Higher is better
+- This metric is **experimental** for agentic sessions.

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -1,5 +1,6 @@
 """Rich CLI summary output — color-coded metrics grouped by category."""
 
+from collections import Counter
 from collections.abc import Sequence
 
 from rich.console import Console
@@ -95,6 +96,62 @@ def format_metric_line(
     count_str = f" (n={sample_count})" if sample_count is not None else ""
     detail_str = f"  ({detail})" if detail else ""
     return f"[{color}]  {label:<35} {score_str}{count_str}{detail_str}[/{color}]"
+
+
+def generate_summary_sentence(report: EvalReport, session_count: int) -> str:
+    """Generate a plain-English summary sentence from aggregate scores.
+
+    The summary highlights key numbers: verify rate, rework cycles, finding counts,
+    and average cost. Missing metrics are gracefully omitted.
+    """
+    parts: list[str] = []
+    scores = report.aggregate_scores
+
+    verify_rate = scores.get("first_pass_verify_rate")
+    if verify_rate is not None:
+        pct = f"{verify_rate * 100:.0f}%"
+        parts.append(f"{pct} of sessions passed on first try")
+
+    rework = scores.get("rework_cycles")
+    if rework is not None:
+        parts.append(f"with an average of {rework:.1f} rework cycles")
+
+    # Count findings from sample_results
+    severity_counter: Counter[str] = Counter()
+    for sample_result in report.sample_results:
+        for finding in sample_result.sample.findings:
+            severity_counter[finding.severity] += 1
+
+    if severity_counter:
+        finding_parts: list[str] = []
+        for severity_level in ("critical", "major", "minor"):
+            count = severity_counter.get(severity_level, 0)
+            if count > 0:
+                finding_parts.append(f"{count} {severity_level}")
+        if finding_parts:
+            finding_text = ", ".join(finding_parts)
+            parts.append(f"Reviewers found {finding_text} issues across all sessions")
+
+    cost = scores.get("cost_efficiency")
+    if cost is not None:
+        parts.append(f"Average cost: ${cost:.2f}/session")
+
+    if not parts:
+        return f"Evaluation completed across {session_count} sessions."
+
+    # Join the first two parts with comma, rest with period
+    sentence_parts: list[str] = []
+    if len(parts) >= 2 and "passed on first try" in parts[0]:
+        sentence_parts.append(f"{parts[0]}, {parts[1]}")
+        remaining = parts[2:]
+    else:
+        sentence_parts.append(parts[0])
+        remaining = parts[1:]
+
+    for part in remaining:
+        sentence_parts.append(part)
+
+    return ". ".join(sentence_parts) + "."
 
 
 def print_summary(

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -366,7 +366,7 @@ def compute_worst_sessions(report: EvalReport, limit: int = 5) -> list[WorstSess
 
 def _build_jinja_env():  # type: ignore[no-any-return]
     """Create a Jinja2 environment loading templates from the package."""
-    from jinja2 import Environment, PackageLoader
+    from jinja2 import Environment, PackageLoader  # ty: ignore[unresolved-import]
 
     return Environment(
         loader=PackageLoader("raki.report", "templates"),

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -6,7 +6,11 @@ from pathlib import Path
 from typing import Literal
 
 from raki.model.report import EvalReport
-from raki.report.cli_summary import EXPERIMENTAL_METRICS, OPERATIONAL_METRICS
+from raki.report.cli_summary import (
+    EXPERIMENTAL_METRICS,
+    OPERATIONAL_METRICS,
+    generate_summary_sentence,
+)
 
 # Metric metadata registry — maps raw metric names to display properties.
 # This mirrors the class-level attributes from each Metric implementation
@@ -18,56 +22,97 @@ METRIC_METADATA: dict[str, dict[str, str | bool]] = {
         "higher_is_better": True,
         "display_format": "percent",
         "description": "% sessions passing verify on first try",
+        "subtitle": "How often the agent's work passes all checks on the first try",
+        "direction": "higher is better",
+        "threshold": "Target: >85%",
+        "docs_anchor": "verify-rate",
     },
     "rework_cycles": {
         "display_name": "Rework cycles",
         "higher_is_better": False,
         "display_format": "count",
         "description": "Average review-fix iterations per session",
+        "subtitle": "How many times the agent had to redo its work after feedback",
+        "direction": "lower is better",
+        "threshold": "Good: <1.0",
+        "docs_anchor": "rework-cycles",
     },
     "review_severity_distribution": {
         "display_name": "Severity score",
         "higher_is_better": True,
         "display_format": "score",
         "description": "Weighted severity of review findings (1.0 = no findings)",
+        "subtitle": "How many issues reviewers found, broken down by severity",
+        "direction": "",
+        "threshold": "",
+        "docs_anchor": "review-findings",
     },
     "cost_efficiency": {
         "display_name": "Cost / session",
         "higher_is_better": False,
         "display_format": "currency",
         "description": "Average LLM cost per session in USD",
+        "subtitle": "How much each agent task costs in API fees",
+        "direction": "",
+        "threshold": "",
+        "docs_anchor": "cost-per-session",
     },
     "knowledge_retrieval_miss_rate": {
         "display_name": "Knowledge miss rate",
         "higher_is_better": False,
         "display_format": "score",
         "description": "Fraction of rework caused by missing retrieval context",
+        "subtitle": (
+            "How often rework happened because the agent lacked the right reference material"
+        ),
+        "direction": "lower is better",
+        "threshold": "Target: <0.20",
+        "docs_anchor": "knowledge-miss-rate",
     },
     "faithfulness": {
         "display_name": "Faithfulness",
         "higher_is_better": True,
         "display_format": "score",
         "description": "Fraction of claims supported by retrieved context",
+        "subtitle": ("How closely the agent's output sticks to the facts in its source material"),
+        "direction": "higher is better",
+        "threshold": "",
+        "docs_anchor": "faithfulness",
     },
     "answer_relevancy": {
         "display_name": "Answer relevancy",
         "higher_is_better": True,
         "display_format": "score",
         "description": "How relevant the response is to the user query",
+        "subtitle": "How relevant the response is to the user query",
+        "direction": "higher is better",
+        "threshold": "",
+        "docs_anchor": "answer-relevancy",
     },
     "context_precision": {
         "display_name": "Context precision",
         "higher_is_better": True,
         "display_format": "score",
         "description": "Precision of retrieved context relative to ground truth",
+        "subtitle": "How much of what the retriever pulled in was actually relevant",
+        "direction": "higher is better",
+        "threshold": "Target: >0.80",
+        "docs_anchor": "context-precision",
     },
     "context_recall": {
         "display_name": "Context recall",
         "higher_is_better": True,
         "display_format": "score",
         "description": "Recall of retrieved context relative to ground truth",
+        "subtitle": ("How much of the needed information the retriever successfully found"),
+        "direction": "higher is better",
+        "threshold": "Target: >0.80",
+        "docs_anchor": "context-recall",
     },
 }
+
+# GitHub base URL for metric documentation links
+DOCS_BASE_URL = "https://github.com/decko/raki/blob/main/docs/interpreting-results.md"
 
 
 def _get_metric_meta(name: str) -> dict[str, str | bool]:
@@ -79,6 +124,10 @@ def _get_metric_meta(name: str) -> dict[str, str | bool]:
             "higher_is_better": True,
             "display_format": "score",
             "description": "",
+            "subtitle": "",
+            "direction": "",
+            "threshold": "",
+            "docs_anchor": "",
         },
     )
 
@@ -139,6 +188,112 @@ def _split_scores(
         name: score for name, score in aggregate_scores.items() if name not in OPERATIONAL_METRICS
     }
     return operational, retrieval
+
+
+@dataclass(frozen=True)
+class SeverityDistribution:
+    """Counts and traffic-light label for review finding severity across all sessions."""
+
+    critical: int
+    major: int
+    minor: int
+    label: Literal["Clean", "Minor", "Moderate", "Severe"]
+    total: int
+
+    @property
+    def critical_pct(self) -> float:
+        """Percentage of critical findings."""
+        return (self.critical / self.total * 100) if self.total > 0 else 0.0
+
+    @property
+    def major_pct(self) -> float:
+        """Percentage of major findings."""
+        return (self.major / self.total * 100) if self.total > 0 else 0.0
+
+    @property
+    def minor_pct(self) -> float:
+        """Percentage of minor findings."""
+        return (self.minor / self.total * 100) if self.total > 0 else 0.0
+
+
+def compute_severity_distribution(report: EvalReport) -> SeverityDistribution:
+    """Compute severity distribution from all findings across all sessions.
+
+    Label logic:
+    - 0 critical + 0 major = "Clean"
+    - 0 critical + some major = "Minor"
+    - weighted > 0.5 = "Severe"
+    - else = "Moderate"
+
+    Weighted score = (3 * critical + 2 * major + 1 * minor) / (3 * total).
+    """
+    severity_counter: Counter[str] = Counter()
+    for sample_result in report.sample_results:
+        for finding in sample_result.sample.findings:
+            severity_counter[finding.severity] += 1
+
+    critical_count = severity_counter.get("critical", 0)
+    major_count = severity_counter.get("major", 0)
+    minor_count = severity_counter.get("minor", 0)
+    total_count = critical_count + major_count + minor_count
+
+    if critical_count == 0 and major_count == 0:
+        label: Literal["Clean", "Minor", "Moderate", "Severe"] = "Clean"
+    elif critical_count == 0:
+        label = "Minor"
+    else:
+        weighted = (3 * critical_count + 2 * major_count + minor_count) / (3 * total_count)
+        if weighted > 0.5:
+            label = "Severe"
+        else:
+            label = "Moderate"
+
+    return SeverityDistribution(
+        critical=critical_count,
+        major=major_count,
+        minor=minor_count,
+        label=label,
+        total=total_count,
+    )
+
+
+def has_knowledge_context(report: EvalReport) -> bool:
+    """Check if any session phase has knowledge_context set.
+
+    Returns True if at least one phase in any sample has a non-None knowledge_context.
+    """
+    for sample_result in report.sample_results:
+        for phase in sample_result.sample.phases:
+            if phase.knowledge_context is not None:
+                return True
+    return False
+
+
+def compute_cost_range(report: EvalReport) -> tuple[float, float] | None:
+    """Compute min and max cost from sample session costs.
+
+    Returns None if no sample results have cost data.
+    """
+    costs: list[float] = []
+    for sample_result in report.sample_results:
+        cost = sample_result.sample.session.total_cost_usd
+        if cost is not None:
+            costs.append(cost)
+    if not costs:
+        return None
+    return (min(costs), max(costs))
+
+
+def rework_cycles_color(value: float) -> str:
+    """Return CSS color class for rework cycles based on threshold.
+
+    Green: <1.0, Yellow: 1.0-2.0, Red: >2.0.
+    """
+    if value < 1.0:
+        return "green"
+    if value <= 2.0:
+        return "yellow"
+    return "red"
 
 
 def _collect_recurring_failures(report: EvalReport) -> list[RecurringFailure]:
@@ -211,7 +366,7 @@ def compute_worst_sessions(report: EvalReport, limit: int = 5) -> list[WorstSess
 
 def _build_jinja_env():  # type: ignore[no-any-return]
     """Create a Jinja2 environment loading templates from the package."""
-    from jinja2 import Environment, PackageLoader  # ty: ignore[unresolved-import]
+    from jinja2 import Environment, PackageLoader
 
     return Environment(
         loader=PackageLoader("raki.report", "templates"),
@@ -224,6 +379,7 @@ def write_html_report(
     output: Path,
     include_sessions: bool = False,
     session_count: int | None = None,
+    has_retrieval: bool = True,
 ) -> None:
     """Render and write a self-contained HTML report.
 
@@ -235,11 +391,19 @@ def write_html_report(
 
     session_count is passed as a separate template variable so the header shows
     the correct count even when sample_results is empty.
+
+    has_retrieval controls whether the Retrieval Quality section is shown.
+    When False (--no-llm mode), a footnote is shown instead.
     """
     from raki.report.json_report import strip_session_data
 
     output = output.resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
+
+    # Compute knowledge context and severity distribution BEFORE stripping
+    show_knowledge_miss = has_knowledge_context(report)
+    severity_dist = compute_severity_distribution(report)
+    cost_range = compute_cost_range(report)
 
     if not include_sessions:
         # Strip session data from a serialized copy, then reload as a clean report
@@ -251,6 +415,7 @@ def write_html_report(
         session_count if session_count is not None else len(report.sample_results)
     )
 
+    summary_sentence = generate_summary_sentence(report, resolved_session_count)
     operational_scores, retrieval_scores = _split_scores(report.aggregate_scores)
     recurring_failures = _collect_recurring_failures(report)
     worst_sessions = compute_worst_sessions(report, limit=5)
@@ -259,12 +424,17 @@ def write_html_report(
     template = env.get_template("report.html.j2")
 
     def color_class_fn(score: float, metric_name: str = "") -> str:
+        # Special handling for rework_cycles using threshold-based coloring
+        if metric_name == "rework_cycles":
+            return f"color-{rework_cycles_color(score)}"
         meta = _get_metric_meta(metric_name)
         higher = bool(meta["higher_is_better"])
         fmt = str(meta["display_format"])
         return f"color-{html_color_for_score(score, higher, fmt)}"
 
     def color_name_fn(score: float, metric_name: str = "") -> str:
+        if metric_name == "rework_cycles":
+            return rework_cycles_color(score)
         meta = _get_metric_meta(metric_name)
         higher = bool(meta["higher_is_better"])
         fmt = str(meta["display_format"])
@@ -282,6 +452,12 @@ def write_html_report(
         get_metric_meta=_get_metric_meta,
         color_class=color_class_fn,
         color_name=color_name_fn,
+        summary_sentence=summary_sentence,
+        severity_dist=severity_dist,
+        show_knowledge_miss=show_knowledge_miss,
+        cost_range=cost_range,
+        has_retrieval=has_retrieval,
+        docs_base_url=DOCS_BASE_URL,
     )
 
     output.write_text(html_content, encoding="utf-8")

--- a/src/raki/report/templates/report.html.j2
+++ b/src/raki/report/templates/report.html.j2
@@ -74,6 +74,22 @@
     color: var(--text-primary);
   }
 
+  /* Summary sentence */
+  .summary-sentence {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
+    font-size: 1rem;
+    color: var(--text-primary);
+    line-height: 1.6;
+  }
+
+  .summary-sentence strong {
+    color: var(--accent);
+  }
+
   /* Score cards */
   .score-grid {
     display: grid;
@@ -91,12 +107,39 @@
     flex-direction: column;
   }
 
+  .score-card.hero-card {
+    grid-column: span 2;
+    padding: 1.5rem 1.5rem;
+  }
+
+  .score-card.hero-card .metric-value {
+    font-size: 2.8rem;
+  }
+
   .score-card .metric-name {
     font-size: 0.85rem;
     color: var(--text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .score-card .metric-name a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--text-muted);
+  }
+
+  .score-card .metric-name a:hover {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+
+  .score-card .metric-subtitle {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-bottom: 0.5rem;
+    line-height: 1.4;
   }
 
   .score-card .metric-description {
@@ -132,6 +175,35 @@
     margin-top: 0.4rem;
   }
 
+  .score-card .metric-footer {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .direction-badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    text-transform: lowercase;
+  }
+
+  .threshold-label {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+
+  .cost-range {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-top: 0.3rem;
+  }
+
   /* Color classes */
   .color-green { color: var(--green); }
   .color-yellow { color: var(--yellow); }
@@ -154,6 +226,101 @@
     color: var(--accent);
     margin-bottom: 0.75rem;
   }
+
+  /* Severity distribution card */
+  .severity-distribution {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1rem;
+  }
+
+  .severity-distribution .metric-name {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.25rem;
+  }
+
+  .severity-distribution .metric-name a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--text-muted);
+  }
+
+  .severity-distribution .metric-name a:hover {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+
+  .severity-distribution .metric-subtitle {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-bottom: 0.5rem;
+  }
+
+  .severity-bar {
+    display: flex;
+    height: 24px;
+    border-radius: 4px;
+    overflow: hidden;
+    margin: 0.5rem 0;
+    background: var(--bg-tertiary);
+  }
+
+  .severity-bar-segment {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #fff;
+    min-width: 0;
+    transition: width 0.3s ease;
+  }
+
+  .severity-bar-critical { background: var(--severity-critical); }
+  .severity-bar-major { background: var(--severity-major); }
+  .severity-bar-minor { background: var(--severity-minor); }
+
+  .severity-legend {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 0.5rem;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    flex-wrap: wrap;
+  }
+
+  .severity-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  .severity-legend-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+
+  .severity-label-badge {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    margin-left: auto;
+  }
+
+  .severity-label-clean { background: rgba(76, 175, 80, 0.2); color: var(--green); }
+  .severity-label-minor { background: rgba(139, 195, 58, 0.2); color: var(--severity-minor); }
+  .severity-label-moderate { background: rgba(255, 152, 0, 0.2); color: var(--severity-major); }
+  .severity-label-severe { background: rgba(244, 67, 54, 0.2); color: var(--severity-critical); }
 
   /* Recurring failures table */
   .failures-table {
@@ -395,6 +562,15 @@
     color: var(--text-primary);
   }
 
+  /* Footnotes */
+  .footnote {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    font-style: italic;
+    padding: 0.5rem 0;
+    margin-top: 0.5rem;
+  }
+
   /* Footer */
   footer {
     margin-top: 3rem;
@@ -425,6 +601,11 @@
   </header>
 
   <main>
+  {# --- Summary Sentence --- #}
+  {% if summary_sentence %}
+  <div class="summary-sentence">{{ summary_sentence }}</div>
+  {% endif %}
+
   {# --- Aggregate Scores --- #}
   <section>
     <h2>Aggregate Scores</h2>
@@ -435,39 +616,111 @@
       <div class="score-grid">
         {% for name, score in operational_scores.items() %}
         {% set meta = get_metric_meta(name) %}
-        <div class="score-card">
-          <div class="metric-name">{{ meta.display_name }}</div>
-          {% if meta.description %}<div class="metric-description">{{ meta.description }}</div>{% endif %}
+        {# Skip knowledge_retrieval_miss_rate when no knowledge context #}
+        {% if name == "knowledge_retrieval_miss_rate" and not show_knowledge_miss %}
+        {% elif name == "review_severity_distribution" %}
+        {# Severity distribution is rendered separately below #}
+        {% else %}
+        <div class="score-card{% if name == 'first_pass_verify_rate' %} hero-card{% endif %}">
+          <div class="metric-name">
+            {% if meta.docs_anchor %}<a href="{{ docs_base_url }}#{{ meta.docs_anchor }}">{{ meta.display_name }}</a>{% else %}{{ meta.display_name }}{% endif %}
+          </div>
+          {% if meta.subtitle %}<div class="metric-subtitle">{{ meta.subtitle }}</div>{% endif %}
           <div class="metric-value {{ color_class(score, name) }}">{% if meta.display_format == "currency" %}${{ "%.2f"|format(score) }}{% elif meta.display_format == "count" %}{{ "%.1f"|format(score) }}{% elif meta.display_format == "percent" %}{{ "%.0f"|format(score * 100) }}%{% else %}{{ "%.2f"|format(score) }}{% endif %}</div>
+          {% if name == "cost_efficiency" and cost_range %}
+          <div class="cost-range">Range: ${{ "%.2f"|format(cost_range[0]) }} &ndash; ${{ "%.2f"|format(cost_range[1]) }}</div>
+          {% endif %}
           {% if meta.display_format not in ("currency", "count") and score <= 1.0 and score >= 0.0 %}
           <div class="metric-bar">
             <div class="metric-bar-fill bg-{{ color_name(score, name) }}" style="width: {{ (score * 100)|int }}%"></div>
           </div>
           {% endif %}
+          <div class="metric-footer">
+            {% if meta.direction %}<span class="direction-badge">{{ meta.direction }}</span>{% endif %}
+            {% if meta.threshold %}<span class="threshold-label">{{ meta.threshold }}</span>{% endif %}
+          </div>
         </div>
+        {% endif %}
         {% endfor %}
       </div>
+
+      {# --- Severity Distribution Bar --- #}
+      {% if severity_dist %}
+      <div class="severity-distribution">
+        <div class="metric-name">
+          <a href="{{ docs_base_url }}#review-findings">Review Findings</a>
+        </div>
+        <div class="metric-subtitle">How many issues reviewers found, broken down by severity</div>
+        {% if severity_dist.total > 0 %}
+        <div class="severity-bar">
+          {% if severity_dist.critical > 0 %}
+          <div class="severity-bar-segment severity-bar-critical" style="width: {{ severity_dist.critical_pct }}%">{{ severity_dist.critical }}</div>
+          {% endif %}
+          {% if severity_dist.major > 0 %}
+          <div class="severity-bar-segment severity-bar-major" style="width: {{ severity_dist.major_pct }}%">{{ severity_dist.major }}</div>
+          {% endif %}
+          {% if severity_dist.minor > 0 %}
+          <div class="severity-bar-segment severity-bar-minor" style="width: {{ severity_dist.minor_pct }}%">{{ severity_dist.minor }}</div>
+          {% endif %}
+        </div>
+        <div class="severity-legend">
+          {% if severity_dist.critical > 0 %}
+          <span class="severity-legend-item"><span class="severity-legend-dot" style="background: var(--severity-critical);"></span> {{ severity_dist.critical }} critical</span>
+          {% endif %}
+          {% if severity_dist.major > 0 %}
+          <span class="severity-legend-item"><span class="severity-legend-dot" style="background: var(--severity-major);"></span> {{ severity_dist.major }} major</span>
+          {% endif %}
+          {% if severity_dist.minor > 0 %}
+          <span class="severity-legend-item"><span class="severity-legend-dot" style="background: var(--severity-minor);"></span> {{ severity_dist.minor }} minor</span>
+          {% endif %}
+          <span class="severity-label-badge severity-label-{{ severity_dist.label|lower }}">{{ severity_dist.label }}</span>
+        </div>
+        {% else %}
+        <div class="severity-legend">
+          <span class="severity-label-badge severity-label-clean">Clean</span>
+          <span style="color: var(--text-muted); font-size: 0.85rem;">No review findings</span>
+        </div>
+        {% endif %}
+      </div>
+      {% endif %}
+
+      {# Knowledge Miss Rate omitted footnote #}
+      {% if not show_knowledge_miss and "knowledge_retrieval_miss_rate" in operational_scores %}
+      <p class="footnote knowledge_miss_footnote">Knowledge Miss Rate omitted &mdash; no retrieval context available in sessions.</p>
+      {% endif %}
     </div>
     {% endif %}
 
-    {% if retrieval_scores %}
+    {% if has_retrieval and retrieval_scores %}
     <div class="category-section">
       <div class="category-label">Retrieval Quality</div>
       <div class="score-grid">
         {% for name, score in retrieval_scores.items() %}
         {% set meta = get_metric_meta(name) %}
         <div class="score-card">
-          <div class="metric-name">{{ meta.display_name }}{% if name in experimental_metrics %} <span class="metric-tag">[experimental]</span>{% endif %}</div>
-          {% if meta.description %}<div class="metric-description">{{ meta.description }}</div>{% endif %}
+          <div class="metric-name">
+            {% if meta.docs_anchor %}<a href="{{ docs_base_url }}#{{ meta.docs_anchor }}">{{ meta.display_name }}</a>{% else %}{{ meta.display_name }}{% endif %}
+            {% if name in experimental_metrics %} <span class="metric-tag">[experimental]</span>{% endif %}
+          </div>
+          {% if meta.subtitle %}<div class="metric-subtitle">{{ meta.subtitle }}</div>{% endif %}
           <div class="metric-value {{ color_class(score, name) }}">{{ "%.2f"|format(score) }}</div>
           {% if score <= 1.0 and score >= 0.0 %}
           <div class="metric-bar">
             <div class="metric-bar-fill bg-{{ color_name(score, name) }}" style="width: {{ (score * 100)|int }}%"></div>
           </div>
           {% endif %}
+          <div class="metric-footer">
+            {% if meta.direction %}<span class="direction-badge">{{ meta.direction }}</span>{% endif %}
+            {% if meta.threshold %}<span class="threshold-label">{{ meta.threshold }}</span>{% endif %}
+          </div>
         </div>
         {% endfor %}
       </div>
+    </div>
+    {% elif not has_retrieval %}
+    <div class="category-section">
+      <div class="category-label">Retrieval Quality</div>
+      <p class="empty-state">Retrieval metrics omitted &mdash; run without --no-llm to enable LLM-backed evaluation.</p>
     </div>
     {% else %}
     <div class="category-section">

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -3,11 +3,18 @@
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 import pytest
 
+from raki.model.phases import ReviewFinding
 from raki.model.report import EvalReport, MetricResult, SampleResult
-from raki.report.cli_summary import color_for_score, format_metric_line, print_summary
+from raki.report.cli_summary import (
+    color_for_score,
+    format_metric_line,
+    generate_summary_sentence,
+    print_summary,
+)
 from raki.report.json_report import load_json_report, write_json_report
 
 from conftest import make_sample
@@ -408,3 +415,110 @@ class TestPrintSummary:
         print_summary(report, session_count=10, console=test_console)
         output = string_io.getvalue()
         assert "same-provider" not in output.lower()
+
+
+# --- generate_summary_sentence tests ---
+
+
+def _make_finding(severity: Literal["critical", "major", "minor"]) -> ReviewFinding:
+    """Helper to create a ReviewFinding with a given severity."""
+    return ReviewFinding(
+        reviewer="test-reviewer",
+        severity=severity,
+        issue=f"Test {severity} issue",
+    )
+
+
+class TestGenerateSummarySentence:
+    def test_includes_verify_rate_percentage(self) -> None:
+        """Summary sentence should include verify rate as a percentage."""
+        report = EvalReport(
+            run_id="summary-test",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.91,
+                "rework_cycles": 0.4,
+                "cost_efficiency": 7.42,
+            },
+        )
+        sentence = generate_summary_sentence(report, session_count=20)
+        assert "91%" in sentence
+
+    def test_includes_rework_cycles(self) -> None:
+        """Summary sentence should include average rework cycles."""
+        report = EvalReport(
+            run_id="summary-test",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.91,
+                "rework_cycles": 0.4,
+                "cost_efficiency": 7.42,
+            },
+        )
+        sentence = generate_summary_sentence(report, session_count=20)
+        assert "0.4" in sentence
+
+    def test_includes_cost(self) -> None:
+        """Summary sentence should include average cost per session."""
+        report = EvalReport(
+            run_id="summary-test",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.91,
+                "rework_cycles": 0.4,
+                "cost_efficiency": 7.42,
+            },
+        )
+        sentence = generate_summary_sentence(report, session_count=20)
+        assert "$7.42" in sentence
+
+    def test_includes_finding_counts_from_samples(self) -> None:
+        """Summary sentence should include severity breakdown when samples exist."""
+        findings_a = [
+            _make_finding("critical"),
+            _make_finding("critical"),
+            _make_finding("major"),
+        ]
+        findings_b = [
+            _make_finding("minor"),
+            _make_finding("minor"),
+            _make_finding("minor"),
+        ]
+        sample_a = make_sample("s1", findings=findings_a)
+        sample_b = make_sample("s2", findings=findings_b)
+        report = EvalReport(
+            run_id="summary-findings",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.80,
+                "rework_cycles": 1.0,
+                "cost_efficiency": 10.0,
+            },
+            sample_results=[
+                SampleResult(sample=sample_a, scores=[]),
+                SampleResult(sample=sample_b, scores=[]),
+            ],
+        )
+        sentence = generate_summary_sentence(report, session_count=2)
+        assert "2 critical" in sentence
+        assert "1 major" in sentence
+        assert "3 minor" in sentence
+
+    def test_omits_missing_metrics(self) -> None:
+        """Summary sentence should gracefully handle missing metrics."""
+        report = EvalReport(
+            run_id="summary-partial",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.75,
+            },
+        )
+        sentence = generate_summary_sentence(report, session_count=10)
+        assert "75%" in sentence
+        # Should not crash, should produce a reasonable sentence
+        assert isinstance(sentence, str)
+        assert len(sentence) > 0
+
+    def test_returns_string(self) -> None:
+        """generate_summary_sentence should always return a string."""
+        report = EvalReport(
+            run_id="summary-empty",
+            aggregate_scores={},
+        )
+        sentence = generate_summary_sentence(report, session_count=0)
+        assert isinstance(sentence, str)

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -7,6 +7,7 @@ import pytest
 
 pytest.importorskip("jinja2")
 
+from raki.model.dataset import EvalSample, SessionMeta
 from raki.model.phases import ReviewFinding
 from raki.model.report import EvalReport, MetricResult, SampleResult
 
@@ -818,8 +819,8 @@ class TestDisplayNames:
         assert "Cost / session" in content
 
     def test_metric_description_subtitle(self, tmp_path: Path) -> None:
-        """Score cards should show metric description as a subtitle."""
-        from raki.report.html_report import METRIC_METADATA, write_html_report
+        """Score cards should show plain-English subtitle from METRIC_METADATA."""
+        from raki.report.html_report import write_html_report
 
         report = EvalReport(
             run_id="eval-desc",
@@ -829,9 +830,8 @@ class TestDisplayNames:
         output = tmp_path / "report.html"
         write_html_report(report, output)
         content = output.read_text()
-        # Should contain the description from METRIC_METADATA
-        meta = METRIC_METADATA["first_pass_verify_rate"]
-        assert meta["description"] in content
+        # Subtitle text (Jinja2 autoescape converts ' to &#39;)
+        assert "passes all checks on the first try" in content
 
 
 class TestAccessibility:
@@ -985,3 +985,487 @@ class TestPercentFormat:
         value_end = content.find("</div>", value_start)
         value_section = content[value_start:value_end]
         assert "85%" in value_section
+
+
+# --- Issue #70: Score cards redesign tests ---
+
+
+def _make_session_meta_helper(session_id: str) -> SessionMeta:
+    """Helper to create a SessionMeta for tests."""
+    return SessionMeta(
+        session_id=session_id,
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=1,
+        rework_cycles=0,
+    )
+
+
+class TestSummarySentenceInHtml:
+    """Summary sentence above score cards."""
+
+    def test_summary_sentence_present(self, tmp_path: Path) -> None:
+        """HTML report should include a summary sentence above the score cards."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "summary-sentence" in content
+
+    def test_summary_sentence_contains_verify_rate(self, tmp_path: Path) -> None:
+        """Summary sentence in HTML should contain the verify rate percentage."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # 0.67 = 67%
+        assert "67%" in content
+
+
+class TestHeroCard:
+    """Verify rate should render as a hero card (wider, larger)."""
+
+    def test_hero_card_class_present(self, tmp_path: Path) -> None:
+        """Verify rate card should have a hero-card CSS class."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-hero",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"first_pass_verify_rate": 0.91},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "hero-card" in content
+
+
+class TestPlainEnglishSubtitles:
+    """Every card has a plain-English subtitle."""
+
+    def test_verify_rate_subtitle(self, tmp_path: Path) -> None:
+        """Verify rate card should have the plain-English subtitle."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-subtitles",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"first_pass_verify_rate": 0.85},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "passes all checks on the first try" in content
+
+    def test_rework_cycles_subtitle(self, tmp_path: Path) -> None:
+        """Rework cycles card should have the plain-English subtitle."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-subtitles",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"rework_cycles": 1.0},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "redo its work after feedback" in content
+
+    def test_cost_subtitle(self, tmp_path: Path) -> None:
+        """Cost card should have the plain-English subtitle."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-subtitles",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"cost_efficiency": 10.0},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "costs in API fees" in content
+
+
+class TestDirectionBadges:
+    """Direction badges on directional metrics (higher/lower is better)."""
+
+    def test_verify_rate_shows_higher_is_better(self, tmp_path: Path) -> None:
+        """Verify rate should show 'higher is better' direction badge."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-direction",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"first_pass_verify_rate": 0.85},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "higher is better" in content.lower()
+
+    def test_rework_cycles_shows_lower_is_better(self, tmp_path: Path) -> None:
+        """Rework cycles should show 'lower is better' direction badge."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-direction",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"rework_cycles": 1.0},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "lower is better" in content.lower()
+
+    def test_verify_rate_shows_target_threshold(self, tmp_path: Path) -> None:
+        """Verify rate card should show target threshold of >85%."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-threshold",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"first_pass_verify_rate": 0.85},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "&gt;85%" in content or ">85%" in content
+
+
+class TestSeverityDistributionBar:
+    """Severity as stacked distribution bar with counts + traffic-light label."""
+
+    def test_severity_bar_present(self, tmp_path: Path) -> None:
+        """Severity section should show a distribution bar, not a single score."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "severity-distribution" in content or "severity-bar" in content
+
+    def test_severity_counts_shown(self, tmp_path: Path) -> None:
+        """Severity distribution should show counts for each severity level."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # _make_report_with_samples has 2 critical, 1 major, 1 minor findings
+        assert "critical" in content.lower()
+        assert "major" in content.lower()
+        assert "minor" in content.lower()
+
+    def test_severity_label_shown(self, tmp_path: Path) -> None:
+        """Severity distribution should show a traffic-light label."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        content_lower = content.lower()
+        assert "clean" in content_lower or "moderate" in content_lower or "severe" in content_lower
+
+
+class TestSeverityDistributionCompute:
+    """compute_severity_distribution helper tests."""
+
+    def test_clean_label_when_no_findings(self) -> None:
+        """No findings at all should produce 'Clean' label."""
+        from raki.report.html_report import SeverityDistribution, compute_severity_distribution
+
+        report = EvalReport(
+            run_id="clean",
+            aggregate_scores={"review_severity_distribution": 1.0},
+            sample_results=[
+                SampleResult(sample=make_sample("s1"), scores=[]),
+            ],
+        )
+        dist = compute_severity_distribution(report)
+        assert isinstance(dist, SeverityDistribution)
+        assert dist.label == "Clean"
+        assert dist.critical == 0
+        assert dist.major == 0
+        assert dist.minor == 0
+
+    def test_minor_label_with_only_major(self) -> None:
+        """0 critical + some major = 'Minor' label."""
+        from raki.report.html_report import compute_severity_distribution
+
+        findings = [
+            ReviewFinding(reviewer="r1", severity="major", issue="test issue"),
+        ]
+        report = EvalReport(
+            run_id="minor-label",
+            aggregate_scores={},
+            sample_results=[
+                SampleResult(sample=make_sample("s1", findings=findings), scores=[]),
+            ],
+        )
+        dist = compute_severity_distribution(report)
+        assert dist.label == "Minor"
+        assert dist.critical == 0
+        assert dist.major == 1
+
+    def test_severe_label_when_weighted_above_threshold(self) -> None:
+        """When weighted score > 0.5, label should be 'Severe'."""
+        from raki.report.html_report import compute_severity_distribution
+
+        findings = [
+            ReviewFinding(reviewer="r1", severity="critical", issue="crit1"),
+            ReviewFinding(reviewer="r1", severity="critical", issue="crit2"),
+            ReviewFinding(reviewer="r1", severity="critical", issue="crit3"),
+        ]
+        report = EvalReport(
+            run_id="severe-label",
+            aggregate_scores={},
+            sample_results=[
+                SampleResult(sample=make_sample("s1", findings=findings), scores=[]),
+            ],
+        )
+        dist = compute_severity_distribution(report)
+        assert dist.label == "Severe"
+
+    def test_moderate_label(self) -> None:
+        """When there are some critical but weighted <= 0.5, label should be 'Moderate'."""
+        from raki.report.html_report import compute_severity_distribution
+
+        findings = [
+            ReviewFinding(reviewer="r1", severity="critical", issue="crit1"),
+            ReviewFinding(reviewer="r1", severity="minor", issue="minor1"),
+            ReviewFinding(reviewer="r1", severity="minor", issue="minor2"),
+            ReviewFinding(reviewer="r1", severity="minor", issue="minor3"),
+            ReviewFinding(reviewer="r1", severity="minor", issue="minor4"),
+            ReviewFinding(reviewer="r1", severity="minor", issue="minor5"),
+        ]
+        report = EvalReport(
+            run_id="moderate-label",
+            aggregate_scores={},
+            sample_results=[
+                SampleResult(sample=make_sample("s1", findings=findings), scores=[]),
+            ],
+        )
+        dist = compute_severity_distribution(report)
+        assert dist.label == "Moderate"
+
+
+class TestKnowledgeMissRateConditional:
+    """Knowledge Miss Rate hidden when no knowledge_context."""
+
+    def test_hidden_when_no_knowledge_context(self, tmp_path: Path) -> None:
+        """Knowledge Miss Rate should be hidden when no session has knowledge_context."""
+        from raki.report.html_report import write_html_report
+
+        sample = make_sample("s1")
+        report = EvalReport(
+            run_id="eval-no-knowledge",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={
+                "first_pass_verify_rate": 0.85,
+                "knowledge_retrieval_miss_rate": 0.15,
+            },
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "Knowledge Miss Rate omitted" in content or "knowledge_miss_footnote" in content
+
+    def test_shown_when_knowledge_context_present(self, tmp_path: Path) -> None:
+        """Knowledge Miss Rate should be shown when sessions have knowledge_context."""
+        from raki.model.phases import PhaseResult
+        from raki.report.html_report import write_html_report
+
+        meta = _make_session_meta_helper("s1")
+        phases = [
+            PhaseResult(
+                name="implement",
+                generation=1,
+                status="completed",
+                output="done",
+                knowledge_context="some reference docs",
+            ),
+        ]
+        sample = EvalSample(session=meta, phases=phases, findings=[], events=[])
+        report = EvalReport(
+            run_id="eval-with-knowledge",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={
+                "first_pass_verify_rate": 0.85,
+                "knowledge_retrieval_miss_rate": 0.15,
+            },
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "Knowledge miss rate" in content or "Knowledge Miss Rate" in content
+
+
+class TestRetrievalQualityConditional:
+    """Retrieval Quality hidden in --no-llm mode."""
+
+    def test_no_llm_footnote_when_no_retrieval(self, tmp_path: Path) -> None:
+        """When has_retrieval=False, a footnote should appear instead of retrieval section."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-no-llm",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={
+                "first_pass_verify_rate": 0.85,
+            },
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output, has_retrieval=False)
+        content = output.read_text()
+        assert "Retrieval metrics omitted" in content or "without --no-llm" in content
+
+
+class TestReworkCyclesColorThresholds:
+    """Rework Cycles colored by threshold (green <1.0, yellow 1.0-2.0, red >2.0)."""
+
+    def test_green_below_one(self, tmp_path: Path) -> None:
+        """Rework cycles below 1.0 should be green."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-rework-green",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"rework_cycles": 0.5},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        rework_idx = content.find("Rework")
+        assert rework_idx != -1
+        card_section = content[rework_idx : rework_idx + 500]
+        assert "color-green" in card_section or "rework-green" in card_section
+
+    def test_yellow_between_one_and_two(self, tmp_path: Path) -> None:
+        """Rework cycles between 1.0-2.0 should be yellow."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-rework-yellow",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"rework_cycles": 1.5},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        rework_idx = content.find("Rework")
+        assert rework_idx != -1
+        card_section = content[rework_idx : rework_idx + 500]
+        assert "color-yellow" in card_section or "rework-yellow" in card_section
+
+    def test_red_above_two(self, tmp_path: Path) -> None:
+        """Rework cycles above 2.0 should be red."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-rework-red",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"rework_cycles": 2.5},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        rework_idx = content.find("Rework")
+        assert rework_idx != -1
+        card_section = content[rework_idx : rework_idx + 500]
+        assert "color-red" in card_section or "rework-red" in card_section
+
+
+class TestCostRange:
+    """Cost shows min-max range."""
+
+    def test_cost_range_shown(self, tmp_path: Path) -> None:
+        """Cost card should show min-max range when samples exist."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "$8.00" in content or "8.00" in content
+        assert "$25.00" in content or "25.00" in content
+
+
+class TestComputeCostRange:
+    """compute_cost_range helper tests."""
+
+    def test_returns_min_max(self) -> None:
+        """compute_cost_range should return min and max from sample costs."""
+        from raki.report.html_report import compute_cost_range
+
+        report = _make_report_with_samples()
+        cost_min, cost_max = compute_cost_range(report)
+        assert cost_min == pytest.approx(8.0)
+        assert cost_max == pytest.approx(25.0)
+
+    def test_returns_none_when_no_costs(self) -> None:
+        """compute_cost_range should return None when no costs available."""
+        from raki.report.html_report import compute_cost_range
+
+        report = _make_minimal_report()
+        result = compute_cost_range(report)
+        assert result is None
+
+
+class TestHasKnowledgeContext:
+    """has_knowledge_context helper tests."""
+
+    def test_false_when_no_context(self) -> None:
+        """has_knowledge_context should return False when no phase has knowledge_context."""
+        from raki.report.html_report import has_knowledge_context
+
+        report = _make_report_with_samples()
+        assert has_knowledge_context(report) is False
+
+    def test_true_when_context_present(self) -> None:
+        """has_knowledge_context should return True when any phase has knowledge_context."""
+        from raki.model.phases import PhaseResult
+        from raki.report.html_report import has_knowledge_context
+
+        meta = _make_session_meta_helper("s1")
+        phases = [
+            PhaseResult(
+                name="implement",
+                generation=1,
+                status="completed",
+                output="done",
+                knowledge_context="reference docs here",
+            ),
+        ]
+        sample = EvalSample(session=meta, phases=phases, findings=[], events=[])
+        report = EvalReport(
+            run_id="with-context",
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+        assert has_knowledge_context(report) is True
+
+
+class TestMetricLinksToInterpretingDocs:
+    """Metric names link to docs/interpreting-results.md."""
+
+    def test_metric_name_is_link(self, tmp_path: Path) -> None:
+        """Metric names on score cards should be rendered as links."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="eval-links",
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+            aggregate_scores={"first_pass_verify_rate": 0.85},
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "interpreting-results" in content
+        assert "<a " in content


### PR DESCRIPTION
## Summary
- Redesign HTML score cards: summary sentence, hero card for verify rate, plain-English subtitles, direction badges with thresholds, stacked severity distribution bar
- Conditional hiding of Knowledge Miss Rate (no knowledge_context) and Retrieval Quality (--no-llm) with footnotes
- Rework Cycles colored by threshold; Cost shows min-max range
- Metric names link to docs/interpreting-results.md
- Added interpreting-results.md with metric definitions and severity distribution section

Refs #70

## Review
- Python Specialist: 3 findings fixed (fallback dict keys, ty ignore removal, Literal type)
- Security Specialist: clean (autoescape, no XSS, no credential leaks)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko