### PR TITLE
feat(report): redesign drill-down with verdict badges, sorting, and phase timeline

### DIFF
--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from raki.model.report import EvalReport
+from raki.model.dataset import EvalSample
+from raki.model.report import EvalReport, SampleResult
 from raki.report.cli_summary import (
     EXPERIMENTAL_METRICS,
     OPERATIONAL_METRICS,
@@ -130,6 +131,106 @@ def _get_metric_meta(name: str) -> dict[str, str | bool]:
             "docs_anchor": "",
         },
     )
+
+
+@dataclass(frozen=True)
+class DrillDownRow:
+    """A row in the per-session drill-down with verdict-based display."""
+
+    session_id: str
+    verdict: Literal["pass", "rework", "fail"]
+    detail: str
+    critical_count: int
+    major_count: int
+    minor_count: int
+    cost: float
+    duration_seconds: int
+    sort_key: tuple[int, float]
+
+
+def _determine_verdict(sample: EvalSample) -> Literal["pass", "rework", "fail"]:
+    """Determine the verdict for a session sample.
+
+    Logic: failed phase -> fail, rework_cycles > 0 -> rework, else pass.
+    """
+    for phase in sample.phases:
+        if phase.status == "failed":
+            return "fail"
+    if sample.session.rework_cycles > 0:
+        return "rework"
+    return "pass"
+
+
+def _build_detail(sample: EvalSample) -> str:
+    """Build detail text for a drill-down row.
+
+    - Failed phase: "<phase_name> failed"
+    - Rework cycles > 0: "<n> cycles"
+    - Clean pass: "<n> phases"
+    """
+    for phase in sample.phases:
+        if phase.status == "failed":
+            return f"{phase.name} failed"
+    if sample.session.rework_cycles > 0:
+        return f"{sample.session.rework_cycles} cycles"
+    return f"{len(sample.phases)} phases"
+
+
+def _compute_duration(sample: EvalSample) -> int:
+    """Sum phase durations in seconds. Returns 0 if no duration data."""
+    total_ms = 0
+    for phase in sample.phases:
+        if phase.duration_ms is not None:
+            total_ms += phase.duration_ms
+    return total_ms // 1000
+
+
+def _format_duration(seconds: int) -> str:
+    """Format seconds as M:SS (e.g. 252 -> '4:12')."""
+    minutes = seconds // 60
+    remaining_seconds = seconds % 60
+    return f"{minutes}:{remaining_seconds:02d}"
+
+
+def compute_drill_down_rows(
+    sample_results: list[SampleResult],
+) -> list[DrillDownRow]:
+    """Build and sort drill-down rows from sample results.
+
+    Sort order: FAIL(0) -> REWORK(1) -> PASS(2), cost descending within each group.
+    """
+    verdict_rank = {"fail": 0, "rework": 1, "pass": 2}
+    rows: list[DrillDownRow] = []
+
+    for sample_result in sample_results:
+        sample = sample_result.sample
+        session_id = sample.session.session_id
+        verdict = _determine_verdict(sample)
+        detail = _build_detail(sample)
+
+        severity_counter: Counter[str] = Counter()
+        for finding in sample.findings:
+            severity_counter[finding.severity] += 1
+
+        cost = sample.session.total_cost_usd or 0.0
+        duration = _compute_duration(sample)
+
+        rows.append(
+            DrillDownRow(
+                session_id=session_id,
+                verdict=verdict,
+                detail=detail,
+                critical_count=severity_counter.get("critical", 0),
+                major_count=severity_counter.get("major", 0),
+                minor_count=severity_counter.get("minor", 0),
+                cost=cost,
+                duration_seconds=duration,
+                sort_key=(verdict_rank[verdict], -cost),
+            )
+        )
+
+    rows.sort(key=lambda row: row.sort_key)
+    return rows
 
 
 @dataclass(frozen=True)
@@ -400,10 +501,13 @@ def write_html_report(
     output = output.resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
 
-    # Compute knowledge context and severity distribution BEFORE stripping
+    # Compute knowledge context, severity distribution, and drill-down BEFORE stripping
     show_knowledge_miss = has_knowledge_context(report)
     severity_dist = compute_severity_distribution(report)
     cost_range = compute_cost_range(report)
+    drill_down_rows = compute_drill_down_rows(report.sample_results)
+    needs_attention_rows = [row for row in drill_down_rows if row.verdict in ("fail", "rework")]
+    needs_attention_count = len(needs_attention_rows)
 
     if not include_sessions:
         # Strip session data from a serialized copy, then reload as a clean report
@@ -458,6 +562,10 @@ def write_html_report(
         cost_range=cost_range,
         has_retrieval=has_retrieval,
         docs_base_url=DOCS_BASE_URL,
+        drill_down_rows=drill_down_rows,
+        needs_attention_rows=needs_attention_rows,
+        needs_attention_count=needs_attention_count,
+        format_duration=_format_duration,
     )
 
     output.write_text(html_content, encoding="utf-8")

--- a/src/raki/report/templates/report.html.j2
+++ b/src/raki/report/templates/report.html.j2
@@ -401,6 +401,22 @@
     margin-bottom: 2rem;
   }
 
+  .needs-attention {
+    margin-bottom: 2rem;
+  }
+
+  .needs-attention-badge {
+    display: inline-block;
+    padding: 0.15rem 0.6rem;
+    border-radius: 10px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    background: rgba(244, 67, 54, 0.15);
+    color: var(--red);
+    margin-left: 0.5rem;
+    vertical-align: middle;
+  }
+
   details {
     background: var(--bg-card);
     border: 1px solid var(--border-color);
@@ -409,16 +425,28 @@
     overflow: hidden;
   }
 
+  details.verdict-fail {
+    border-left: 4px solid var(--red);
+  }
+
+  details.verdict-rework {
+    border-left: 4px solid var(--yellow);
+  }
+
+  details.verdict-pass {
+    border-left: 4px solid var(--green);
+  }
+
   summary {
     padding: 0.8rem 1.2rem;
     cursor: pointer;
     display: flex;
     align-items: center;
-    justify-content: space-between;
     font-weight: 600;
     color: var(--text-primary);
     user-select: none;
     list-style: none;
+    gap: 0.6rem;
   }
 
   summary::-webkit-details-marker { display: none; }
@@ -426,13 +454,99 @@
   summary::before {
     content: "\25b6";
     display: inline-block;
-    margin-right: 0.7rem;
     font-size: 0.7rem;
     transition: transform 0.2s;
+    flex-shrink: 0;
   }
 
   details[open] > summary::before {
     transform: rotate(90deg);
+  }
+
+  .verdict-badge {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    flex-shrink: 0;
+  }
+
+  .verdict-badge-fail {
+    background: rgba(244, 67, 54, 0.2);
+    color: var(--red);
+  }
+
+  .verdict-badge-rework {
+    background: rgba(255, 193, 7, 0.2);
+    color: var(--yellow);
+  }
+
+  .verdict-badge-pass {
+    background: rgba(76, 175, 80, 0.15);
+    color: var(--green);
+  }
+
+  .row-session-id {
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+
+  .row-detail {
+    color: var(--text-secondary);
+    font-weight: 400;
+    font-size: 0.9rem;
+  }
+
+  .row-severity-pills {
+    display: inline-flex;
+    gap: 0.4rem;
+    flex-shrink: 0;
+  }
+
+  .row-severity-pill {
+    display: inline-block;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.7rem;
+    font-weight: 600;
+  }
+
+  .row-severity-pill-critical {
+    background: rgba(244, 67, 54, 0.2);
+    color: var(--severity-critical);
+  }
+
+  .row-severity-pill-major {
+    background: rgba(255, 152, 0, 0.2);
+    color: var(--severity-major);
+  }
+
+  .row-severity-pill-minor {
+    background: rgba(139, 195, 58, 0.2);
+    color: var(--severity-minor);
+  }
+
+  .row-right {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-shrink: 0;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    font-weight: 400;
+  }
+
+  .row-cost {
+    font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  }
+
+  .row-duration {
+    font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+    color: var(--text-muted);
   }
 
   .detail-content {
@@ -483,6 +597,12 @@
   .phase-status-failed { background: var(--red); }
   .phase-status-skipped { background: var(--text-muted); }
 
+  .phase-duration {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  }
+
   .findings-list {
     margin: 0.5rem 0;
   }
@@ -510,6 +630,11 @@
   }
 
   .finding-location {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+  }
+
+  .finding-reviewer {
     color: var(--text-muted);
     font-size: 0.8rem;
   }
@@ -764,7 +889,7 @@
     <h2>Worst {{ worst_sessions | length if worst_sessions else 0 }} Sessions</h2>
     {% if worst_sessions %}
     {% for entry in worst_sessions %}
-    <button class="worst-session-row" type="button" data-target="session-{{ entry.session_id }}" aria-label="Jump to session {{ entry.session_id }}">
+    <button class="worst-session-row" type="button" data-target="drilldown-session-{{ entry.session_id }}" aria-label="Jump to session {{ entry.session_id }}">
       <span class="session-id">{{ entry.session_id }}</span>
       <span class="session-score {{ color_class(entry.avg_score, "") }}">{{ "%.2f"|format(entry.avg_score) }}</span>
     </button>
@@ -774,99 +899,159 @@
     {% endif %}
   </section>
 
-  {# --- Per-Session Drill-Down --- #}
-  <section class="drilldown-section">
-    <h2>Per-Session Drill-Down</h2>
-    {% if report.sample_results %}
-    {% for sample_result in report.sample_results %}
-    {% set sample = sample_result.sample %}
-    {% set session_id = sample.session.session_id %}
-    <details id="session-{{ session_id }}" aria-expanded="false">
-      <summary>
-        <span>{{ session_id }}</span>
-        <span class="score-chips">
-          {% for metric_result in sample_result.scores %}
-          {% if session_id in metric_result.sample_scores %}
-          {% set session_score = metric_result.sample_scores[session_id] %}
-          <span class="score-chip">
-            <span class="chip-name">{{ metric_result.name }}</span>
-            <span class="chip-value {{ color_class(session_score, metric_result.name) }}">{{ "%.2f"|format(session_score) }}</span>
-          </span>
-          {% endif %}
-          {% endfor %}
-        </span>
-      </summary>
-      <div class="detail-content">
-        <div class="session-meta">
-          <div class="meta-item">
-            <span class="meta-label">Rework Cycles</span>
-            <span>{{ sample.session.rework_cycles }}</span>
-          </div>
-          {% if sample.session.total_cost_usd is not none %}
-          <div class="meta-item">
-            <span class="meta-label">Cost</span>
-            <span>${{ "%.2f"|format(sample.session.total_cost_usd) }}</span>
-          </div>
-          {% endif %}
-          <div class="meta-item">
-            <span class="meta-label">Phases</span>
-            <span>{{ sample.phases | length }}</span>
-          </div>
+  {# --- Macro: render a single drill-down row with expanded detail --- #}
+  {% macro render_drilldown_row(row, sample_result, prefix="session") %}
+  {% set sample = sample_result.sample %}
+  {% set session_id = sample.session.session_id %}
+  <details id="{{ prefix }}-session-{{ session_id }}" class="verdict-{{ row.verdict }}" aria-expanded="false">
+    <summary>
+      <span class="verdict-badge verdict-badge-{{ row.verdict }}">{{ row.verdict | upper }}</span>
+      <span class="row-session-id">{{ session_id }}</span>
+      <span class="row-detail">&mdash; {{ row.detail }}</span>
+      {% if row.verdict != "pass" or row.minor_count > 0 %}
+      <span class="row-severity-pills">
+        {% if row.critical_count > 0 %}
+        <span class="row-severity-pill row-severity-pill-critical">{{ row.critical_count }} critical</span>
+        {% endif %}
+        {% if row.major_count > 0 %}
+        <span class="row-severity-pill row-severity-pill-major">{{ row.major_count }} major</span>
+        {% endif %}
+        {% if row.minor_count > 0 %}
+        <span class="row-severity-pill row-severity-pill-minor">{{ row.minor_count }} minor</span>
+        {% endif %}
+      </span>
+      {% endif %}
+      <span class="row-right">
+        <span class="row-cost">${{ "%.2f"|format(row.cost) }}</span>
+        <span class="row-duration">{{ format_duration(row.duration_seconds) }}</span>
+      </span>
+    </summary>
+    <div class="detail-content">
+      <div class="session-meta">
+        <div class="meta-item">
+          <span class="meta-label">Rework Cycles</span>
+          <span>{{ sample.session.rework_cycles }}</span>
         </div>
-
-        {# Phases #}
-        <h3>Phases</h3>
-        <div class="phase-list">
-          {% for phase in sample.phases %}
-          <div class="phase-item">
-            <span class="phase-status phase-status-{{ phase.status }}"></span>
-            <span>{{ phase.name }} (gen {{ phase.generation }})</span>
-            <span style="color: var(--text-muted);">&mdash; {{ phase.status }}</span>
-          </div>
-          {% endfor %}
-        </div>
-
-        {# Findings #}
-        {% if sample.findings %}
-        <h3>Findings</h3>
-        <div class="findings-list">
-          {% for finding in sample.findings %}
-          <div class="finding-item finding-{{ finding.severity }}">
-            <div class="finding-header">
-              <span class="severity-badge severity-{{ finding.severity }}">{{ finding.severity }}</span>
-              <span class="finding-issue">{{ finding.issue }}</span>
-            </div>
-            {% if finding.file %}
-            <div class="finding-location">{{ finding.file }}{% if finding.line %}:{{ finding.line }}{% endif %}</div>
-            {% endif %}
-            {% if finding.suggestion %}
-            <div class="finding-suggestion">{{ finding.suggestion }}</div>
-            {% endif %}
-          </div>
-          {% endfor %}
+        {% if sample.session.total_cost_usd is not none %}
+        <div class="meta-item">
+          <span class="meta-label">Cost</span>
+          <span>${{ "%.2f"|format(sample.session.total_cost_usd) }}</span>
         </div>
         {% endif %}
+        <div class="meta-item">
+          <span class="meta-label">Phases</span>
+          <span>{{ sample.phases | length }}</span>
+        </div>
+      </div>
 
-        {# Faithfulness breakdown #}
-        {% for metric_result in sample_result.scores %}
-        {% if metric_result.name == "faithfulness" and metric_result.details %}
-        <div class="faithfulness-detail">
-          <span class="claims-label">Faithfulness Claims:</span>
-          {% if "claims_verified" in metric_result.details and "claims_total" in metric_result.details %}
-          {{ metric_result.details["claims_verified"] }} / {{ metric_result.details["claims_total"] }} claims verified
-          {% else %}
-          {% for detail_key, detail_val in metric_result.details.items() %}
-          {{ detail_key }}: {{ detail_val }}{% if not loop.last %}, {% endif %}
-          {% endfor %}
+      {# Phase timeline #}
+      {% if sample.phases %}
+      <h3>Phases</h3>
+      <div class="phase-list">
+        {% for phase in sample.phases %}
+        <div class="phase-item">
+          <span class="phase-status phase-status-{{ phase.status }}"></span>
+          <span>{{ phase.name }} (gen {{ phase.generation }})</span>
+          <span style="color: var(--text-muted);">&mdash; {{ phase.status }}</span>
+          {% if phase.duration_ms is not none %}
+          <span class="phase-duration">{{ format_duration(phase.duration_ms // 1000) }}</span>
           {% endif %}
         </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <p class="empty-state">Phase data unavailable</p>
+      {% endif %}
+
+      {# Findings #}
+      {% if sample.findings %}
+      <h3>Findings</h3>
+      <div class="findings-list">
+        {% for finding in sample.findings %}
+        <div class="finding-item finding-{{ finding.severity }}">
+          <div class="finding-header">
+            <span class="severity-badge severity-{{ finding.severity }}">{{ finding.severity }}</span>
+            <span class="finding-issue">{{ finding.issue }}</span>
+          </div>
+          {% if finding.file %}
+          <div class="finding-location">{{ finding.file }}{% if finding.line %}:{{ finding.line }}{% endif %}</div>
+          {% endif %}
+          {% if finding.reviewer %}
+          <div class="finding-reviewer">Reviewer: {{ finding.reviewer }}</div>
+          {% endif %}
+          {% if finding.suggestion %}
+          <div class="finding-suggestion">{{ finding.suggestion }}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <p class="empty-state">No review findings in this session</p>
+      {% endif %}
+
+      {# Score chips #}
+      {% if sample_result.scores %}
+      <div class="score-chips">
+        {% for metric_result in sample_result.scores %}
+        {% if session_id in metric_result.sample_scores %}
+        {% set session_score = metric_result.sample_scores[session_id] %}
+        <span class="score-chip">
+          <span class="chip-name">{{ metric_result.name }}</span>
+          <span class="chip-value {{ color_class(session_score, metric_result.name) }}">{{ "%.2f"|format(session_score) }}</span>
+        </span>
         {% endif %}
         {% endfor %}
       </div>
-    </details>
+      {% endif %}
+
+      {# Faithfulness breakdown #}
+      {% for metric_result in sample_result.scores %}
+      {% if metric_result.name == "faithfulness" and metric_result.details %}
+      <div class="faithfulness-detail">
+        <span class="claims-label">Faithfulness Claims:</span>
+        {% if "claims_verified" in metric_result.details and "claims_total" in metric_result.details %}
+        {{ metric_result.details["claims_verified"] }} / {{ metric_result.details["claims_total"] }} claims verified
+        {% else %}
+        {% for detail_key, detail_val in metric_result.details.items() %}
+        {{ detail_key }}: {{ detail_val }}{% if not loop.last %}, {% endif %}
+        {% endfor %}
+        {% endif %}
+      </div>
+      {% endif %}
+      {% endfor %}
+    </div>
+  </details>
+  {% endmacro %}
+
+  {# --- Build session_id -> sample_result lookup --- #}
+  {% set session_lookup = {} %}
+  {% for sample_result in report.sample_results %}
+  {% set _ = session_lookup.update({sample_result.sample.session.session_id: sample_result}) %}
+  {% endfor %}
+
+  {# --- Needs Attention Section --- #}
+  {% if needs_attention_count > 0 %}
+  <section class="needs-attention">
+    <h2>Needs Attention <span class="needs-attention-badge">{{ needs_attention_count }} session{{ "s" if needs_attention_count != 1 else "" }} need{{ "s" if needs_attention_count == 1 else "" }} attention</span></h2>
+    {% for row in needs_attention_rows %}
+    {% if row.session_id in session_lookup %}
+    {{ render_drilldown_row(row, session_lookup[row.session_id], prefix="attention") }}
+    {% endif %}
+    {% endfor %}
+  </section>
+  {% endif %}
+
+  {# --- Per-Session Drill-Down --- #}
+  <section class="drilldown-section">
+    <h2>Per-Session Drill-Down</h2>
+    {% if drill_down_rows %}
+    {% for row in drill_down_rows %}
+    {% if row.session_id in session_lookup %}
+    {{ render_drilldown_row(row, session_lookup[row.session_id], prefix="drilldown") }}
+    {% endif %}
     {% endfor %}
     {% else %}
-    <p class="empty-state">No per-session data available.</p>
+    <p class="empty-state">Per-session details unavailable &mdash; regenerate with --include-sessions</p>
     {% endif %}
   </section>
   </main>

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -1469,3 +1469,487 @@ class TestMetricLinksToInterpretingDocs:
         content = output.read_text()
         assert "interpreting-results" in content
         assert "<a " in content
+
+
+# --- Issue #68: Drill-down redesign tests ---
+
+
+class TestDrillDownRowDataclass:
+    """DrillDownRow frozen dataclass with verdict, detail, severity counts, cost, duration."""
+
+    def test_drill_down_row_creation(self) -> None:
+        """DrillDownRow should store session_id, verdict, detail, severity counts, cost, duration."""
+        from raki.report.html_report import DrillDownRow
+
+        row = DrillDownRow(
+            session_id="session-101",
+            verdict="fail",
+            detail="implement failed",
+            critical_count=2,
+            major_count=0,
+            minor_count=1,
+            cost=4.20,
+            duration_seconds=42,
+            sort_key=(0, -4.20),
+        )
+        assert row.session_id == "session-101"
+        assert row.verdict == "fail"
+        assert row.detail == "implement failed"
+        assert row.critical_count == 2
+        assert row.major_count == 0
+        assert row.minor_count == 1
+        assert row.cost == pytest.approx(4.20)
+        assert row.duration_seconds == 42
+        assert row.sort_key == (0, -4.20)
+
+    def test_drill_down_row_is_frozen(self) -> None:
+        """DrillDownRow should be immutable (frozen dataclass)."""
+        from raki.report.html_report import DrillDownRow
+
+        row = DrillDownRow(
+            session_id="session-101",
+            verdict="pass",
+            detail="5 phases",
+            critical_count=0,
+            major_count=0,
+            minor_count=0,
+            cost=8.50,
+            duration_seconds=252,
+            sort_key=(2, -8.50),
+        )
+        with pytest.raises(AttributeError):
+            row.verdict = "fail"  # type: ignore[misc]
+
+
+class TestDetermineVerdict:
+    """_determine_verdict: failed phase -> fail, rework_cycles > 0 -> rework, else pass."""
+
+    def test_fail_when_phase_failed(self) -> None:
+        """Session with a failed phase should have verdict 'fail'."""
+        from raki.report.html_report import _determine_verdict
+
+        sample = make_sample("s1", verify_status="failed")
+        assert _determine_verdict(sample) == "fail"
+
+    def test_rework_when_cycles_positive(self) -> None:
+        """Session with rework_cycles > 0 but no failed phase should have verdict 'rework'."""
+        from raki.report.html_report import _determine_verdict
+
+        sample = make_sample("s1", rework_cycles=2, verify_status="completed")
+        assert _determine_verdict(sample) == "rework"
+
+    def test_pass_when_clean(self) -> None:
+        """Session with no failed phases and 0 rework_cycles should have verdict 'pass'."""
+        from raki.report.html_report import _determine_verdict
+
+        sample = make_sample("s1", rework_cycles=0, verify_status="completed")
+        assert _determine_verdict(sample) == "pass"
+
+    def test_fail_takes_precedence_over_rework(self) -> None:
+        """When both failed phase and rework_cycles > 0, verdict should be 'fail'."""
+        from raki.report.html_report import _determine_verdict
+
+        sample = make_sample("s1", rework_cycles=2, verify_status="failed")
+        assert _determine_verdict(sample) == "fail"
+
+
+class TestBuildDetail:
+    """_build_detail: "implement failed" / "2 cycles" / "5 phases"."""
+
+    def test_detail_for_fail(self) -> None:
+        """When a phase fails, detail should name the failed phase."""
+        from raki.report.html_report import _build_detail
+
+        sample = make_sample("s1", verify_status="failed")
+        detail = _build_detail(sample)
+        assert "verify failed" in detail
+
+    def test_detail_for_rework(self) -> None:
+        """When rework_cycles > 0 and no failure, detail should show cycle count."""
+        from raki.report.html_report import _build_detail
+
+        sample = make_sample("s1", rework_cycles=2, verify_status="completed")
+        detail = _build_detail(sample)
+        assert "2 cycles" in detail
+
+    def test_detail_for_pass(self) -> None:
+        """When clean pass, detail should show phase count."""
+        from raki.report.html_report import _build_detail
+
+        sample = make_sample("s1", rework_cycles=0, verify_status="completed")
+        detail = _build_detail(sample)
+        assert "phases" in detail
+
+
+class TestComputeDuration:
+    """_compute_duration: sum phase durations in seconds."""
+
+    def test_sums_phase_durations(self) -> None:
+        """Should sum all phase duration_ms values and convert to seconds."""
+        from raki.model.phases import PhaseResult
+        from raki.report.html_report import _compute_duration
+
+        meta = SessionMeta(
+            session_id="s1",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=2,
+            rework_cycles=0,
+        )
+        phases = [
+            PhaseResult(
+                name="implement",
+                generation=1,
+                status="completed",
+                output="done",
+                duration_ms=60000,
+            ),
+            PhaseResult(
+                name="verify",
+                generation=1,
+                status="completed",
+                output="PASS",
+                duration_ms=30000,
+            ),
+        ]
+        sample = EvalSample(session=meta, phases=phases, findings=[], events=[])
+        assert _compute_duration(sample) == 90
+
+    def test_zero_when_no_duration_data(self) -> None:
+        """Should return 0 when phases have no duration_ms."""
+        from raki.report.html_report import _compute_duration
+
+        sample = make_sample("s1")
+        assert _compute_duration(sample) == 0
+
+
+class TestFormatDuration:
+    """_format_duration: format seconds as M:SS."""
+
+    def test_format_minutes_seconds(self) -> None:
+        """Should format 252 seconds as '4:12'."""
+        from raki.report.html_report import _format_duration
+
+        assert _format_duration(252) == "4:12"
+
+    def test_format_zero(self) -> None:
+        """Should format 0 seconds as '0:00'."""
+        from raki.report.html_report import _format_duration
+
+        assert _format_duration(0) == "0:00"
+
+    def test_format_under_minute(self) -> None:
+        """Should format 42 seconds as '0:42'."""
+        from raki.report.html_report import _format_duration
+
+        assert _format_duration(42) == "0:42"
+
+    def test_format_exact_minutes(self) -> None:
+        """Should format 120 seconds as '2:00'."""
+        from raki.report.html_report import _format_duration
+
+        assert _format_duration(120) == "2:00"
+
+    def test_format_large_duration(self) -> None:
+        """Should format 454 seconds as '7:34'."""
+        from raki.report.html_report import _format_duration
+
+        assert _format_duration(454) == "7:34"
+
+
+class TestComputeDrillDownRows:
+    """compute_drill_down_rows: build and sort rows with FAIL first, then REWORK, then PASS."""
+
+    def test_sorts_fail_first(self) -> None:
+        """FAIL rows should come before REWORK and PASS."""
+        from raki.report.html_report import compute_drill_down_rows
+
+        sample_fail = make_sample("s-fail", verify_status="failed", cost=4.20)
+        sample_rework = make_sample("s-rework", rework_cycles=2, cost=26.10)
+        sample_pass = make_sample("s-pass", rework_cycles=0, cost=8.50)
+        sample_results = [
+            SampleResult(sample=sample_pass, scores=[]),
+            SampleResult(sample=sample_fail, scores=[]),
+            SampleResult(sample=sample_rework, scores=[]),
+        ]
+        rows = compute_drill_down_rows(sample_results)
+        assert rows[0].verdict == "fail"
+        assert rows[1].verdict == "rework"
+        assert rows[2].verdict == "pass"
+
+    def test_cost_descending_within_verdict_group(self) -> None:
+        """Within the same verdict group, rows should be sorted by cost descending."""
+        from raki.report.html_report import compute_drill_down_rows
+
+        sample_pass_cheap = make_sample("s-cheap", rework_cycles=0, cost=5.00)
+        sample_pass_expensive = make_sample("s-expensive", rework_cycles=0, cost=20.00)
+        sample_results = [
+            SampleResult(sample=sample_pass_cheap, scores=[]),
+            SampleResult(sample=sample_pass_expensive, scores=[]),
+        ]
+        rows = compute_drill_down_rows(sample_results)
+        assert rows[0].session_id == "s-expensive"
+        assert rows[1].session_id == "s-cheap"
+
+    def test_severity_counts_from_findings(self) -> None:
+        """Row severity counts should reflect actual findings."""
+        from raki.report.html_report import compute_drill_down_rows
+
+        findings = [
+            ReviewFinding(reviewer="r1", severity="critical", issue="crit1"),
+            ReviewFinding(reviewer="r1", severity="critical", issue="crit2"),
+            ReviewFinding(reviewer="r1", severity="major", issue="maj1"),
+        ]
+        sample = make_sample("s1", rework_cycles=1, findings=findings)
+        rows = compute_drill_down_rows([SampleResult(sample=sample, scores=[])])
+        assert rows[0].critical_count == 2
+        assert rows[0].major_count == 1
+        assert rows[0].minor_count == 0
+
+    def test_empty_sample_results_returns_empty(self) -> None:
+        """Empty sample_results should return empty list."""
+        from raki.report.html_report import compute_drill_down_rows
+
+        rows = compute_drill_down_rows([])
+        assert rows == []
+
+
+class TestDrillDownRowsInHtml:
+    """Drill-down rows render in HTML with verdict badges, borders, cost, and duration."""
+
+    def test_verdict_badges_in_html(self, tmp_path: Path) -> None:
+        """HTML drill-down should show FAIL/REWORK/PASS verdict badges."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # session-alpha has verify failed -> FAIL
+        assert "verdict-fail" in content or "FAIL" in content
+        # session-beta has rework_cycles=1 -> REWORK
+        assert "verdict-rework" in content or "REWORK" in content
+        # session-gamma has no rework/failure -> PASS
+        assert "verdict-pass" in content or "PASS" in content
+
+    def test_verdict_left_border_colors(self, tmp_path: Path) -> None:
+        """Rows should have left border colored by verdict (red/yellow/none)."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "border-fail" in content or "border-left" in content
+
+    def test_cost_shown_in_drilldown_row(self, tmp_path: Path) -> None:
+        """Each drill-down row should show cost with dollar sign."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "$25.00" in content
+        assert "$15.00" in content
+        assert "$8.00" in content
+
+    def test_severity_badges_on_fail_rework_only(self, tmp_path: Path) -> None:
+        """Severity badges should appear on FAIL/REWORK rows but not on clean PASS rows."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # session-gamma is PASS with no findings -- should not have severity pills in row
+        # Find the gamma session in the drill-down section (verdict-pass details element)
+        drilldown_start = content.find("Per-Session Drill-Down")
+        assert drilldown_start != -1
+        gamma_idx = content.find("session-gamma", drilldown_start)
+        assert gamma_idx != -1
+        # Find the next summary/details boundary after gamma
+        next_detail_idx = content.find("</summary>", gamma_idx)
+        gamma_row = content[gamma_idx:next_detail_idx]
+        assert "row-severity-pill-critical" not in gamma_row
+        assert "row-severity-pill-major" not in gamma_row
+
+    def test_drill_down_sorted_fail_first(self, tmp_path: Path) -> None:
+        """In HTML, FAIL sessions should appear before REWORK which appear before PASS."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # session-alpha is FAIL (verify failed), session-beta is REWORK, session-gamma is PASS
+        fail_pos = content.find("session-alpha")
+        rework_pos = content.find("session-beta")
+        pass_pos = content.find("session-gamma")
+        assert fail_pos < rework_pos < pass_pos
+
+
+class TestNeedsAttentionSection:
+    """'Needs Attention' section above full drill-down with FAIL+REWORK count badge."""
+
+    def test_needs_attention_present(self, tmp_path: Path) -> None:
+        """When FAIL or REWORK sessions exist, 'Needs Attention' section should appear."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "needs-attention" in content.lower() or "Needs Attention" in content
+
+    def test_needs_attention_count_badge(self, tmp_path: Path) -> None:
+        """Needs Attention section should show count of FAIL+REWORK sessions."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # session-alpha (FAIL) + session-beta (REWORK) = 2
+        assert "2 sessions need attention" in content.lower() or "2 session" in content.lower()
+
+    def test_needs_attention_shows_only_fail_rework(self, tmp_path: Path) -> None:
+        """Needs Attention section should only contain FAIL and REWORK sessions."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Find the Needs Attention heading in the HTML body (not CSS)
+        attention_heading = content.find("Needs Attention")
+        assert attention_heading != -1
+        # The section should end before the full drill-down starts
+        drilldown_idx = content.find("Per-Session Drill-Down", attention_heading)
+        assert drilldown_idx != -1
+        attention_section = content[attention_heading:drilldown_idx]
+        # session-gamma (PASS) should NOT be in attention section
+        assert "session-gamma" not in attention_section
+        # session-alpha (FAIL) and session-beta (REWORK) should be present
+        assert "session-alpha" in attention_section
+        assert "session-beta" in attention_section
+
+    def test_no_needs_attention_when_all_pass(self, tmp_path: Path) -> None:
+        """When all sessions pass, Needs Attention section should not appear or be empty."""
+        from raki.report.html_report import write_html_report
+
+        all_pass_sample = make_sample("s1", rework_cycles=0, cost=10.0)
+        report = EvalReport(
+            run_id="all-pass",
+            aggregate_scores={"first_pass_verify_rate": 1.0},
+            sample_results=[SampleResult(sample=all_pass_sample, scores=[])],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Either no needs-attention section, or it has an empty state
+        attention_lower = content.lower()
+        if "needs-attention" in attention_lower or "needs attention" in attention_lower:
+            # It's acceptable if the section exists but has no rows
+            assert "0 sessions" in attention_lower or "no sessions" in attention_lower
+
+
+class TestDrillDownEmptyState:
+    """Empty state when no session data."""
+
+    def test_empty_state_message(self, tmp_path: Path) -> None:
+        """When sample_results is empty, show message about --include-sessions."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_minimal_report()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "--include-sessions" in content
+
+
+class TestDrillDownExpandedView:
+    """Expanded view: phase timeline with status dots + duration, findings with severity."""
+
+    def test_phase_timeline_in_expanded_view(self, tmp_path: Path) -> None:
+        """Expanded session should show phase timeline with status dots."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Phase status dots
+        assert "phase-status" in content
+        assert "implement" in content
+        assert "verify" in content
+
+    def test_findings_with_severity_in_expanded_view(self, tmp_path: Path) -> None:
+        """Expanded session should show findings with severity badges and file location."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "SQL injection vulnerability" in content
+        assert "main.py" in content
+        assert "severity-critical" in content or "critical" in content.lower()
+
+    def test_reviewer_name_in_expanded_view(self, tmp_path: Path) -> None:
+        """Expanded session should show reviewer name for findings."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "reviewer-1" in content or "reviewer" in content.lower()
+
+
+class TestPassRowsClean:
+    """PASS rows should be visually clean -- no severity badges unless minor findings exist."""
+
+    def test_pass_row_no_badges_when_clean(self, tmp_path: Path) -> None:
+        """PASS row with no findings should have no severity badges in the summary."""
+        from raki.report.html_report import write_html_report
+
+        clean_pass = make_sample("s-clean", rework_cycles=0, cost=6.80)
+        report = EvalReport(
+            run_id="clean-pass",
+            aggregate_scores={},
+            sample_results=[SampleResult(sample=clean_pass, scores=[])],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Find the summary row for s-clean
+        clean_idx = content.find("s-clean")
+        assert clean_idx != -1
+        summary_end = content.find("</summary>", clean_idx)
+        row_text = content[clean_idx:summary_end]
+        # No severity pills in summary
+        assert "critical" not in row_text.lower()
+        assert "major" not in row_text.lower()
+
+    def test_pass_row_shows_minor_badge_when_minor_findings(self, tmp_path: Path) -> None:
+        """PASS row with minor findings should show minor badge."""
+        from raki.report.html_report import write_html_report
+
+        findings = [
+            ReviewFinding(reviewer="r1", severity="minor", issue="Style issue"),
+        ]
+        minor_pass = make_sample("s-minor", rework_cycles=0, cost=8.50, findings=findings)
+        report = EvalReport(
+            run_id="minor-pass",
+            aggregate_scores={},
+            sample_results=[SampleResult(sample=minor_pass, scores=[])],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Find the summary row for s-minor
+        minor_idx = content.find("s-minor")
+        assert minor_idx != -1
+        summary_end = content.find("</summary>", minor_idx)
+        row_text = content[minor_idx:summary_end]
+        assert "1 minor" in row_text or "minor" in row_text.lower()


### PR DESCRIPTION
## Summary
- Redesign per-session drill-down: verdict badges (PASS/REWORK/FAIL), FAIL-first sorting, severity badges, cost + duration
- "Needs Attention" section above drill-down showing only FAIL + REWORK rows with count badge
- Expanded view: phase timeline with status dots + duration, review findings with severity + file
- PASS rows visually clean, empty state for stripped data
- Unique DOM id prefixes per section to avoid duplicate id attributes

Refs #68

## Review
- Python Specialist: 1 finding fixed (duplicate HTML id attributes)
- Security Specialist: clean (autoescape, no data leaks, session stripping correct)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko