### PR TITLE
fix(cli): wire ground truth matching into run and validate

### DIFF
--- a/docs/curation-guide.md
+++ b/docs/curation-guide.md
@@ -107,6 +107,20 @@ Problems: the question is too vague to discriminate retrieval quality, the conte
 
 This works because it requires synthesizing knowledge across notifications, auth, and rate limiting -- three separate domains. The contexts each capture a distinct required piece.
 
+## How Matching Works
+
+RAKI matches ground truth entries to sessions using domain-token overlap. During evaluation, each session's triage phase `output_structured["code_area"]` field is split into domain tokens. These tokens are compared against the `domains` list in each ground truth entry. The entry with the highest overlap is assigned to the session.
+
+**Important:** Sessions without a triage phase or without a `code_area` field in their structured output will not match any ground truth entry. If you see a low match rate (below 50%), check that your sessions include triage phases with `code_area` populated.
+
+You can verify match rates before running a full evaluation:
+
+```bash
+raki validate -m raki.yaml
+```
+
+The validate command shows a ground truth match preview when `ground_truth.path` is configured in your manifest.
+
 ## Further Reading
 
 - [`examples/ground-truth/curated.yaml`](../examples/ground-truth/curated.yaml) -- five fully annotated entries covering all difficulty levels and knowledge types

--- a/docs/interpretation-reference.md
+++ b/docs/interpretation-reference.md
@@ -71,6 +71,8 @@ Fraction of rework-triggering findings where the relevant knowledge was not in t
 
 These metrics use LLM-backed evaluation via Ragas and require ground truth data.
 
+> **Note:** Retrieval quality metrics require ground truth to be configured and matched. If `ground_truth.path` is not set in your manifest, or if sessions do not match any ground truth entries, these metrics will produce 0.0 scores. Run `raki validate` to check your ground truth match rate.
+
 ### context_precision -- Context precision
 
 Fraction of retrieved contexts that are actually relevant to the question (higher is better).

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -200,6 +200,35 @@ def run(
             f"({len(loader.skipped)} skipped, {len(loader.errors)} errors)"
         )
 
+    # Wire ground truth matching when configured
+    if manifest.ground_truth.path is not None:
+        try:
+            from raki.ground_truth.matcher import load_ground_truth, match_ground_truth
+
+            gt_entries = load_ground_truth(manifest.ground_truth.path)
+            matched_count = 0
+            for sample in dataset.samples:
+                match = match_ground_truth(sample, gt_entries)
+                if match is not None:
+                    sample.ground_truth = match
+                    matched_count += 1
+            if not quiet:
+                out.print(
+                    f"Matched ground truth for "
+                    f"[bold]{matched_count}/{len(dataset.samples)}[/bold] sessions"
+                )
+                if len(dataset.samples) > 0 and matched_count / len(dataset.samples) < 0.5:
+                    out.print(
+                        "[yellow]Warning: Low match rate — ground truth matching relies on "
+                        'output_structured["code_area"] in triage phases. Sessions without '
+                        "a triage phase or using a different schema will not match.[/yellow]"
+                    )
+        except Exception as exc:
+            out.print(
+                f"[yellow]Warning: Failed to load ground truth: "
+                f"{redact_sensitive(str(exc))}. Continuing without ground truth.[/yellow]"
+            )
+
     from raki.metrics import MetricsEngine
     from raki.metrics.operational import ALL_OPERATIONAL
     from raki.metrics.protocol import Metric, MetricConfig
@@ -326,6 +355,27 @@ def validate(manifest_path: str | None, quiet: bool, verbose: bool) -> None:
     dataset = loader.load_directory(manifest.sessions.path)
 
     console.print(f"[green]\u2713[/green] {len(dataset.samples)} sessions loaded")
+
+    # Report ground truth status when configured
+    if manifest.ground_truth.path is not None:
+        try:
+            from raki.ground_truth.matcher import load_ground_truth, match_ground_truth
+
+            gt_entries = load_ground_truth(manifest.ground_truth.path)
+            console.print(f"[green]\u2713[/green] {len(gt_entries)} ground truth entries loaded")
+            preview_matched = sum(
+                1
+                for sample in dataset.samples
+                if match_ground_truth(sample, gt_entries) is not None
+            )
+            console.print(
+                f"[green]\u2713[/green] Ground truth match preview: "
+                f"{preview_matched}/{len(dataset.samples)} sessions"
+            )
+        except Exception as exc:
+            console.print(
+                f"[yellow]\u26a0[/yellow] Failed to load ground truth: {redact_sensitive(str(exc))}"
+            )
 
     if loader.skipped:
         console.print(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,30 @@ def manifest_with_session(tmp_path: Path, pass_simple_dir: Path) -> tuple[Path, 
 
 
 @pytest.fixture
+def manifest_with_ground_truth(tmp_path: Path, pass_simple_dir: Path) -> tuple[Path, Path, Path]:
+    """Create a tmp_path with a manifest, sessions, and a ground truth YAML.
+
+    Returns:
+        Tuple of (manifest_path, sessions_directory, ground_truth_path).
+    """
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    session_dest = sessions / "101"
+    session_dest.mkdir()
+    for file_path in pass_simple_dir.iterdir():
+        (session_dest / file_path.name).write_text(file_path.read_text())
+    ground_truth = tmp_path / "curated.yaml"
+    ground_truth.write_text(
+        "- question: test question\n  expected_approach: test approach\n  domains:\n    - testing\n"
+    )
+    manifest = tmp_path / "raki.yaml"
+    manifest.write_text(
+        f"sessions:\n  path: {sessions}\n  format: auto\nground_truth:\n  path: {ground_truth}\n"
+    )
+    return manifest, sessions, ground_truth
+
+
+@pytest.fixture
 def empty_manifest(tmp_path: Path) -> Path:
     """Create a tmp_path with a manifest pointing to an empty sessions directory.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -711,6 +711,125 @@ def _write_diff_report_json(
     path.write_text(json.dumps(data, indent=2, default=str))
 
 
+class TestGroundTruthWiring:
+    def test_run_loads_ground_truth_when_configured(self, manifest_with_ground_truth):
+        """run() should succeed when manifest has ground_truth.path set."""
+        manifest_path, _sessions, _gt = manifest_with_ground_truth
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "-m", str(manifest_path), "--no-llm", "-q"])
+        assert result.exit_code == 0
+
+    def test_run_logs_match_count(self, manifest_with_ground_truth):
+        """run() should log how many sessions matched ground truth."""
+        manifest_path, _sessions, _gt = manifest_with_ground_truth
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "-m", str(manifest_path), "--no-llm"])
+        assert "Matched ground truth" in result.output
+
+    def test_run_warns_low_match_rate(self, manifest_with_ground_truth):
+        """run() should warn when match rate is below 50%."""
+        manifest_path, _sessions, _gt = manifest_with_ground_truth
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "-m", str(manifest_path), "--no-llm"])
+        # The pass-simple fixture has no triage phase with code_area, so 0/1 match rate
+        assert (
+            "ground truth matching relies on" in result.output
+            or "Matched ground truth for 0" in result.output
+        )
+
+    def test_run_graceful_on_corrupt_ground_truth(self, tmp_path, pass_simple_dir):
+        """run() should continue gracefully when ground truth YAML is corrupt."""
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        session_dest = sessions / "101"
+        session_dest.mkdir()
+        for file_path in pass_simple_dir.iterdir():
+            (session_dest / file_path.name).write_text(file_path.read_text())
+
+        ground_truth = tmp_path / "curated.yaml"
+        ground_truth.write_text("not: valid: yaml: [[[")
+
+        manifest = tmp_path / "raki.yaml"
+        manifest.write_text(
+            f"sessions:\n  path: {sessions}\n  format: auto\n"
+            f"ground_truth:\n  path: {ground_truth}\n"
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "-m", str(manifest), "--no-llm"])
+        assert result.exit_code == 0
+
+    def test_run_quiet_suppresses_match_log(self, manifest_with_ground_truth):
+        """run() in quiet mode should not log match count."""
+        manifest_path, _sessions, _gt = manifest_with_ground_truth
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "-m", str(manifest_path), "--no-llm", "-q"])
+        assert result.exit_code == 0
+        assert "Matched ground truth" not in result.output
+
+    def test_validate_reports_ground_truth_status(self, manifest_with_ground_truth):
+        """validate command should report ground truth status when configured."""
+        manifest_path, _sessions, _gt = manifest_with_ground_truth
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest_path)])
+        assert "ground truth" in result.output.lower()
+
+    def test_validate_graceful_on_corrupt_ground_truth(self, tmp_path, pass_simple_dir):
+        """validate command should warn on corrupt ground truth YAML."""
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        session_dest = sessions / "101"
+        session_dest.mkdir()
+        for file_path in pass_simple_dir.iterdir():
+            (session_dest / file_path.name).write_text(file_path.read_text())
+
+        ground_truth = tmp_path / "curated.yaml"
+        ground_truth.write_text("not: valid: yaml: [[[")
+
+        manifest = tmp_path / "raki.yaml"
+        manifest.write_text(
+            f"sessions:\n  path: {sessions}\n  format: auto\n"
+            f"ground_truth:\n  path: {ground_truth}\n"
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest)])
+        assert result.exit_code == 0
+
+    def test_run_with_matching_ground_truth(self, tmp_path, pass_simple_dir):
+        """run() should match ground truth when session has matching triage code_area."""
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        session_dest = sessions / "101"
+        session_dest.mkdir()
+        for file_path in pass_simple_dir.iterdir():
+            (session_dest / file_path.name).write_text(file_path.read_text())
+        # Patch triage.json to include code_area for domain matching
+        triage_path = session_dest / "triage.json"
+        triage_path.write_text(
+            '{"ticket_key": "101", "complexity": "small", '
+            '"approach": "Add pydantic validation", '
+            '"automatable": true, "code_area": "api validation"}'
+        )
+
+        ground_truth = tmp_path / "curated.yaml"
+        ground_truth.write_text(
+            "- question: How does API validation work?\n"
+            "  expected_approach: Use pydantic\n"
+            "  domains:\n"
+            "    - api\n"
+            "    - validation\n"
+        )
+
+        manifest = tmp_path / "raki.yaml"
+        manifest.write_text(
+            f"sessions:\n  path: {sessions}\n  format: auto\n"
+            f"ground_truth:\n  path: {ground_truth}\n"
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "-m", str(manifest), "--no-llm"])
+        assert result.exit_code == 0
+        assert "Matched ground truth for 1/1" in result.output
+
+
 class TestCliReportDiff:
     def test_diff_produces_cli_summary(self, tmp_path):
         """raki report --diff baseline.json compare.json produces CLI summary."""


### PR DESCRIPTION
## Summary

- Wire `load_ground_truth()` and `match_ground_truth()` into `run()` when `manifest.ground_truth.path` is set
- Log match count, warn on <50% match rate, graceful degradation on corrupt YAML
- `validate` command now reports ground truth status when configured
- Add "How Matching Works" section to curation guide and ground truth note to interpretation reference

Refs #77

## Review
- Python Specialist: clean (3 MINOR — test assertion strength, minor duplication)
- Security Specialist: clean (1 MINOR — file size bound consistency in load_ground_truth)
- RAG Specialist: not applicable

## Minor Findings (deferred)
- Test corrupt-YAML handlers don't assert warning message text
- Disjunctive assertion in low-match-rate test could be tightened
- load_ground_truth() lacks 50MB file size check (consistent with other readers)

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko