### PR TITLE
feat(cli): implement --metrics filtering and raki metrics subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,20 @@ uv run raki run --manifest raki.yaml
 # Run operational metrics only
 uv run raki run --manifest raki.yaml --no-llm
 
+# Run specific metrics only
+uv run raki run --manifest raki.yaml --no-llm --metrics cost_efficiency,rework_cycles
+
 # Validate manifest and session data
 uv run raki validate --manifest raki.yaml
 
 # List available adapters
 uv run raki adapters
+
+# List available metrics (name, display name, LLM requirement)
+uv run raki metrics
+
+# Machine-readable metric list
+uv run raki metrics --json
 ```
 
 ## Documentation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,26 @@ Run an evaluation using only operational metrics (no LLM required):
 uv run raki run --manifest examples/raki-minimal.yaml --no-llm
 ```
 
+### Discovering Available Metrics
+
+List all metrics RAKI can compute, including which ones require an LLM provider:
+
+```bash
+uv run raki metrics
+```
+
+Use `--json` for machine-readable output:
+
+```bash
+uv run raki metrics --json
+```
+
+Run only specific metrics by name (use the internal name from `raki metrics`):
+
+```bash
+uv run raki run --manifest examples/raki-minimal.yaml --no-llm --metrics cost_efficiency,rework_cycles
+```
+
 ## Prepare Your Data
 
 RAKI evaluates session transcripts produced by agentic coding tools. Each session is a directory containing phase files (`triage.json`, `implement.json`, `verify.json`, `review.json`) and an `events.jsonl` log. See `examples/sessions/` for working examples.

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -100,6 +100,30 @@ def _warn_unimplemented_options(con: Console | None = None, **options: object) -
             out.print(f"[yellow]Warning: --{option_name} is not yet implemented[/yellow]")
 
 
+# LLM metric names that are always known (Ragas-backed retrieval metrics)
+_RAGAS_METRICS: dict[str, tuple[str, bool]] = {
+    "context_precision": ("Context precision", True),
+    "context_recall": ("Context recall", True),
+    "faithfulness": ("Faithfulness", True),
+    "answer_relevancy": ("Answer relevancy", True),
+}
+
+
+def _all_metric_names() -> dict[str, str]:
+    """Return a mapping of all known metric names to display names.
+
+    Includes operational metrics from ALL_OPERATIONAL and Ragas retrieval metrics.
+    """
+    from raki.metrics.operational import ALL_OPERATIONAL
+
+    names: dict[str, str] = {}
+    for metric in ALL_OPERATIONAL:
+        names[metric.name] = metric.display_name
+    for ragas_name, (display_name, _requires_llm) in _RAGAS_METRICS.items():
+        names[ragas_name] = display_name
+    return names
+
+
 @click.group()
 @click.version_option(package_name="raki")
 def main():
@@ -161,9 +185,22 @@ def run(
 
     _warn_unimplemented_options(
         con=out,
-        metrics=metric_names,
         tenant=tenant,
     )
+
+    # Validate --metrics filter before doing any heavy loading
+    requested_names: set[str] | None = None
+    if metric_names is not None:
+        all_known = _all_metric_names()
+        requested_names = {name.strip() for name in metric_names.split(",")}
+        unknown = requested_names - set(all_known.keys())
+        if unknown:
+            valid_list = ", ".join(sorted(all_known.keys()))
+            raise click.BadParameter(
+                f"Unknown metric(s): {', '.join(sorted(unknown))}. Valid metrics: {valid_list}",
+                param_hint="'--metrics'",
+            )
+
     manifest_file = _resolve_manifest(manifest_path, quiet=quiet, con=out)
 
     try:
@@ -240,7 +277,14 @@ def run(
     )
 
     all_metrics: list[Metric] = list(ALL_OPERATIONAL)
-    if not no_llm:
+
+    # Determine whether LLM metrics are needed: only import Ragas machinery
+    # when the user has not excluded LLM metrics via --no-llm and the
+    # --metrics filter (if any) includes at least one LLM-backed metric.
+    needs_llm = not no_llm and (
+        requested_names is None or any(name in requested_names for name in _RAGAS_METRICS)
+    )
+    if needs_llm:
         from raki.metrics.ragas.faithfulness import FaithfulnessMetric
         from raki.metrics.ragas.precision import ContextPrecisionMetric
         from raki.metrics.ragas.recall import ContextRecallMetric
@@ -254,6 +298,10 @@ def run(
                 AnswerRelevancyMetric(),
             ]
         )
+
+    # Apply --metrics filter after assembling the full metric list
+    if requested_names is not None:
+        all_metrics = [metric for metric in all_metrics if metric.name in requested_names]
 
     engine = MetricsEngine(all_metrics, config=config)
     report = engine.run(dataset, skip_llm=no_llm)
@@ -405,6 +453,55 @@ def adapters() -> None:
             f"  [bold]{adapter.name}[/bold]  {adapter.description}  "
             f"[dim](detects: {adapter.detection_hint})[/dim]"
         )
+
+
+@main.command()
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+def metrics(json_output: bool) -> None:
+    """List available metrics."""
+    from raki.metrics.operational import ALL_OPERATIONAL
+
+    all_metrics_info: list[dict[str, str | bool]] = []
+    for metric in ALL_OPERATIONAL:
+        all_metrics_info.append(
+            {
+                "name": metric.name,
+                "display_name": metric.display_name,
+                "requires_llm": metric.requires_llm,
+                "higher_is_better": metric.higher_is_better,
+            }
+        )
+    for ragas_name, (display_name, requires_llm) in _RAGAS_METRICS.items():
+        all_metrics_info.append(
+            {
+                "name": ragas_name,
+                "display_name": display_name,
+                "requires_llm": requires_llm,
+                "higher_is_better": True,
+            }
+        )
+
+    if json_output:
+        import json as json_mod
+
+        click.echo(json_mod.dumps({"metrics": all_metrics_info}, indent=2))
+        return
+
+    from rich.table import Table
+
+    table = Table(title="Available Metrics")
+    table.add_column("Name", style="bold")
+    table.add_column("Display Name")
+    table.add_column("Requires LLM")
+    table.add_column("Higher is Better")
+    for info in all_metrics_info:
+        table.add_row(
+            str(info["name"]),
+            str(info["display_name"]),
+            "\u2713" if info["requires_llm"] else "",
+            "\u2713" if info["higher_is_better"] else "",
+        )
+    console.print(table)
 
 
 def _is_session_data_stripped(report: EvalReport) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -373,22 +373,210 @@ class TestAdapterFiltering:
         assert "Warning: --adapter is not yet implemented" not in result.output
 
 
-class TestCliUnimplementedOptions:
-    def test_warns_metrics_option(self, empty_manifest):
+class TestMetricsFiltering:
+    def test_filter_single_metric(self, manifest_with_session):
+        manifest_path, _sessions = manifest_with_session
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["run", "-m", str(empty_manifest), "--no-llm", "--metrics", "f1,recall"],
+            ["run", "-m", str(manifest_path), "--no-llm", "--metrics", "cost_efficiency", "-q"],
         )
-        assert "Warning: --metrics is not yet implemented" in result.output
+        assert result.exit_code == 0
 
-    def test_warns_tenant_option(self, empty_manifest):
+    def test_filter_multiple_metrics(self, manifest_with_session):
+        manifest_path, _sessions = manifest_with_session
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["run", "-m", str(empty_manifest), "--no-llm", "--tenant", "acme"],
+            [
+                "run",
+                "-m",
+                str(manifest_path),
+                "--no-llm",
+                "--metrics",
+                "cost_efficiency,rework_cycles",
+                "-q",
+            ],
         )
-        assert "Warning: --tenant is not yet implemented" in result.output
+        assert result.exit_code == 0
+
+    def test_invalid_metric_name_exits_2(self, manifest_with_session):
+        manifest_path, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(manifest_path), "--no-llm", "--metrics", "nonexistent"],
+        )
+        assert result.exit_code == 2
+
+    def test_invalid_metric_name_shows_valid_names(self, manifest_with_session):
+        manifest_path, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(manifest_path), "--no-llm", "--metrics", "nonexistent"],
+        )
+        assert "Valid metrics" in result.output
+
+    def test_filter_only_runs_selected_metrics(self, manifest_with_session, tmp_path):
+        """Filtering to a single metric should only include that metric in the report."""
+        manifest_path, _sessions = manifest_with_session
+        output_dir = tmp_path / "results"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(manifest_path),
+                "--no-llm",
+                "--metrics",
+                "cost_efficiency",
+                "-o",
+                str(output_dir),
+                "--json",
+                "-q",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        metric_names = set(data.get("aggregate_scores", {}).keys())
+        assert "cost_efficiency" in metric_names
+        # Other operational metrics should not appear
+        assert "first_pass_verify_rate" not in metric_names
+
+    def test_filter_avoids_llm_import_when_only_operational(self, manifest_with_session):
+        """When --metrics selects only operational metrics, LLM imports should not happen."""
+        manifest_path, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(manifest_path),
+                "--metrics",
+                "cost_efficiency",
+                "-q",
+            ],
+        )
+        # Should succeed without LLM setup even though --no-llm was not specified
+        assert result.exit_code == 0
+
+    def test_filter_with_spaces_around_names(self, manifest_with_session):
+        """Metric names with spaces around commas should be trimmed."""
+        manifest_path, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(manifest_path),
+                "--no-llm",
+                "--metrics",
+                " cost_efficiency , rework_cycles ",
+                "-q",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_combined_metrics_and_no_llm(self, manifest_with_session):
+        """--metrics with only operational names + --no-llm should work fine."""
+        manifest_path, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(manifest_path),
+                "--no-llm",
+                "--metrics",
+                "first_pass_verify_rate,rework_cycles",
+                "-q",
+            ],
+        )
+        assert result.exit_code == 0
+
+
+class TestMetricsSubcommand:
+    def test_metrics_command_shows_in_help(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "metrics" in result.output
+
+    def test_metrics_lists_all(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["metrics"])
+        assert result.exit_code == 0
+        # Rich table may truncate long names; check for a shorter metric name
+        assert "rework_cycles" in result.output
+
+    def test_metrics_shows_operational_metrics(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["metrics"])
+        assert result.exit_code == 0
+        assert "cost_efficiency" in result.output
+        assert "rework_cycles" in result.output
+
+    def test_metrics_shows_ragas_metrics(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["metrics"])
+        assert result.exit_code == 0
+        assert "context_precision" in result.output
+        assert "faithfulness" in result.output
+
+    def test_metrics_shows_display_name(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["metrics"])
+        assert result.exit_code == 0
+        assert "Verify rate" in result.output
+
+    def test_metrics_shows_requires_llm_column(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["metrics"])
+        assert result.exit_code == 0
+        assert "Requires LLM" in result.output
+
+    def test_metrics_shows_higher_is_better_column(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["metrics"])
+        assert result.exit_code == 0
+        assert "Higher is Better" in result.output
+
+    def test_metrics_json_output(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["metrics", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "metrics" in data
+        metric_names = {metric_info["name"] for metric_info in data["metrics"]}
+        assert "first_pass_verify_rate" in metric_names
+        assert "context_precision" in metric_names
+
+    def test_metrics_json_includes_all_fields(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["metrics", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        for metric_info in data["metrics"]:
+            assert "name" in metric_info
+            assert "display_name" in metric_info
+            assert "requires_llm" in metric_info
+            assert "higher_is_better" in metric_info
+
+    def test_metrics_json_types(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["metrics", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        for metric_info in data["metrics"]:
+            assert isinstance(metric_info["name"], str)
+            assert isinstance(metric_info["display_name"], str)
+            assert isinstance(metric_info["requires_llm"], bool)
+            assert isinstance(metric_info["higher_is_better"], bool)
 
 
 class TestCliJudgeModel:
@@ -1026,3 +1214,40 @@ class TestCliReportDiff:
         result = runner.invoke(main, ["report", "--diff", str(baseline), str(compare)])
         assert result.exit_code == 0
         assert "Improvement" in result.output or "improvement" in result.output.lower()
+
+
+class TestCliUnimplementedOptions:
+    def test_tenant_warning(self, empty_manifest):
+        """--tenant is still unimplemented and should produce a warning."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm", "--tenant", "acme-corp"],
+        )
+        assert result.exit_code == 0
+        assert "Warning: --tenant is not yet implemented" in result.output
+
+
+class TestRagasMetricsSync:
+    """_RAGAS_METRICS dict keys must stay in sync with actual Ragas metric class .name attributes."""
+
+    def test_ragas_metrics_keys_match_class_names(self):
+        """The set of _RAGAS_METRICS keys must equal the set of Ragas metric .name values."""
+        from raki.cli import _RAGAS_METRICS
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+        from raki.metrics.ragas.recall import ContextRecallMetric
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        ragas_classes = [
+            FaithfulnessMetric,
+            ContextPrecisionMetric,
+            ContextRecallMetric,
+            AnswerRelevancyMetric,
+        ]
+        class_names = {cls.name for cls in ragas_classes}
+        dict_keys = set(_RAGAS_METRICS.keys())
+        assert dict_keys == class_names, (
+            f"_RAGAS_METRICS keys {dict_keys} do not match "
+            f"Ragas metric class .name attributes {class_names}"
+        )


### PR DESCRIPTION
## Summary

- Implement comma-separated `--metrics` filter validating against known metric names
- Skip Ragas imports when only operational metrics are selected
- Add `raki metrics` subcommand with Rich table and `--json` output
- Update README.md and docs/getting-started.md with usage examples

Refs #80

## Review
- Python Specialist: clean after 1 fix iteration (3 IMPORTANT fixed: sync test, --tenant test, blank line)
- Security Specialist: clean (2 MINOR — empty string edge case, registry duplication)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko