### PR TITLE
refactor(adapters): extract adapter registry to default_registry()

### DIFF
--- a/docs/adapter-guide.md
+++ b/docs/adapter-guide.md
@@ -62,13 +62,13 @@ Use `redact_sensitive()` on free-text fields, `redact_dict()` on structured data
 
 ## Registration
 
-Add your adapter to `_build_registry()` in `src/raki/cli.py`:
+Register your adapter in `default_registry()` in `src/raki/adapters/__init__.py`:
 
 ```python
-def _build_registry():
-    from raki.adapters import AdapterRegistry, AlcoveAdapter, SessionSchemaAdapter
-    from raki.adapters.my_format import MyFormatAdapter
+from raki.adapters.my_format import MyFormatAdapter
 
+
+def default_registry() -> AdapterRegistry:
     registry = AdapterRegistry()
     registry.register(SessionSchemaAdapter())
     registry.register(AlcoveAdapter())
@@ -77,6 +77,14 @@ def _build_registry():
 ```
 
 Run `raki adapters` to verify your adapter appears in the list.
+
+For programmatic use, you can also call `default_registry()` directly:
+
+```python
+from raki.adapters import default_registry
+
+registry = default_registry()
+```
 
 ## Testing
 

--- a/src/raki/adapters/__init__.py
+++ b/src/raki/adapters/__init__.py
@@ -5,6 +5,19 @@ from raki.adapters.redact import redact_sensitive
 from raki.adapters.registry import AdapterRegistry
 from raki.adapters.session_schema import SessionSchemaAdapter
 
+
+def default_registry() -> AdapterRegistry:
+    """Build the default adapter registry with all built-in adapters.
+
+    Returns a fresh ``AdapterRegistry`` each call so that callers can
+    customise their copy without affecting others.
+    """
+    registry = AdapterRegistry()
+    registry.register(SessionSchemaAdapter())
+    registry.register(AlcoveAdapter())
+    return registry
+
+
 __all__ = [
     "AdapterRegistry",
     "AlcoveAdapter",
@@ -12,5 +25,6 @@ __all__ = [
     "LoadError",
     "SessionAdapter",
     "SessionSchemaAdapter",
+    "default_registry",
     "redact_sensitive",
 ]

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -51,12 +51,9 @@ def _stderr_console() -> Console:
 
 def _build_registry():
     """Build the default adapter registry with all built-in adapters."""
-    from raki.adapters import AdapterRegistry, AlcoveAdapter, SessionSchemaAdapter
+    from raki.adapters import default_registry
 
-    registry = AdapterRegistry()
-    registry.register(SessionSchemaAdapter())
-    registry.register(AlcoveAdapter())
-    return registry
+    return default_registry()
 
 
 def _resolve_manifest(

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1013,6 +1013,27 @@ def test_generational_sorting_no_meta_generation_defaults(tmp_path):
     assert impl_phases[2].generation == 3
 
 
+# --- default_registry() tests (issue #78) ---
+
+
+class TestDefaultRegistry:
+    def test_default_registry_contains_both_adapters(self):
+        from raki.adapters import default_registry
+
+        registry = default_registry()
+        adapters = registry.list_all()
+        adapter_names = {adapter.name for adapter in adapters}
+        assert "session-schema" in adapter_names
+        assert "alcove" in adapter_names
+
+    def test_default_registry_returns_fresh_instance(self):
+        from raki.adapters import default_registry
+
+        registry_a = default_registry()
+        registry_b = default_registry()
+        assert registry_a is not registry_b
+
+
 # --- Zero-token and missing-data edge-case tests (issue #37) ---
 
 


### PR DESCRIPTION
## Summary

- Extract hardcoded adapter registration from `cli.py:_build_registry()` into `adapters/__init__.py:default_registry()`
- CLI now delegates to `default_registry()` — enables programmatic use outside CLI
- Unit tests verify both adapters registered and fresh instances per call
- Adapter guide updated to reference new location

Refs #78

## Review
- Python Specialist: clean (0 findings)
- Security Specialist: not applicable (pure refactor)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko