### PR TITLE
ci: add PyPI publish workflow on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+      - run: uv sync --python 3.14 --extra dev
+      - run: uv run ruff check src/ tests/
+      - run: uv run ruff format --check src/ tests/
+      - run: uv run ty check src/raki/
+      - run: uv run pytest tests/ -v --tb=short
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+      - run: uv build
+      - name: Smoke test
+        run: uv run --with ./dist/*.whl -- raki --version
+      - run: uv publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
     environment: pypi
     permissions:
       id-token: write
@@ -35,3 +36,18 @@ jobs:
       - name: Smoke test
         run: uv run --with ./dist/*.whl -- raki --version
       - run: uv publish
+
+  release:
+    runs-on: ubuntu-latest
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that publishes RAKI to PyPI on tag push (v*).

Uses uv build + uv publish with PyPI Trusted Publishing (OIDC) — no API tokens or secrets needed.

## Setup required before first publish
1. Create pending publisher on https://pypi.org/manage/account/publishing/
2. Create `pypi` environment in GitHub repo Settings → Environments

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>