### PR TITLE
feat(adapters): implement --adapter filtering

### DIFF
--- a/src/raki/adapters/loader.py
+++ b/src/raki/adapters/loader.py
@@ -18,13 +18,22 @@ class DatasetLoader:
         self.errors: list[LoadError] = []
         self.skipped: list[Path] = []
 
-    def load_directory(self, root: Path, *, recursive: bool = False) -> EvalDataset:
+    def load_directory(
+        self,
+        root: Path,
+        *,
+        recursive: bool = False,
+        adapter_name: str | None = None,
+    ) -> EvalDataset:
         """Load sessions from a directory.
 
         Args:
             root: Root directory to scan for sessions.
             recursive: When True, descend into subdirectories to find sessions.
                 Default is False for backward compatibility.
+            adapter_name: When set, bypass auto-detection and use the named
+                adapter for every child path. Raises ``ValueError`` if the
+                name is not registered.
 
         Returns:
             EvalDataset containing all successfully loaded sessions.
@@ -32,10 +41,13 @@ class DatasetLoader:
         # Resolve to an absolute path to prevent trivial path traversal.
         # Full manifest-level validation is deferred to the CLI/manifest layer (Issues #6/#8).
         root = root.resolve()
+        if adapter_name is not None and self._registry.get(adapter_name) is None:
+            valid_names = ", ".join(adapter.name for adapter in self._registry.list_all())
+            raise ValueError(f"Unknown adapter: '{adapter_name}'. Valid adapters: {valid_names}")
         samples: list[EvalSample] = []
         self.errors = []
         self.skipped = []
-        self._scan_directory(root, samples, recursive=recursive)
+        self._scan_directory(root, samples, recursive=recursive, adapter_name=adapter_name)
         return EvalDataset(samples=samples)
 
     def _scan_directory(
@@ -44,10 +56,18 @@ class DatasetLoader:
         samples: list[EvalSample],
         *,
         recursive: bool,
+        adapter_name: str | None = None,
     ) -> None:
-        """Scan a directory for sessions, optionally recursing into subdirectories."""
+        """Scan a directory for sessions, optionally recursing into subdirectories.
+
+        When *adapter_name* is set, the named adapter is used for every child
+        instead of auto-detecting the format.
+        """
         for child in sorted(directory.iterdir()):
-            adapter = self._detect_adapter(child)
+            if adapter_name is not None:
+                adapter = self._registry.get(adapter_name)
+            else:
+                adapter = self._detect_adapter(child)
             if adapter is not None:
                 try:
                     sample = adapter.load(child)
@@ -55,7 +75,7 @@ class DatasetLoader:
                 except Exception as exc:
                     self.errors.append(LoadError(path=child, error=str(exc)))
             elif recursive and child.is_dir() and not child.is_symlink():
-                self._scan_directory(child, samples, recursive=True)
+                self._scan_directory(child, samples, recursive=True, adapter_name=adapter_name)
             else:
                 self.skipped.append(child)
 

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -161,7 +161,6 @@ def run(
 
     _warn_unimplemented_options(
         con=out,
-        adapter=adapter_format,
         metrics=metric_names,
         tenant=tenant,
     )
@@ -178,12 +177,16 @@ def run(
     from raki.adapters import DatasetLoader
 
     registry = _build_registry()
+
     loader = DatasetLoader(registry)
 
     if not quiet:
         out.print(f"Loading sessions from [bold]{manifest.sessions.path}[/bold]...")
 
-    dataset = loader.load_directory(manifest.sessions.path)
+    try:
+        dataset = loader.load_directory(manifest.sessions.path, adapter_name=adapter_format)
+    except ValueError as exc:
+        raise click.BadParameter(str(exc), param_hint="'--adapter'") from exc
 
     if verbose:
         for error in loader.errors:

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1013,6 +1013,63 @@ def test_generational_sorting_no_meta_generation_defaults(tmp_path):
     assert impl_phases[2].generation == 3
 
 
+# --- DatasetLoader adapter_name filtering tests (issue #79) ---
+
+
+class TestDatasetLoaderAdapterName:
+    def test_load_directory_with_valid_adapter_name(self, sessions_dir):
+        registry = AdapterRegistry()
+        registry.register(SessionSchemaAdapter())
+        loader = DatasetLoader(registry)
+        dataset = loader.load_directory(sessions_dir, adapter_name="session-schema")
+        assert len(dataset.samples) == 2
+
+    def test_load_directory_with_invalid_adapter_name(self, sessions_dir):
+        registry = AdapterRegistry()
+        registry.register(SessionSchemaAdapter())
+        loader = DatasetLoader(registry)
+        with pytest.raises(ValueError, match="Unknown adapter"):
+            loader.load_directory(sessions_dir, adapter_name="nonexistent")
+
+    def test_load_directory_adapter_name_bypasses_detection(self, tmp_path):
+        """When adapter_name is set, _detect_adapter() is not called for each child."""
+        import shutil
+
+        # Copy alcove fixture into a flat dir alongside a session-schema dir
+        shutil.copy(ALCOVE_FIXTURE, tmp_path / "alcove-simple.json")
+        session_dir = tmp_path / "session-101"
+        session_dir.mkdir()
+        meta = {
+            "ticket": "101",
+            "summary": "test",
+            "started_at": "2026-04-10T08:00:00Z",
+            "total_cost": 1.0,
+            "rework_cycles": 0,
+            "phases": {},
+        }
+        import json
+
+        (session_dir / "meta.json").write_text(json.dumps(meta))
+        (session_dir / "events.jsonl").write_text("")
+
+        registry = AdapterRegistry()
+        registry.register(SessionSchemaAdapter())
+        registry.register(AlcoveAdapter())
+        loader = DatasetLoader(registry)
+
+        # Force session-schema adapter: alcove file should be skipped/error, not loaded
+        dataset = loader.load_directory(tmp_path, adapter_name="session-schema")
+        session_ids = {sample.session.session_id for sample in dataset.samples}
+        # Only the session-schema session should be loaded (alcove file will fail/be skipped)
+        assert "101" in session_ids
+        alcove_ids = {
+            sample.session.session_id
+            for sample in dataset.samples
+            if sample.session.session_id == "ae7d2bf4-2f77-4ea6-8e3c-5442fe3d9fa7"
+        }
+        assert len(alcove_ids) == 0
+
+
 # --- default_registry() tests (issue #78) ---
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -332,15 +332,48 @@ class TestCliExitCodes:
         assert result.exit_code == 2
 
 
-class TestCliUnimplementedOptions:
-    def test_warns_adapter_option(self, empty_manifest):
+class TestAdapterFiltering:
+    def test_valid_adapter_name(self, manifest_with_session):
+        manifest_path, _sessions = manifest_with_session
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["run", "-m", str(empty_manifest), "--no-llm", "--adapter", "custom"],
+            ["run", "-m", str(manifest_path), "--no-llm", "--adapter", "session-schema", "-q"],
         )
-        assert "Warning: --adapter is not yet implemented" in result.output
+        assert result.exit_code == 0
 
+    def test_invalid_adapter_name_exits_2(self, manifest_with_session):
+        manifest_path, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(manifest_path), "--no-llm", "--adapter", "nonexistent"],
+        )
+        assert result.exit_code == 2
+
+    def test_invalid_adapter_name_shows_valid_names(self, manifest_with_session):
+        manifest_path, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(manifest_path), "--no-llm", "--adapter", "nonexistent"],
+        )
+        assert "session-schema" in result.output
+        assert "alcove" in result.output
+
+    def test_adapter_name_passed_to_loader(self, manifest_with_session):
+        """Valid adapter name should be passed through to the loader without warning."""
+        manifest_path, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(manifest_path), "--no-llm", "--adapter", "session-schema"],
+        )
+        assert result.exit_code == 0
+        assert "Warning: --adapter is not yet implemented" not in result.output
+
+
+class TestCliUnimplementedOptions:
     def test_warns_metrics_option(self, empty_manifest):
         runner = CliRunner()
         result = runner.invoke(


### PR DESCRIPTION
## Summary

- Add `adapter_name` parameter to `DatasetLoader.load_directory()` to bypass auto-detection
- CLI validates adapter name, shows valid names on error with exit code 2
- Replaced old "not yet implemented" warning test with proper filtering tests

Refs #79

## Review
- Python Specialist: clean after 1 fix iteration (2 IMPORTANT fixed: vacuous assertion, duplicate validation)
- Security Specialist: not applicable
- RAG Specialist: not applicable

## Minor Findings (deferred)
- In-function stdlib imports in tests could be top-of-file
- Near-duplicate CLI tests could be merged

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko