### PR TITLE
feat(report): add raki report --diff to compare two evaluation runs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,6 +84,29 @@ uv run raki report --input results/raki-report-20260410T120000.json --html resul
 
 If the JSON report was generated without `--include-sessions`, RAKI will show aggregate scores only and warn that per-session drill-down is unavailable.
 
+## Comparing Runs
+
+Compare two evaluation runs side by side to see what improved and what regressed:
+
+```bash
+# Compare a baseline and a new run
+uv run raki report --diff results/baseline.json results/compare.json
+
+# Generate an HTML diff report
+uv run raki report --diff results/baseline.json results/compare.json --html results/diff.html
+
+# Write HTML to a specific output directory
+uv run raki report --diff results/baseline.json results/compare.json -o results/
+```
+
+The diff output shows:
+
+- **Coverage line** -- how many sessions matched between runs, plus counts of new and dropped sessions.
+- **Aggregate deltas** -- metric-by-metric comparison with direction indicators (green for improvements, red for regressions).
+- **Session transitions** -- which sessions changed verdict (e.g., REWORK to PASS), grouped by transition type with regressions listed first.
+
+For per-session transition analysis, both reports must have been generated with `--include-sessions`. Without session data, only aggregate deltas are shown.
+
 ## Next Steps
 
 - [Results Interpretation Reference](interpretation-reference.md) -- thresholds, patterns, and what to do about low scores

--- a/docs/interpreting-results.md
+++ b/docs/interpreting-results.md
@@ -96,3 +96,48 @@ its source material.
 
 - **Direction:** Higher is better
 - This metric is **experimental** for agentic sessions.
+
+## Comparing Runs
+
+Use `raki report --diff baseline.json compare.json` to compare two evaluation
+runs side by side. The diff output highlights what changed between runs.
+
+### Reading the Diff Output
+
+**Coverage line** shows how many sessions were matched by `session_id`:
+
+```
+Matched: 42/58 sessions (16 new, 4 dropped)
+```
+
+If sessions were dropped or added, a warning banner notes that aggregate
+deltas are based on matched sessions only.
+
+**Aggregate deltas** show the change for each metric:
+
+- **Direction indicators**: a green up arrow (improved) or red down arrow
+  (regressed) respects each metric's `higher_is_better` setting. For
+  example, a *decrease* in rework cycles is shown as an improvement.
+- **Flat deltas** are shown with an equals sign when values are identical.
+
+**Session transitions** group sessions by verdict change:
+
+- Regressions (PASS to REWORK, PASS to FAIL) are listed first.
+- Improvements (REWORK to PASS, FAIL to PASS) follow.
+- Sessions with unchanged verdicts are not listed.
+
+### What You Need
+
+Both reports must have been generated with `--include-sessions` for
+per-session transition analysis. Without session data, only aggregate
+metric deltas are shown, and a warning notes that per-session comparison
+is unavailable.
+
+### When to Use Diff
+
+- **After prompt or config changes**: compare before/after runs to verify
+  that changes improved metrics without introducing regressions.
+- **Across evaluation batches**: compare runs on different session sets to
+  spot trends in retrieval quality or operational health.
+- **CI pipelines**: use diff to gate merges -- if regressions appear, the
+  diff output shows exactly which sessions regressed and by how much.

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -409,8 +410,17 @@ def _metric_stubs_from_metadata(
     "-i",
     "--input",
     "input_path",
-    required=True,
-    help="Path to JSON report (required)",
+    required=False,
+    default=None,
+    help="Path to JSON report",
+)
+@click.option(
+    "--diff",
+    "diff_paths",
+    nargs=2,
+    type=str,
+    default=None,
+    help="Compare two JSON reports: --diff baseline.json compare.json",
 )
 @click.option(
     "--html",
@@ -418,8 +428,31 @@ def _metric_stubs_from_metadata(
     default=None,
     help="Output HTML file path",
 )
-def report(input_path: str, html_path: str | None) -> None:
-    """Re-render CLI summary and HTML from a saved JSON report."""
+@click.option(
+    "-o",
+    "--output",
+    "output_dir",
+    default=None,
+    help="Output directory for diff report",
+)
+def report(
+    input_path: str | None,
+    diff_paths: tuple[str, str] | None,
+    html_path: str | None,
+    output_dir: str | None,
+) -> None:
+    """Re-render CLI summary and HTML from a saved JSON report.
+
+    Use --diff to compare two evaluation runs side by side.
+    """
+    if diff_paths is not None:
+        _handle_diff(diff_paths, html_path, output_dir)
+        return
+
+    if input_path is None:
+        console.print("[red]Error: --input is required when not using --diff[/red]")
+        raise SystemExit(2)
+
     from raki.report.json_report import load_json_report
 
     path = Path(input_path)
@@ -466,6 +499,66 @@ def report(input_path: str, html_path: str | None) -> None:
         except ImportError:
             console.print(
                 "[yellow]Note: jinja2 not installed — skipping HTML report. "
+                "Install with: uv pip install raki[html][/yellow]"
+            )
+
+
+def _handle_diff(
+    diff_paths: tuple[str, str],
+    html_path: str | None,
+    output_dir: str | None,
+) -> None:
+    """Handle the --diff subflow of the report command."""
+    from raki.report.json_report import load_json_report
+
+    baseline_path = Path(diff_paths[0])
+    compare_path = Path(diff_paths[1])
+
+    if not baseline_path.exists():
+        console.print(f"[red]Error: baseline file not found: {baseline_path}[/red]")
+        raise SystemExit(2)
+    if not compare_path.exists():
+        console.print(f"[red]Error: compare file not found: {compare_path}[/red]")
+        raise SystemExit(2)
+
+    try:
+        baseline_report = load_json_report(baseline_path)
+    except Exception as exc:
+        console.print(f"[red]Error loading baseline report: {redact_sensitive(str(exc))}[/red]")
+        raise SystemExit(2) from exc
+
+    try:
+        compare_report = load_json_report(compare_path)
+    except Exception as exc:
+        console.print(f"[red]Error loading compare report: {redact_sensitive(str(exc))}[/red]")
+        raise SystemExit(2) from exc
+
+    from raki.report.diff import generate_diff_report
+
+    diff_report = generate_diff_report(baseline_report, compare_report)
+
+    from raki.report.cli_summary import print_diff_summary
+
+    print_diff_summary(diff_report, console=console)
+
+    # Determine HTML output path
+    resolved_html_path: Path | None = None
+    if html_path is not None:
+        resolved_html_path = Path(html_path)
+    elif output_dir is not None:
+        safe_base = re.sub(r"[/\\]|\.\.", "_", baseline_report.run_id)
+        safe_comp = re.sub(r"[/\\]|\.\.", "_", compare_report.run_id)
+        resolved_html_path = Path(output_dir) / f"diff-{safe_base}-vs-{safe_comp}.html"
+
+    if resolved_html_path is not None:
+        try:
+            from raki.report.html_report import write_diff_html_report
+
+            write_diff_html_report(diff_report, resolved_html_path)
+            console.print(f"\nDiff report written:\n  HTML -> {resolved_html_path}")
+        except ImportError:
+            console.print(
+                "[yellow]Note: jinja2 not installed — skipping HTML diff report. "
                 "Install with: uv pip install raki[html][/yellow]"
             )
 

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -1,12 +1,18 @@
 """Rich CLI summary output — color-coded metrics grouped by category."""
 
+from __future__ import annotations
+
 from collections import Counter
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from rich.console import Console
 
 from raki.metrics.protocol import Metric
 from raki.model.report import EvalReport
+
+if TYPE_CHECKING:
+    from raki.report.diff import DiffReport, SessionTransition
 
 OPERATIONAL_METRICS = {
     "first_pass_verify_rate",
@@ -236,3 +242,137 @@ def print_summary(
         output_console.print(
             f"[dim]  {session_count} evaluated, {skipped_count} skipped, {error_count} errors[/dim]"
         )
+
+
+def _format_delta_value(value: float, display_format: str) -> str:
+    """Format a metric value for the diff summary."""
+    if display_format == "currency":
+        return f"${value:.2f}"
+    if display_format == "count":
+        return f"{value:.1f}"
+    if display_format == "percent":
+        return f"{value * 100:.0f}%"
+    return f"{value:.2f}"
+
+
+def _format_delta_change(delta: float, display_format: str) -> str:
+    """Format a delta change value with sign."""
+    sign = "+" if delta >= 0 else ""
+    if display_format == "currency":
+        if delta < 0:
+            return f"-${abs(delta):.2f}"
+        return f"{sign}${delta:.2f}"
+    if display_format == "count":
+        return f"{sign}{delta:.1f}"
+    if display_format == "percent":
+        return f"{sign}{delta * 100:.0f}%"
+    return f"{sign}{delta:.2f}"
+
+
+def print_diff_summary(
+    diff: DiffReport,
+    console: Console | None = None,
+) -> None:
+    """Print a Rich CLI diff summary comparing two evaluation runs.
+
+    Shows the comparison header, coverage line, aggregate metric deltas
+    with direction indicators, and session transition counts.
+    """
+    from raki.report.html_report import METRIC_METADATA
+
+    output_console = console or Console()
+    output_console.print()
+
+    # Header
+    output_console.print(
+        f"Comparing [bold]{diff.baseline_run_id}[/bold] → [bold]{diff.compare_run_id}[/bold]"
+    )
+
+    # Coverage line
+    match_result = diff.match_result
+    matched_count = len(match_result.matched_ids)
+    total_count = max(match_result.baseline_total, match_result.compare_total)
+    new_count = len(match_result.new_ids)
+    dropped_count = len(match_result.dropped_ids)
+
+    coverage_parts: list[str] = []
+    if new_count > 0:
+        coverage_parts.append(f"{new_count} new")
+    if dropped_count > 0:
+        coverage_parts.append(f"{dropped_count} dropped")
+    coverage_detail = f" ({', '.join(coverage_parts)})" if coverage_parts else ""
+    output_console.print(f"Matched: {matched_count}/{total_count} sessions{coverage_detail}")
+
+    # Warning banner for dropped/new sessions
+    if dropped_count > 0 or new_count > 0:
+        warning_parts: list[str] = []
+        if dropped_count > 0:
+            warning_parts.append(f"{dropped_count} sessions dropped")
+        if new_count > 0:
+            warning_parts.append(f"{new_count} new")
+        output_console.print(
+            f"[yellow]Warning: {', '.join(warning_parts)} — "
+            f"aggregate deltas based on matched sessions only[/yellow]"
+        )
+
+    output_console.print()
+
+    # Aggregate deltas table
+    if diff.deltas:
+        for metric_delta in diff.deltas:
+            meta = METRIC_METADATA.get(metric_delta.name, {})
+            display_name = str(meta.get("display_name", metric_delta.name))
+            display_format = str(meta.get("display_format", "score"))
+
+            baseline_str = _format_delta_value(metric_delta.baseline_value, display_format)
+            compare_str = _format_delta_value(metric_delta.compare_value, display_format)
+            delta_str = _format_delta_change(metric_delta.delta, display_format)
+
+            if metric_delta.direction == "improved":
+                color = "green"
+                indicator = "▲"
+            elif metric_delta.direction == "regressed":
+                color = "red"
+                indicator = "▼"
+            else:
+                color = "white"
+                indicator = "="
+
+            output_console.print(
+                f"[{color}]  {display_name:<20} {baseline_str} → {compare_str}  "
+                f"({delta_str})  {indicator}[/{color}]"
+            )
+        output_console.print()
+
+    # Session transition counts
+    if diff.has_session_data:
+        if diff.improvements:
+            transition_labels = _group_transition_labels(diff.improvements)
+            output_console.print(
+                f"Improvements: {len(diff.improvements)} sessions ({transition_labels})"
+            )
+        if diff.regressions:
+            transition_labels = _group_transition_labels(diff.regressions)
+            output_console.print(
+                f"Regressions:  {len(diff.regressions)} sessions ({transition_labels})"
+            )
+        if not diff.improvements and not diff.regressions:
+            output_console.print("[dim]No session verdict changes[/dim]")
+    else:
+        output_console.print(
+            "[yellow]Per-session comparison unavailable — "
+            "both reports must be generated with --include-sessions[/yellow]"
+        )
+
+
+def _group_transition_labels(
+    transitions: list[SessionTransition],
+) -> str:
+    """Group transitions by type and produce a summary label like 'REWORK → PASS'."""
+    label_counter: Counter[str] = Counter()
+    for trans in transitions:
+        label = f"{trans.old_verdict.upper()} → {trans.new_verdict.upper()}"
+        label_counter[label] += 1
+
+    parts = [label for label, _count in label_counter.most_common()]
+    return ", ".join(parts)

--- a/src/raki/report/diff.py
+++ b/src/raki/report/diff.py
@@ -1,0 +1,216 @@
+"""Diff computation — compare two evaluation runs by session matching and metric deltas."""
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from raki.model.report import EvalReport, SampleResult
+from raki.report.html_report import METRIC_METADATA, determine_verdict
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    """Result of matching sessions between baseline and compare reports."""
+
+    matched_ids: set[str] = field(default_factory=set)
+    new_ids: set[str] = field(default_factory=set)
+    dropped_ids: set[str] = field(default_factory=set)
+    baseline_total: int = 0
+    compare_total: int = 0
+
+
+@dataclass(frozen=True)
+class MetricDelta:
+    """Delta for a single metric between baseline and compare."""
+
+    name: str
+    baseline_value: float
+    compare_value: float
+    delta: float
+    direction: Literal["improved", "regressed", "flat"]
+
+
+@dataclass(frozen=True)
+class SessionTransition:
+    """A session whose verdict changed between baseline and compare."""
+
+    session_id: str
+    old_verdict: Literal["pass", "rework", "fail"]
+    new_verdict: Literal["pass", "rework", "fail"]
+    transition_type: Literal["improvement", "regression"]
+
+
+@dataclass(frozen=True)
+class DiffReport:
+    """Complete diff between two evaluation runs."""
+
+    baseline_run_id: str
+    compare_run_id: str
+    match_result: MatchResult
+    deltas: list[MetricDelta] = field(default_factory=list)
+    improvements: list[SessionTransition] = field(default_factory=list)
+    regressions: list[SessionTransition] = field(default_factory=list)
+    has_session_data: bool = True
+
+
+# Verdict rank for sorting: lower rank = worse verdict
+_VERDICT_RANK: dict[str, int] = {"fail": 0, "rework": 1, "pass": 2}
+
+
+def _is_higher_is_better(metric_name: str) -> bool:
+    """Determine if a metric is higher_is_better from METRIC_METADATA.
+
+    Defaults to True for unknown metrics.
+    """
+    meta = METRIC_METADATA.get(metric_name)
+    if meta is None:
+        return True
+    return bool(meta.get("higher_is_better", True))
+
+
+def match_sessions(baseline: EvalReport, compare: EvalReport) -> MatchResult:
+    """Match sessions between baseline and compare reports by session_id.
+
+    Partitions into matched (in both), new (compare only), and dropped (baseline only).
+    """
+    baseline_ids = {
+        sample_result.sample.session.session_id for sample_result in baseline.sample_results
+    }
+    compare_ids = {
+        sample_result.sample.session.session_id for sample_result in compare.sample_results
+    }
+
+    matched = baseline_ids & compare_ids
+    new = compare_ids - baseline_ids
+    dropped = baseline_ids - compare_ids
+
+    return MatchResult(
+        matched_ids=matched,
+        new_ids=new,
+        dropped_ids=dropped,
+        baseline_total=len(baseline_ids),
+        compare_total=len(compare_ids),
+    )
+
+
+def compute_deltas(
+    baseline_scores: dict[str, float],
+    compare_scores: dict[str, float],
+) -> list[MetricDelta]:
+    """Compute deltas for metrics present in both baseline and compare.
+
+    Direction is determined by higher_is_better from METRIC_METADATA:
+    - higher_is_better=True: positive delta = improved, negative = regressed
+    - higher_is_better=False: negative delta = improved, positive = regressed
+    """
+    deltas: list[MetricDelta] = []
+    # Only compute deltas for metrics present in both reports
+    common_metrics = set(baseline_scores.keys()) & set(compare_scores.keys())
+
+    for metric_name in common_metrics:
+        baseline_value = baseline_scores[metric_name]
+        compare_value = compare_scores[metric_name]
+        delta = compare_value - baseline_value
+        higher_is_better = _is_higher_is_better(metric_name)
+
+        if abs(delta) < 1e-9:
+            direction: Literal["improved", "regressed", "flat"] = "flat"
+        elif higher_is_better:
+            direction = "improved" if delta > 0 else "regressed"
+        else:
+            direction = "improved" if delta < 0 else "regressed"
+
+        deltas.append(
+            MetricDelta(
+                name=metric_name,
+                baseline_value=baseline_value,
+                compare_value=compare_value,
+                delta=delta,
+                direction=direction,
+            )
+        )
+
+    return deltas
+
+
+def compute_transitions(
+    baseline_results: list[SampleResult],
+    compare_results: list[SampleResult],
+    matched_ids: set[str],
+) -> list[SessionTransition]:
+    """Compute verdict transitions for matched sessions.
+
+    Returns transitions sorted with regressions first, then improvements.
+    """
+    baseline_by_id = {
+        sample_result.sample.session.session_id: sample_result for sample_result in baseline_results
+    }
+    compare_by_id = {
+        sample_result.sample.session.session_id: sample_result for sample_result in compare_results
+    }
+
+    transitions: list[SessionTransition] = []
+
+    for session_id in matched_ids:
+        baseline_sample = baseline_by_id.get(session_id)
+        compare_sample = compare_by_id.get(session_id)
+        if baseline_sample is None or compare_sample is None:
+            continue
+
+        old_verdict = determine_verdict(baseline_sample.sample)
+        new_verdict = determine_verdict(compare_sample.sample)
+
+        if old_verdict == new_verdict:
+            continue
+
+        old_rank = _VERDICT_RANK[old_verdict]
+        new_rank = _VERDICT_RANK[new_verdict]
+
+        transition_type: Literal["improvement", "regression"] = (
+            "improvement" if new_rank > old_rank else "regression"
+        )
+
+        transitions.append(
+            SessionTransition(
+                session_id=session_id,
+                old_verdict=old_verdict,
+                new_verdict=new_verdict,
+                transition_type=transition_type,
+            )
+        )
+
+    # Sort: regressions first, then improvements
+    transitions.sort(key=lambda trans: 0 if trans.transition_type == "regression" else 1)
+    return transitions
+
+
+def generate_diff_report(baseline: EvalReport, compare: EvalReport) -> DiffReport:
+    """Generate a complete diff report from two evaluation reports.
+
+    Computes session matching, metric deltas, and verdict transitions.
+    """
+    match_result = match_sessions(baseline, compare)
+    deltas = compute_deltas(baseline.aggregate_scores, compare.aggregate_scores)
+
+    has_session_data = bool(baseline.sample_results and compare.sample_results)
+
+    if has_session_data:
+        transitions = compute_transitions(
+            baseline.sample_results,
+            compare.sample_results,
+            match_result.matched_ids,
+        )
+    else:
+        transitions = []
+
+    improvements = [trans for trans in transitions if trans.transition_type == "improvement"]
+    regressions = [trans for trans in transitions if trans.transition_type == "regression"]
+
+    return DiffReport(
+        baseline_run_id=baseline.run_id,
+        compare_run_id=compare.run_id,
+        match_result=match_result,
+        deltas=deltas,
+        improvements=improvements,
+        regressions=regressions,
+        has_session_data=has_session_data,
+    )

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -1,9 +1,11 @@
 """HTML report generation — self-contained dark-themed report with Jinja2."""
 
+from __future__ import annotations
+
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from raki.model.dataset import EvalSample
 from raki.model.report import EvalReport, SampleResult
@@ -12,6 +14,9 @@ from raki.report.cli_summary import (
     OPERATIONAL_METRICS,
     generate_summary_sentence,
 )
+
+if TYPE_CHECKING:
+    from raki.report.diff import DiffReport
 
 # Metric metadata registry — maps raw metric names to display properties.
 # This mirrors the class-level attributes from each Metric implementation
@@ -148,7 +153,7 @@ class DrillDownRow:
     sort_key: tuple[int, float]
 
 
-def _determine_verdict(sample: EvalSample) -> Literal["pass", "rework", "fail"]:
+def determine_verdict(sample: EvalSample) -> Literal["pass", "rework", "fail"]:
     """Determine the verdict for a session sample.
 
     Logic: failed phase -> fail, rework_cycles > 0 -> rework, else pass.
@@ -161,7 +166,7 @@ def _determine_verdict(sample: EvalSample) -> Literal["pass", "rework", "fail"]:
     return "pass"
 
 
-def _build_detail(sample: EvalSample) -> str:
+def build_detail(sample: EvalSample) -> str:
     """Build detail text for a drill-down row.
 
     - Failed phase: "<phase_name> failed"
@@ -205,8 +210,8 @@ def compute_drill_down_rows(
     for sample_result in sample_results:
         sample = sample_result.sample
         session_id = sample.session.session_id
-        verdict = _determine_verdict(sample)
-        detail = _build_detail(sample)
+        verdict = determine_verdict(sample)
+        detail = build_detail(sample)
 
         severity_counter: Counter[str] = Counter()
         for finding in sample.findings:
@@ -566,6 +571,72 @@ def write_html_report(
         needs_attention_rows=needs_attention_rows,
         needs_attention_count=needs_attention_count,
         format_duration=_format_duration,
+    )
+
+    output.write_text(html_content, encoding="utf-8")
+
+
+def write_diff_html_report(
+    diff: "DiffReport",
+    output: Path,
+) -> None:
+    """Render and write a self-contained HTML diff report.
+
+    All CSS is inlined — no external dependencies. Uses the same dark theme
+    CSS variables as the main report template.
+    """
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    match_result = diff.match_result
+    matched_count = len(match_result.matched_ids)
+    total_count = max(match_result.baseline_total, match_result.compare_total)
+    new_count = len(match_result.new_ids)
+    dropped_count = len(match_result.dropped_ids)
+
+    def format_display_name(metric_name: str) -> str:
+        meta = METRIC_METADATA.get(metric_name, {})
+        return str(meta.get("display_name", metric_name))
+
+    def format_value(value: float, metric_name: str) -> str:
+        meta = METRIC_METADATA.get(metric_name, {})
+        display_format = str(meta.get("display_format", "score"))
+        if display_format == "currency":
+            return f"${value:.2f}"
+        if display_format == "count":
+            return f"{value:.1f}"
+        if display_format == "percent":
+            return f"{value * 100:.0f}%"
+        return f"{value:.2f}"
+
+    def format_delta(delta: float, metric_name: str) -> str:
+        meta = METRIC_METADATA.get(metric_name, {})
+        display_format = str(meta.get("display_format", "score"))
+        sign = "+" if delta >= 0 else ""
+        if display_format == "currency":
+            if delta < 0:
+                return f"-${abs(delta):.2f}"
+            return f"{sign}${delta:.2f}"
+        if display_format == "count":
+            return f"{sign}{delta:.1f}"
+        if display_format == "percent":
+            return f"{sign}{delta * 100:.0f}%"
+        return f"{sign}{delta:.2f}"
+
+    env = _build_jinja_env()
+    template = env.get_template("diff.html.j2")
+
+    html_content = template.render(
+        diff=diff,
+        matched_count=matched_count,
+        total_count=total_count,
+        new_count=new_count,
+        dropped_count=dropped_count,
+        new_session_ids=sorted(match_result.new_ids),
+        dropped_session_ids=sorted(match_result.dropped_ids),
+        format_display_name=format_display_name,
+        format_value=format_value,
+        format_delta=format_delta,
     )
 
     output.write_text(html_content, encoding="utf-8")

--- a/src/raki/report/templates/diff.html.j2
+++ b/src/raki/report/templates/diff.html.j2
@@ -1,0 +1,482 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RAKI Diff Report &mdash; {{ diff.baseline_run_id }} vs {{ diff.compare_run_id }}</title>
+<style>
+  :root {
+    --bg-primary: #0f0f1a;
+    --bg-secondary: #1a1a2e;
+    --bg-tertiary: #252540;
+    --bg-card: #1e1e35;
+    --text-primary: #e0e0e8;
+    --text-secondary: #a0a0b8;
+    --text-muted: #6a6a80;
+    --border-color: #2e2e48;
+    --accent: #6c63ff;
+    --green: #4caf50;
+    --yellow: #ffc107;
+    --red: #f44336;
+    --white-metric: #b0b0c8;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    padding: 2rem;
+  }
+
+  .container {
+    max-width: 1000px;
+    margin: 0 auto;
+  }
+
+  header {
+    margin-bottom: 2rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  header h1 {
+    font-size: 1.8rem;
+    color: var(--text-primary);
+    margin-bottom: 0.5rem;
+  }
+
+  header .meta {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+
+  header .meta span {
+    margin-right: 1.5rem;
+  }
+
+  h2 {
+    font-size: 1.4rem;
+    margin: 1.5rem 0 1rem;
+    color: var(--text-primary);
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.5rem;
+  }
+
+  .coverage-line {
+    font-size: 1.1rem;
+    margin-bottom: 1rem;
+    color: var(--text-primary);
+  }
+
+  .coverage-line strong {
+    color: var(--accent);
+  }
+
+  .warning-banner {
+    background: rgba(255, 193, 7, 0.1);
+    border: 1px solid rgba(255, 193, 7, 0.3);
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.5rem;
+    color: var(--yellow);
+    font-size: 0.9rem;
+  }
+
+  .info-banner {
+    background: rgba(108, 99, 255, 0.1);
+    border: 1px solid rgba(108, 99, 255, 0.3);
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.5rem;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-style: italic;
+  }
+
+  /* Deltas table */
+  .deltas-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 2rem;
+  }
+
+  .deltas-table th,
+  .deltas-table td {
+    padding: 0.7rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .deltas-table th {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .deltas-table td {
+    color: var(--text-primary);
+    font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+    font-size: 0.95rem;
+  }
+
+  .deltas-table td.metric-name-cell {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-weight: 600;
+  }
+
+  .delta-improved { color: var(--green); }
+  .delta-regressed { color: var(--red); }
+  .delta-flat { color: var(--text-muted); }
+
+  .direction-indicator {
+    font-size: 1rem;
+    margin-left: 0.3rem;
+  }
+
+  /* Transition groups */
+  .transition-group {
+    margin-bottom: 1.5rem;
+  }
+
+  .transition-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .transition-count {
+    color: var(--text-muted);
+    font-weight: 400;
+    font-size: 0.9rem;
+  }
+
+  .transition-row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.5rem 1rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    margin-bottom: 0.4rem;
+    font-size: 0.9rem;
+  }
+
+  .transition-row.regression-row {
+    border-left: 3px solid var(--red);
+  }
+
+  .transition-row.improvement-row {
+    border-left: 3px solid var(--green);
+  }
+
+  .verdict-badge {
+    display: inline-block;
+    padding: 0.12rem 0.45rem;
+    border-radius: 3px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    flex-shrink: 0;
+  }
+
+  .verdict-badge-fail {
+    background: rgba(244, 67, 54, 0.2);
+    color: var(--red);
+  }
+
+  .verdict-badge-rework {
+    background: rgba(255, 193, 7, 0.2);
+    color: var(--yellow);
+  }
+
+  .verdict-badge-pass {
+    background: rgba(76, 175, 80, 0.15);
+    color: var(--green);
+  }
+
+  .session-id {
+    font-weight: 600;
+  }
+
+  .was-label {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+  }
+
+  .arrow {
+    color: var(--text-muted);
+  }
+
+  /* Collapsed sections */
+  details {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    margin-bottom: 0.75rem;
+    overflow: hidden;
+  }
+
+  summary {
+    padding: 0.8rem 1.2rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    font-weight: 600;
+    color: var(--text-primary);
+    user-select: none;
+    list-style: none;
+    gap: 0.6rem;
+  }
+
+  summary::-webkit-details-marker { display: none; }
+
+  summary::before {
+    content: "\25b6";
+    display: inline-block;
+    font-size: 0.7rem;
+    transition: transform 0.2s;
+    flex-shrink: 0;
+  }
+
+  details[open] > summary::before {
+    transform: rotate(90deg);
+  }
+
+  .collapsed-content {
+    padding: 0 1.2rem 1rem;
+  }
+
+  .collapsed-session-list {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.8;
+  }
+
+  /* Summary box */
+  .summary-box {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
+    font-size: 1rem;
+  }
+
+  .summary-stat {
+    display: inline-block;
+    margin-right: 2rem;
+    margin-bottom: 0.3rem;
+  }
+
+  .summary-stat .stat-value {
+    font-weight: 700;
+    color: var(--accent);
+  }
+
+  .empty-state {
+    color: var(--text-muted);
+    font-style: italic;
+    padding: 1rem 0;
+  }
+
+  footer {
+    margin-top: 3rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color);
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    text-align: center;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <header>
+    <h1>RAKI Diff Report</h1>
+    <div class="meta">
+      <span><strong>Baseline:</strong> {{ diff.baseline_run_id }}</span>
+      <span><strong>Compare:</strong> {{ diff.compare_run_id }}</span>
+    </div>
+  </header>
+
+  <main>
+  {# --- Coverage --- #}
+  <div class="coverage-line">
+    Matched: <strong>{{ matched_count }}/{{ total_count }}</strong> sessions
+    {% if new_count > 0 or dropped_count > 0 %}
+    ({% if new_count > 0 %}{{ new_count }} new{% endif %}{% if new_count > 0 and dropped_count > 0 %}, {% endif %}{% if dropped_count > 0 %}{{ dropped_count }} dropped{% endif %})
+    {% endif %}
+  </div>
+
+  {% if dropped_count > 0 or new_count > 0 %}
+  <div class="warning-banner">
+    &#9888;
+    {% if dropped_count > 0 %}{{ dropped_count }} sessions dropped{% endif %}{% if dropped_count > 0 and new_count > 0 %}, {% endif %}{% if new_count > 0 %}{{ new_count }} new{% endif %}
+    &mdash; aggregate deltas based on {{ matched_count }} matched sessions only
+  </div>
+  {% endif %}
+
+  {# --- Aggregate Deltas --- #}
+  <h2>Aggregate Deltas</h2>
+  {% if diff.deltas %}
+  <table class="deltas-table">
+    <thead>
+      <tr>
+        <th>Metric</th>
+        <th>Baseline</th>
+        <th>Compare</th>
+        <th>Delta</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for delta in diff.deltas %}
+      <tr>
+        <td class="metric-name-cell">{{ format_display_name(delta.name) }}</td>
+        <td>{{ format_value(delta.baseline_value, delta.name) }}</td>
+        <td>{{ format_value(delta.compare_value, delta.name) }}</td>
+        <td class="delta-{{ delta.direction }}">
+          {{ format_delta(delta.delta, delta.name) }}
+          <span class="direction-indicator">{% if delta.direction == "improved" %}&#9650;{% elif delta.direction == "regressed" %}&#9660;{% else %}={% endif %}</span>
+        </td>
+        <td></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="empty-state">No common metrics to compare.</p>
+  {% endif %}
+
+  {# --- Changed Sessions --- #}
+  <h2>Changed Sessions</h2>
+
+  {% if not diff.has_session_data %}
+  <div class="info-banner">
+    Per-session comparison unavailable &mdash; both reports must be generated with --include-sessions
+  </div>
+  {% else %}
+
+  {# --- Summary box --- #}
+  {% if diff.regressions or diff.improvements %}
+  <div class="summary-box">
+    {% if diff.improvements %}
+    <span class="summary-stat">
+      <span class="stat-value" style="color: var(--green);">{{ diff.improvements | length }}</span> improvement{{ "s" if diff.improvements | length != 1 else "" }}
+    </span>
+    {% endif %}
+    {% if diff.regressions %}
+    <span class="summary-stat">
+      <span class="stat-value" style="color: var(--red);">{{ diff.regressions | length }}</span> regression{{ "s" if diff.regressions | length != 1 else "" }}
+    </span>
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {# --- Regressions first --- #}
+  {% if diff.regressions %}
+  {% set regression_groups = {} %}
+  {% for trans in diff.regressions %}
+  {% set label = trans.old_verdict|upper ~ " → " ~ trans.new_verdict|upper %}
+  {% if label not in regression_groups %}
+  {% set _ = regression_groups.update({label: []}) %}
+  {% endif %}
+  {% set _ = regression_groups[label].append(trans) %}
+  {% endfor %}
+
+  {% for label, transitions in regression_groups.items() %}
+  <div class="transition-group">
+    <div class="transition-header">
+      <span style="color: var(--red);">{{ label }}</span>
+      <span class="transition-count">({{ transitions | length }} session{{ "s" if transitions | length != 1 else "" }})</span>
+    </div>
+    {% for trans in transitions %}
+    <div class="transition-row regression-row">
+      <span class="verdict-badge verdict-badge-{{ trans.new_verdict }}">{{ trans.new_verdict | upper }}</span>
+      <span class="session-id">{{ trans.session_id }}</span>
+      <span class="was-label">&mdash; was {{ trans.old_verdict | upper }}</span>
+    </div>
+    {% endfor %}
+  </div>
+  {% endfor %}
+  {% endif %}
+
+  {# --- Improvements --- #}
+  {% if diff.improvements %}
+  {% set improvement_groups = {} %}
+  {% for trans in diff.improvements %}
+  {% set label = trans.old_verdict|upper ~ " → " ~ trans.new_verdict|upper %}
+  {% if label not in improvement_groups %}
+  {% set _ = improvement_groups.update({label: []}) %}
+  {% endif %}
+  {% set _ = improvement_groups[label].append(trans) %}
+  {% endfor %}
+
+  {% for label, transitions in improvement_groups.items() %}
+  <div class="transition-group">
+    <div class="transition-header">
+      <span style="color: var(--green);">{{ label }}</span>
+      <span class="transition-count">({{ transitions | length }} session{{ "s" if transitions | length != 1 else "" }})</span>
+    </div>
+    {% for trans in transitions %}
+    <div class="transition-row improvement-row">
+      <span class="verdict-badge verdict-badge-{{ trans.new_verdict }}">{{ trans.new_verdict | upper }}</span>
+      <span class="session-id">{{ trans.session_id }}</span>
+      <span class="was-label">&mdash; was {{ trans.old_verdict | upper }}</span>
+    </div>
+    {% endfor %}
+  </div>
+  {% endfor %}
+  {% endif %}
+
+  {% if not diff.regressions and not diff.improvements %}
+  <p class="empty-state">No session verdict changes between runs.</p>
+  {% endif %}
+
+  {# --- New sessions (collapsed) --- #}
+  {% if new_session_ids %}
+  <details>
+    <summary>New sessions ({{ new_session_ids | length }})</summary>
+    <div class="collapsed-content">
+      <div class="collapsed-session-list">
+        {% for sid in new_session_ids %}
+        {{ sid }}{% if not loop.last %}<br>{% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </details>
+  {% endif %}
+
+  {# --- Dropped sessions (collapsed) --- #}
+  {% if dropped_session_ids %}
+  <details>
+    <summary>Dropped sessions ({{ dropped_session_ids | length }})</summary>
+    <div class="collapsed-content">
+      <div class="collapsed-session-list">
+        {% for sid in dropped_session_ids %}
+        {{ sid }}{% if not loop.last %}<br>{% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </details>
+  {% endif %}
+
+  {% endif %}
+  </main>
+
+  <footer>
+    Generated by RAKI &mdash; Retrieval Assessment for Knowledge Impact
+  </footer>
+</div>
+</body>
+</html>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,8 @@
-"""Tests for CLI commands: raki run, raki validate, raki adapters, raki report."""
+"""Tests for CLI commands: raki run, raki validate, raki adapters, raki report, raki report --diff."""
 
 import importlib.util
 import json
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -651,3 +652,225 @@ class TestCliReport:
         assert result.exit_code == 0
         # Should use display names from METRIC_METADATA, not raw metric keys
         assert "Verify rate" in result.output
+
+
+def _write_diff_report_json(
+    path: Path,
+    run_id: str = "eval-abc123",
+    aggregate_scores: dict | None = None,
+    include_sessions: bool = False,
+    session_ids: list[str] | None = None,
+    rework_cycles: int = 0,
+    verify_status: str = "completed",
+) -> None:
+    """Write a minimal EvalReport JSON file for diff testing."""
+    scores = aggregate_scores or {
+        "first_pass_verify_rate": 0.85,
+        "rework_cycles": 0.3,
+        "cost_efficiency": 7.50,
+    }
+    data = {
+        "run_id": run_id,
+        "timestamp": "2026-04-10T00:00:00Z",
+        "aggregate_scores": scores,
+        "sample_results": [],
+    }
+    if include_sessions and session_ids:
+        for session_id in session_ids:
+            verify_output = "PASS" if verify_status == "completed" else "FAIL"
+            data["sample_results"].append(
+                {
+                    "sample": {
+                        "session": {
+                            "session_id": session_id,
+                            "started_at": "2026-04-10T00:00:00Z",
+                            "total_phases": 3,
+                            "rework_cycles": rework_cycles,
+                            "total_cost_usd": 7.50,
+                        },
+                        "phases": [
+                            {
+                                "name": "implement",
+                                "generation": 1,
+                                "status": "completed",
+                                "output": "done",
+                            },
+                            {
+                                "name": "verify",
+                                "generation": 1,
+                                "status": verify_status,
+                                "output": verify_output,
+                            },
+                        ],
+                        "findings": [],
+                        "events": [],
+                    },
+                    "scores": [],
+                }
+            )
+    path.write_text(json.dumps(data, indent=2, default=str))
+
+
+class TestCliReportDiff:
+    def test_diff_produces_cli_summary(self, tmp_path):
+        """raki report --diff baseline.json compare.json produces CLI summary."""
+        baseline = tmp_path / "baseline.json"
+        compare = tmp_path / "compare.json"
+        _write_diff_report_json(
+            baseline,
+            run_id="eval-baseline",
+            aggregate_scores={"first_pass_verify_rate": 0.78, "rework_cycles": 1.2},
+        )
+        _write_diff_report_json(
+            compare,
+            run_id="eval-compare",
+            aggregate_scores={"first_pass_verify_rate": 0.91, "rework_cycles": 0.4},
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--diff", str(baseline), str(compare)])
+        assert result.exit_code == 0
+        assert "eval-baseline" in result.output
+        assert "eval-compare" in result.output
+
+    def test_diff_shows_coverage_line(self, tmp_path):
+        """Diff output shows session coverage line."""
+        baseline = tmp_path / "baseline.json"
+        compare = tmp_path / "compare.json"
+        _write_diff_report_json(
+            baseline,
+            run_id="base",
+            include_sessions=True,
+            session_ids=["session-101", "session-102"],
+        )
+        _write_diff_report_json(
+            compare,
+            run_id="comp",
+            include_sessions=True,
+            session_ids=["session-101", "session-200"],
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--diff", str(baseline), str(compare)])
+        assert result.exit_code == 0
+        assert "Matched" in result.output
+
+    def test_diff_exit_code_2_for_missing_file(self, tmp_path):
+        """Exit code 2 when baseline or compare file is missing."""
+        existing = tmp_path / "existing.json"
+        _write_diff_report_json(existing)
+        runner = CliRunner()
+        # Missing baseline
+        result = runner.invoke(
+            main, ["report", "--diff", str(tmp_path / "nope.json"), str(existing)]
+        )
+        assert result.exit_code == 2
+        # Missing compare
+        result = runner.invoke(
+            main, ["report", "--diff", str(existing), str(tmp_path / "nope.json")]
+        )
+        assert result.exit_code == 2
+
+    def test_diff_warns_no_session_data(self, tmp_path):
+        """Warning when either report lacks session data."""
+        baseline = tmp_path / "baseline.json"
+        compare = tmp_path / "compare.json"
+        _write_diff_report_json(baseline, run_id="base")
+        _write_diff_report_json(compare, run_id="comp")
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--diff", str(baseline), str(compare)])
+        assert result.exit_code == 0
+        assert "include-sessions" in result.output.lower() or "unavailable" in result.output.lower()
+
+    def test_diff_shows_direction_indicators(self, tmp_path):
+        """Diff shows direction indicators for metric changes."""
+        baseline = tmp_path / "baseline.json"
+        compare = tmp_path / "compare.json"
+        _write_diff_report_json(
+            baseline,
+            run_id="base",
+            aggregate_scores={"first_pass_verify_rate": 0.78},
+        )
+        _write_diff_report_json(
+            compare,
+            run_id="comp",
+            aggregate_scores={"first_pass_verify_rate": 0.91},
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--diff", str(baseline), str(compare)])
+        assert result.exit_code == 0
+        # Should contain an indicator (green or ▲)
+        assert "▲" in result.output or "improved" in result.output.lower()
+
+    def test_diff_warning_banner_when_sessions_dropped(self, tmp_path):
+        """Warning banner when sessions are dropped or added."""
+        baseline = tmp_path / "baseline.json"
+        compare = tmp_path / "compare.json"
+        _write_diff_report_json(
+            baseline,
+            run_id="base",
+            include_sessions=True,
+            session_ids=["session-101", "session-102", "session-103"],
+        )
+        _write_diff_report_json(
+            compare,
+            run_id="comp",
+            include_sessions=True,
+            session_ids=["session-101"],
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--diff", str(baseline), str(compare)])
+        assert result.exit_code == 0
+        assert "dropped" in result.output.lower()
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("jinja2"),
+        reason="jinja2 not installed",
+    )
+    def test_diff_generates_html(self, tmp_path):
+        """raki report --diff --html produces an HTML diff report."""
+        baseline = tmp_path / "baseline.json"
+        compare = tmp_path / "compare.json"
+        html_out = tmp_path / "diff.html"
+        _write_diff_report_json(
+            baseline,
+            run_id="eval-base",
+            aggregate_scores={"first_pass_verify_rate": 0.78},
+        )
+        _write_diff_report_json(
+            compare,
+            run_id="eval-comp",
+            aggregate_scores={"first_pass_verify_rate": 0.91},
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["report", "--diff", str(baseline), str(compare), "--html", str(html_out)],
+        )
+        assert result.exit_code == 0
+        assert html_out.exists()
+        content = html_out.read_text()
+        assert "<html" in content.lower()
+        assert "eval-base" in content
+        assert "eval-comp" in content
+
+    def test_diff_changed_sessions_grouped(self, tmp_path):
+        """Changed sessions are grouped by transition type."""
+        baseline = tmp_path / "baseline.json"
+        compare = tmp_path / "compare.json"
+        _write_diff_report_json(
+            baseline,
+            run_id="base",
+            include_sessions=True,
+            session_ids=["session-101"],
+            verify_status="failed",
+        )
+        _write_diff_report_json(
+            compare,
+            run_id="comp",
+            include_sessions=True,
+            session_ids=["session-101"],
+            verify_status="completed",
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--diff", str(baseline), str(compare)])
+        assert result.exit_code == 0
+        assert "Improvement" in result.output or "improvement" in result.output.lower()

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -490,6 +490,10 @@ class TestPrintDiffSummary:
         assert "green" in output.lower() or "▲" in output
 
 
+@pytest.mark.skipif(
+    not __import__("importlib").util.find_spec("jinja2"),
+    reason="jinja2 not installed",
+)
 class TestWriteDiffHtmlReport:
     def test_generates_html_file(self, tmp_path):
         diff = DiffReport(

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,599 @@
+"""Tests for diff module — session matching, delta computation, transition grouping."""
+
+from datetime import datetime, timezone
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from raki.model.report import EvalReport, MetricResult, SampleResult
+from raki.report.cli_summary import print_diff_summary
+from raki.report.diff import (
+    DiffReport,
+    MatchResult,
+    MetricDelta,
+    SessionTransition,
+    compute_deltas,
+    compute_transitions,
+    generate_diff_report,
+    match_sessions,
+)
+
+from tests.conftest import make_sample
+
+
+def _make_eval_report(
+    run_id: str,
+    aggregate_scores: dict[str, float],
+    sample_results: list[SampleResult] | None = None,
+) -> EvalReport:
+    """Create a minimal EvalReport for diff testing."""
+    return EvalReport(
+        run_id=run_id,
+        timestamp=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        aggregate_scores=aggregate_scores,
+        sample_results=sample_results or [],
+    )
+
+
+def _make_sample_result(
+    session_id: str,
+    rework_cycles: int = 0,
+    cost: float = 10.0,
+    verify_status: str = "completed",
+    scores: dict[str, float] | None = None,
+) -> SampleResult:
+    """Create a SampleResult for diff testing."""
+    sample = make_sample(
+        session_id=session_id,
+        rework_cycles=rework_cycles,
+        cost=cost,
+        verify_status=verify_status,
+    )
+    metric_results = []
+    if scores:
+        for metric_name, score_value in scores.items():
+            metric_results.append(
+                MetricResult(
+                    name=metric_name,
+                    score=score_value,
+                    sample_scores={session_id: score_value},
+                )
+            )
+    return SampleResult(sample=sample, scores=metric_results)
+
+
+class TestMatchSessions:
+    def test_all_sessions_match(self):
+        baseline = _make_eval_report(
+            "base",
+            {},
+            [
+                _make_sample_result("session-101"),
+                _make_sample_result("session-102"),
+            ],
+        )
+        compare = _make_eval_report(
+            "comp",
+            {},
+            [
+                _make_sample_result("session-101"),
+                _make_sample_result("session-102"),
+            ],
+        )
+        result = match_sessions(baseline, compare)
+        assert isinstance(result, MatchResult)
+        assert result.matched_ids == {"session-101", "session-102"}
+        assert result.new_ids == set()
+        assert result.dropped_ids == set()
+
+    def test_new_sessions_in_compare(self):
+        baseline = _make_eval_report("base", {}, [_make_sample_result("session-101")])
+        compare = _make_eval_report(
+            "comp",
+            {},
+            [
+                _make_sample_result("session-101"),
+                _make_sample_result("session-200"),
+            ],
+        )
+        result = match_sessions(baseline, compare)
+        assert result.matched_ids == {"session-101"}
+        assert result.new_ids == {"session-200"}
+        assert result.dropped_ids == set()
+
+    def test_dropped_sessions_in_baseline(self):
+        baseline = _make_eval_report(
+            "base",
+            {},
+            [
+                _make_sample_result("session-101"),
+                _make_sample_result("session-102"),
+            ],
+        )
+        compare = _make_eval_report("comp", {}, [_make_sample_result("session-101")])
+        result = match_sessions(baseline, compare)
+        assert result.matched_ids == {"session-101"}
+        assert result.new_ids == set()
+        assert result.dropped_ids == {"session-102"}
+
+    def test_empty_reports_match_nothing(self):
+        baseline = _make_eval_report("base", {})
+        compare = _make_eval_report("comp", {})
+        result = match_sessions(baseline, compare)
+        assert result.matched_ids == set()
+        assert result.new_ids == set()
+        assert result.dropped_ids == set()
+
+    def test_disjoint_sessions(self):
+        baseline = _make_eval_report("base", {}, [_make_sample_result("session-101")])
+        compare = _make_eval_report("comp", {}, [_make_sample_result("session-200")])
+        result = match_sessions(baseline, compare)
+        assert result.matched_ids == set()
+        assert result.new_ids == {"session-200"}
+        assert result.dropped_ids == {"session-101"}
+
+    def test_counts_property(self):
+        baseline = _make_eval_report(
+            "base",
+            {},
+            [
+                _make_sample_result("session-101"),
+                _make_sample_result("session-102"),
+                _make_sample_result("session-103"),
+            ],
+        )
+        compare = _make_eval_report(
+            "comp",
+            {},
+            [
+                _make_sample_result("session-101"),
+                _make_sample_result("session-200"),
+            ],
+        )
+        result = match_sessions(baseline, compare)
+        assert result.baseline_total == 3
+        assert result.compare_total == 2
+        assert len(result.matched_ids) == 1
+        assert len(result.new_ids) == 1
+        assert len(result.dropped_ids) == 2
+
+
+class TestComputeDeltas:
+    def test_higher_is_better_improvement(self):
+        baseline_scores = {"first_pass_verify_rate": 0.78}
+        compare_scores = {"first_pass_verify_rate": 0.91}
+        deltas = compute_deltas(baseline_scores, compare_scores)
+        assert len(deltas) == 1
+        delta = deltas[0]
+        assert delta.name == "first_pass_verify_rate"
+        assert delta.baseline_value == pytest.approx(0.78)
+        assert delta.compare_value == pytest.approx(0.91)
+        assert delta.delta == pytest.approx(0.13)
+        assert delta.direction == "improved"
+
+    def test_higher_is_better_regression(self):
+        baseline_scores = {"first_pass_verify_rate": 0.91}
+        compare_scores = {"first_pass_verify_rate": 0.78}
+        deltas = compute_deltas(baseline_scores, compare_scores)
+        assert deltas[0].direction == "regressed"
+
+    def test_lower_is_better_improvement(self):
+        """Rework cycles: lower is better, so decrease = improvement."""
+        baseline_scores = {"rework_cycles": 1.2}
+        compare_scores = {"rework_cycles": 0.4}
+        deltas = compute_deltas(baseline_scores, compare_scores)
+        delta = deltas[0]
+        assert delta.delta == pytest.approx(-0.8)
+        assert delta.direction == "improved"
+
+    def test_lower_is_better_regression(self):
+        """Rework cycles: lower is better, so increase = regression."""
+        baseline_scores = {"rework_cycles": 0.4}
+        compare_scores = {"rework_cycles": 1.2}
+        deltas = compute_deltas(baseline_scores, compare_scores)
+        assert deltas[0].direction == "regressed"
+
+    def test_flat_delta(self):
+        baseline_scores = {"first_pass_verify_rate": 0.85}
+        compare_scores = {"first_pass_verify_rate": 0.85}
+        deltas = compute_deltas(baseline_scores, compare_scores)
+        assert deltas[0].direction == "flat"
+        assert deltas[0].delta == pytest.approx(0.0)
+
+    def test_multiple_metrics(self):
+        baseline_scores = {
+            "first_pass_verify_rate": 0.78,
+            "rework_cycles": 1.2,
+            "cost_efficiency": 12.30,
+        }
+        compare_scores = {
+            "first_pass_verify_rate": 0.91,
+            "rework_cycles": 0.4,
+            "cost_efficiency": 7.42,
+        }
+        deltas = compute_deltas(baseline_scores, compare_scores)
+        assert len(deltas) == 3
+        delta_names = {delta.name for delta in deltas}
+        assert "first_pass_verify_rate" in delta_names
+        assert "rework_cycles" in delta_names
+        assert "cost_efficiency" in delta_names
+
+    def test_metric_only_in_baseline_skipped(self):
+        baseline_scores = {"first_pass_verify_rate": 0.78, "context_precision": 0.90}
+        compare_scores = {"first_pass_verify_rate": 0.91}
+        deltas = compute_deltas(baseline_scores, compare_scores)
+        delta_names = {delta.name for delta in deltas}
+        assert "first_pass_verify_rate" in delta_names
+        # context_precision is only in baseline, should be skipped
+        assert "context_precision" not in delta_names
+
+    def test_metric_only_in_compare_skipped(self):
+        baseline_scores = {"first_pass_verify_rate": 0.78}
+        compare_scores = {"first_pass_verify_rate": 0.91, "context_precision": 0.90}
+        deltas = compute_deltas(baseline_scores, compare_scores)
+        delta_names = {delta.name for delta in deltas}
+        assert "first_pass_verify_rate" in delta_names
+        assert "context_precision" not in delta_names
+
+
+class TestComputeTransitions:
+    def test_pass_to_fail_is_regression(self):
+        baseline_results = [_make_sample_result("session-101", verify_status="completed")]
+        compare_results = [_make_sample_result("session-101", verify_status="failed")]
+        matched_ids = {"session-101"}
+        transitions = compute_transitions(baseline_results, compare_results, matched_ids)
+        assert len(transitions) == 1
+        assert transitions[0].session_id == "session-101"
+        assert transitions[0].old_verdict == "pass"
+        assert transitions[0].new_verdict == "fail"
+        assert transitions[0].transition_type == "regression"
+
+    def test_fail_to_pass_is_improvement(self):
+        baseline_results = [_make_sample_result("session-101", verify_status="failed")]
+        compare_results = [_make_sample_result("session-101", verify_status="completed")]
+        matched_ids = {"session-101"}
+        transitions = compute_transitions(baseline_results, compare_results, matched_ids)
+        assert len(transitions) == 1
+        assert transitions[0].transition_type == "improvement"
+
+    def test_rework_to_pass_is_improvement(self):
+        baseline_results = [_make_sample_result("session-101", rework_cycles=2)]
+        compare_results = [_make_sample_result("session-101", rework_cycles=0)]
+        matched_ids = {"session-101"}
+        transitions = compute_transitions(baseline_results, compare_results, matched_ids)
+        assert len(transitions) == 1
+        assert transitions[0].old_verdict == "rework"
+        assert transitions[0].new_verdict == "pass"
+        assert transitions[0].transition_type == "improvement"
+
+    def test_pass_to_rework_is_regression(self):
+        baseline_results = [_make_sample_result("session-101", rework_cycles=0)]
+        compare_results = [_make_sample_result("session-101", rework_cycles=2)]
+        matched_ids = {"session-101"}
+        transitions = compute_transitions(baseline_results, compare_results, matched_ids)
+        assert len(transitions) == 1
+        assert transitions[0].transition_type == "regression"
+
+    def test_same_verdict_no_transition(self):
+        baseline_results = [_make_sample_result("session-101")]
+        compare_results = [_make_sample_result("session-101")]
+        matched_ids = {"session-101"}
+        transitions = compute_transitions(baseline_results, compare_results, matched_ids)
+        assert len(transitions) == 0
+
+    def test_unmatched_sessions_excluded(self):
+        baseline_results = [
+            _make_sample_result("session-101"),
+            _make_sample_result("session-200"),
+        ]
+        compare_results = [
+            _make_sample_result("session-101"),
+            _make_sample_result("session-300"),
+        ]
+        matched_ids = {"session-101"}
+        transitions = compute_transitions(baseline_results, compare_results, matched_ids)
+        # session-101 is pass->pass (no change), others not matched
+        assert len(transitions) == 0
+
+    def test_multiple_transitions_sorted_regressions_first(self):
+        baseline_results = [
+            _make_sample_result("session-101", verify_status="completed"),
+            _make_sample_result("session-102", verify_status="failed"),
+        ]
+        compare_results = [
+            _make_sample_result("session-101", verify_status="failed"),
+            _make_sample_result("session-102", verify_status="completed"),
+        ]
+        matched_ids = {"session-101", "session-102"}
+        transitions = compute_transitions(baseline_results, compare_results, matched_ids)
+        assert len(transitions) == 2
+        # Regressions should come first
+        assert transitions[0].transition_type == "regression"
+        assert transitions[1].transition_type == "improvement"
+
+
+class TestGenerateDiffReport:
+    def test_produces_diff_report(self):
+        baseline = _make_eval_report(
+            "eval-abc123",
+            {"first_pass_verify_rate": 0.78, "rework_cycles": 1.2},
+            [_make_sample_result("session-101")],
+        )
+        compare = _make_eval_report(
+            "eval-def456",
+            {"first_pass_verify_rate": 0.91, "rework_cycles": 0.4},
+            [_make_sample_result("session-101")],
+        )
+        diff = generate_diff_report(baseline, compare)
+        assert isinstance(diff, DiffReport)
+        assert diff.baseline_run_id == "eval-abc123"
+        assert diff.compare_run_id == "eval-def456"
+        assert isinstance(diff.match_result, MatchResult)
+        assert len(diff.deltas) == 2
+
+    def test_diff_report_with_transitions(self):
+        baseline = _make_eval_report(
+            "base",
+            {"first_pass_verify_rate": 0.50},
+            [_make_sample_result("session-101", verify_status="failed")],
+        )
+        compare = _make_eval_report(
+            "comp",
+            {"first_pass_verify_rate": 1.0},
+            [_make_sample_result("session-101", verify_status="completed")],
+        )
+        diff = generate_diff_report(baseline, compare)
+        assert len(diff.improvements) == 1
+        assert len(diff.regressions) == 0
+
+    def test_diff_report_empty_sample_results(self):
+        """Diff should still work with aggregate-only reports (no sample_results)."""
+        baseline = _make_eval_report("base", {"first_pass_verify_rate": 0.78})
+        compare = _make_eval_report("comp", {"first_pass_verify_rate": 0.91})
+        diff = generate_diff_report(baseline, compare)
+        assert len(diff.deltas) == 1
+        assert len(diff.improvements) == 0
+        assert len(diff.regressions) == 0
+        assert diff.has_session_data is False
+
+
+class TestPrintDiffSummary:
+    def _capture_diff_output(self, diff: DiffReport) -> str:
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=False, width=120)
+        print_diff_summary(diff, console=test_console)
+        return string_io.getvalue()
+
+    def test_shows_comparing_header(self):
+        diff = DiffReport(
+            baseline_run_id="eval-abc123",
+            compare_run_id="eval-def456",
+            match_result=MatchResult(
+                matched_ids={"session-101"},
+                baseline_total=1,
+                compare_total=1,
+            ),
+        )
+        output = self._capture_diff_output(diff)
+        assert "eval-abc123" in output
+        assert "eval-def456" in output
+
+    def test_shows_coverage_line(self):
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(
+                matched_ids={"s1", "s2"},
+                new_ids={"s3"},
+                dropped_ids={"s4"},
+                baseline_total=3,
+                compare_total=3,
+            ),
+        )
+        output = self._capture_diff_output(diff)
+        assert "2" in output  # matched count
+        assert "new" in output.lower()
+        assert "dropped" in output.lower()
+
+    def test_shows_metric_deltas(self):
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(matched_ids={"s1"}, baseline_total=1, compare_total=1),
+            deltas=[
+                MetricDelta(
+                    name="first_pass_verify_rate",
+                    baseline_value=0.78,
+                    compare_value=0.91,
+                    delta=0.13,
+                    direction="improved",
+                ),
+            ],
+        )
+        output = self._capture_diff_output(diff)
+        # Display format for verify rate is "percent", so values show as 78%, 91%
+        assert "78%" in output
+        assert "91%" in output
+        assert "+13%" in output
+
+    def test_shows_improvement_regression_counts(self):
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(matched_ids={"s1", "s2"}, baseline_total=2, compare_total=2),
+            improvements=[
+                SessionTransition(
+                    session_id="s1",
+                    old_verdict="rework",
+                    new_verdict="pass",
+                    transition_type="improvement",
+                ),
+            ],
+            regressions=[
+                SessionTransition(
+                    session_id="s2",
+                    old_verdict="pass",
+                    new_verdict="fail",
+                    transition_type="regression",
+                ),
+            ],
+        )
+        output = self._capture_diff_output(diff)
+        assert "improvement" in output.lower() or "Improvement" in output
+        assert "regression" in output.lower() or "Regression" in output
+
+    def test_warning_when_sessions_dropped_or_added(self):
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(
+                matched_ids={"s1"},
+                new_ids={"s2", "s3"},
+                dropped_ids={"s4"},
+                baseline_total=2,
+                compare_total=3,
+            ),
+        )
+        output = self._capture_diff_output(diff)
+        # Should contain a warning about dropped/new sessions
+        assert "dropped" in output.lower()
+        assert "new" in output.lower()
+
+    def test_no_session_data_warning(self):
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(),
+            has_session_data=False,
+        )
+        output = self._capture_diff_output(diff)
+        assert "include-sessions" in output.lower() or "unavailable" in output.lower()
+
+    def test_direction_indicator_for_improved(self):
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(matched_ids={"s1"}, baseline_total=1, compare_total=1),
+            deltas=[
+                MetricDelta(
+                    name="first_pass_verify_rate",
+                    baseline_value=0.78,
+                    compare_value=0.91,
+                    delta=0.13,
+                    direction="improved",
+                ),
+            ],
+        )
+        output = self._capture_diff_output(diff)
+        # Should have a green direction indicator
+        assert "green" in output.lower() or "▲" in output
+
+
+class TestWriteDiffHtmlReport:
+    def test_generates_html_file(self, tmp_path):
+        diff = DiffReport(
+            baseline_run_id="eval-base",
+            compare_run_id="eval-comp",
+            match_result=MatchResult(
+                matched_ids={"s1"},
+                baseline_total=1,
+                compare_total=1,
+            ),
+            deltas=[
+                MetricDelta(
+                    name="first_pass_verify_rate",
+                    baseline_value=0.78,
+                    compare_value=0.91,
+                    delta=0.13,
+                    direction="improved",
+                ),
+            ],
+        )
+        from raki.report.html_report import write_diff_html_report
+
+        html_path = tmp_path / "diff.html"
+        write_diff_html_report(diff, html_path)
+        assert html_path.exists()
+        content = html_path.read_text()
+        assert "<html" in content.lower()
+        assert "eval-base" in content
+        assert "eval-comp" in content
+
+    def test_html_contains_dark_theme_vars(self, tmp_path):
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(),
+        )
+        from raki.report.html_report import write_diff_html_report
+
+        html_path = tmp_path / "diff.html"
+        write_diff_html_report(diff, html_path)
+        content = html_path.read_text()
+        assert "--bg-primary" in content
+        assert "--bg-secondary" in content
+
+    def test_html_contains_transitions(self, tmp_path):
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(
+                matched_ids={"s1"},
+                baseline_total=1,
+                compare_total=1,
+            ),
+            regressions=[
+                SessionTransition(
+                    session_id="s1",
+                    old_verdict="pass",
+                    new_verdict="fail",
+                    transition_type="regression",
+                ),
+            ],
+        )
+        from raki.report.html_report import write_diff_html_report
+
+        html_path = tmp_path / "diff.html"
+        write_diff_html_report(diff, html_path)
+        content = html_path.read_text()
+        assert "s1" in content
+        assert "PASS" in content
+        assert "FAIL" in content
+
+    def test_html_contains_new_and_dropped(self, tmp_path):
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(
+                matched_ids={"s1"},
+                new_ids={"s2"},
+                dropped_ids={"s3"},
+                baseline_total=2,
+                compare_total=2,
+            ),
+        )
+        from raki.report.html_report import write_diff_html_report
+
+        html_path = tmp_path / "diff.html"
+        write_diff_html_report(diff, html_path)
+        content = html_path.read_text()
+        assert "s2" in content  # new session
+        assert "s3" in content  # dropped session
+        assert "dropped" in content.lower()
+
+
+class TestMetricDeltaDirection:
+    def test_cost_efficiency_decrease_is_improved(self):
+        """Cost efficiency: lower is better (it's not in higher_is_better)."""
+        baseline_scores = {"cost_efficiency": 12.30}
+        compare_scores = {"cost_efficiency": 7.42}
+        deltas = compute_deltas(baseline_scores, compare_scores)
+        # cost_efficiency has higher_is_better=False in metadata
+        assert deltas[0].direction == "improved"
+
+    def test_unknown_metric_defaults_to_higher_is_better(self):
+        baseline_scores = {"some_new_metric": 0.5}
+        compare_scores = {"some_new_metric": 0.7}
+        deltas = compute_deltas(baseline_scores, compare_scores)
+        assert deltas[0].direction == "improved"

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -1522,62 +1522,62 @@ class TestDrillDownRowDataclass:
 
 
 class TestDetermineVerdict:
-    """_determine_verdict: failed phase -> fail, rework_cycles > 0 -> rework, else pass."""
+    """determine_verdict: failed phase -> fail, rework_cycles > 0 -> rework, else pass."""
 
     def test_fail_when_phase_failed(self) -> None:
         """Session with a failed phase should have verdict 'fail'."""
-        from raki.report.html_report import _determine_verdict
+        from raki.report.html_report import determine_verdict
 
         sample = make_sample("s1", verify_status="failed")
-        assert _determine_verdict(sample) == "fail"
+        assert determine_verdict(sample) == "fail"
 
     def test_rework_when_cycles_positive(self) -> None:
         """Session with rework_cycles > 0 but no failed phase should have verdict 'rework'."""
-        from raki.report.html_report import _determine_verdict
+        from raki.report.html_report import determine_verdict
 
         sample = make_sample("s1", rework_cycles=2, verify_status="completed")
-        assert _determine_verdict(sample) == "rework"
+        assert determine_verdict(sample) == "rework"
 
     def test_pass_when_clean(self) -> None:
         """Session with no failed phases and 0 rework_cycles should have verdict 'pass'."""
-        from raki.report.html_report import _determine_verdict
+        from raki.report.html_report import determine_verdict
 
         sample = make_sample("s1", rework_cycles=0, verify_status="completed")
-        assert _determine_verdict(sample) == "pass"
+        assert determine_verdict(sample) == "pass"
 
     def test_fail_takes_precedence_over_rework(self) -> None:
         """When both failed phase and rework_cycles > 0, verdict should be 'fail'."""
-        from raki.report.html_report import _determine_verdict
+        from raki.report.html_report import determine_verdict
 
         sample = make_sample("s1", rework_cycles=2, verify_status="failed")
-        assert _determine_verdict(sample) == "fail"
+        assert determine_verdict(sample) == "fail"
 
 
 class TestBuildDetail:
-    """_build_detail: "implement failed" / "2 cycles" / "5 phases"."""
+    """build_detail: "implement failed" / "2 cycles" / "5 phases"."""
 
     def test_detail_for_fail(self) -> None:
         """When a phase fails, detail should name the failed phase."""
-        from raki.report.html_report import _build_detail
+        from raki.report.html_report import build_detail
 
         sample = make_sample("s1", verify_status="failed")
-        detail = _build_detail(sample)
+        detail = build_detail(sample)
         assert "verify failed" in detail
 
     def test_detail_for_rework(self) -> None:
         """When rework_cycles > 0 and no failure, detail should show cycle count."""
-        from raki.report.html_report import _build_detail
+        from raki.report.html_report import build_detail
 
         sample = make_sample("s1", rework_cycles=2, verify_status="completed")
-        detail = _build_detail(sample)
+        detail = build_detail(sample)
         assert "2 cycles" in detail
 
     def test_detail_for_pass(self) -> None:
         """When clean pass, detail should show phase count."""
-        from raki.report.html_report import _build_detail
+        from raki.report.html_report import build_detail
 
         sample = make_sample("s1", rework_cycles=0, verify_status="completed")
-        detail = _build_detail(sample)
+        detail = build_detail(sample)
         assert "phases" in detail
 
 


### PR DESCRIPTION
## Summary
- Add `raki report --diff baseline.json compare.json` with session matching, aggregate metric deltas, and session transition tracking
- CLI summary: coverage line, delta table with direction indicators, transition counts
- HTML diff report: self-contained dark theme with delta table, regressions-first session transitions
- Sanitized `run_id` in output filenames to prevent path traversal
- Updated getting-started.md and interpreting-results.md with diff usage and "Comparing Runs" section

Refs #71

## Review
- Python Specialist: findings pre-addressed by implementation (currency formatting, typed params, public API)
- Security Specialist: 1 finding fixed (path traversal via run_id), session data exposure confirmed safe by design
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko