### PR TITLE
feat(cli): remove --tenant, fix threshold warning, report positional arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased] (v0.6.0) — Make It Real
+
+### Breaking Changes
+
+- **`raki report` positional argument**: `raki report --input file.json` is now
+  `raki report file.json`. The `--input` / `-i` option has been replaced with a
+  positional argument. Update any scripts or CI pipelines that use the old syntax.
+- **`--tenant` removed**: The `--tenant` CLI option has been removed entirely.
+  It wrote a field nothing consumed. It can be re-added with actual functionality
+  if needed later.
+
+### Changed
+
+- `--threshold` + `--no-llm` warning updated from generic message to:
+  "No retrieval metrics active — threshold applies only to LLM-backed metrics.
+  Operational metrics use non-0-1 scales; per-metric thresholds planned for v0.7.0."
+
 ## [Unreleased] (v0.4.0) — Security & Data Completeness
 - Security hardening: symlinks, encoding, redaction, size limits
 - Adapter completeness: model_id, tokens, recursive loading, generational sorting

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,10 +96,10 @@ RAKI saves evaluation results as JSON. You can re-render the CLI summary or gene
 
 ```bash
 # Re-render CLI summary from a saved report
-uv run raki report --input results/raki-report-20260410T120000.json
+uv run raki report results/raki-report-20260410T120000.json
 
 # Generate an HTML report from the same JSON
-uv run raki report --input results/raki-report-20260410T120000.json --html results/report.html
+uv run raki report results/raki-report-20260410T120000.json --html results/report.html
 ```
 
 If the JSON report was generated without `--include-sessions`, RAKI will show aggregate scores only and warn that per-session drill-down is unavailable.

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -92,14 +92,6 @@ def _resolve_manifest(
     return found
 
 
-def _warn_unimplemented_options(con: Console | None = None, **options: object) -> None:
-    """Print a warning for each option that was provided but is not yet implemented."""
-    out = con or console
-    for option_name, value in options.items():
-        if value is not None:
-            out.print(f"[yellow]Warning: --{option_name} is not yet implemented[/yellow]")
-
-
 # LLM metric names that are always known (Ragas-backed retrieval metrics)
 _RAGAS_METRICS: dict[str, tuple[str, bool]] = {
     "context_precision": ("Context precision", True),
@@ -157,7 +149,6 @@ def main():
     default="claude-sonnet-4-6",
     help="LLM model for judge metrics (default: claude-sonnet-4-6)",
 )
-@click.option("--tenant", default=None, help="Set tenant_id on the report")
 @click.option(
     "--include-sessions",
     is_flag=True,
@@ -175,18 +166,12 @@ def run(
     metric_names: str | None,
     parallel_count: int,
     judge_model: str,
-    tenant: str | None,
     include_sessions: bool,
     json_stdout: bool,
     verbose: bool,
 ) -> None:
     """Run evaluation against sessions."""
     out = _stderr_console() if json_stdout else console
-
-    _warn_unimplemented_options(
-        con=out,
-        tenant=tenant,
-    )
 
     # Validate --metrics filter before doing any heavy loading
     requested_names: set[str] | None = None
@@ -320,8 +305,9 @@ def run(
 
     if threshold is not None and no_llm:
         out.print(
-            "[yellow]Warning: --threshold is set but --no-llm is active. "
-            "Threshold applies to retrieval quality scores which require LLM metrics.[/yellow]"
+            "[yellow]Warning: No retrieval metrics active — threshold applies only to "
+            "LLM-backed metrics. Operational metrics use non-0-1 scales; "
+            "per-metric thresholds planned for v0.7.0.[/yellow]"
         )
 
     output_path = Path(output_dir)
@@ -553,14 +539,7 @@ def _metric_stubs_from_metadata(
 
 
 @main.command()
-@click.option(
-    "-i",
-    "--input",
-    "input_path",
-    required=False,
-    default=None,
-    help="Path to JSON report",
-)
+@click.argument("input_path", required=False, default=None)
 @click.option(
     "--diff",
     "diff_paths",
@@ -597,7 +576,7 @@ def report(
         return
 
     if input_path is None:
-        console.print("[red]Error: --input is required when not using --diff[/red]")
+        console.print("[red]Error: input path is required when not using --diff[/red]")
         raise SystemExit(2)
 
     from raki.report.json_report import load_json_report

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,8 +162,7 @@ class TestCliRunThreshold:
             main,
             ["run", "-m", str(empty_manifest), "--no-llm", "--threshold", "0.8"],
         )
-        assert "threshold" in result.output.lower()
-        assert "no-llm" in result.output.lower() or "no_llm" in result.output.lower()
+        assert "No retrieval metrics active" in result.output
 
     def test_threshold_exit_code_1_when_below(self, manifest_with_session, tmp_path, monkeypatch):
         """--threshold 0.99 with low retrieval scores should produce exit code 1."""
@@ -786,11 +785,11 @@ class TestCliReport:
         assert "report" in result.output
 
     def test_report_renders_cli_summary(self, tmp_path):
-        """raki report --input renders CLI summary to terminal."""
+        """raki report file.json renders CLI summary to terminal."""
         report_json = tmp_path / "report.json"
         _write_report_json(report_json, include_sessions=True)
         runner = CliRunner()
-        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        result = runner.invoke(main, ["report", str(report_json)])
         assert result.exit_code == 0
         assert "Operational Health" in result.output
 
@@ -799,7 +798,7 @@ class TestCliReport:
         report_json = tmp_path / "report.json"
         _write_report_json(report_json, include_sessions=True)
         runner = CliRunner()
-        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        result = runner.invoke(main, ["report", str(report_json)])
         assert result.exit_code == 0
         assert "0.85" in result.output
 
@@ -808,14 +807,12 @@ class TestCliReport:
         reason="jinja2 not installed",
     )
     def test_report_generates_html(self, tmp_path):
-        """raki report --input --html generates an HTML file."""
+        """raki report file.json --html generates an HTML file."""
         report_json = tmp_path / "report.json"
         _write_report_json(report_json, include_sessions=True)
         html_path = tmp_path / "output.html"
         runner = CliRunner()
-        result = runner.invoke(
-            main, ["report", "--input", str(report_json), "--html", str(html_path)]
-        )
+        result = runner.invoke(main, ["report", str(report_json), "--html", str(html_path)])
         assert result.exit_code == 0
         assert html_path.exists()
         content = html_path.read_text()
@@ -826,7 +823,7 @@ class TestCliReport:
         report_json = tmp_path / "report.json"
         _write_report_json(report_json, include_sessions=False)
         runner = CliRunner()
-        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        result = runner.invoke(main, ["report", str(report_json)])
         assert result.exit_code == 0
         assert "--include-sessions" in result.output
 
@@ -835,31 +832,22 @@ class TestCliReport:
         report_json = tmp_path / "report.json"
         _write_report_json(report_json, include_sessions=True)
         runner = CliRunner()
-        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        result = runner.invoke(main, ["report", str(report_json)])
         assert result.exit_code == 0
         assert "--include-sessions" not in result.output
 
     def test_report_exit_code_2_for_missing_input(self, tmp_path):
         """Exit code 2 when input file does not exist."""
         runner = CliRunner()
-        result = runner.invoke(main, ["report", "--input", str(tmp_path / "nonexistent.json")])
+        result = runner.invoke(main, ["report", str(tmp_path / "nonexistent.json")])
         assert result.exit_code == 2
-
-    def test_report_short_input_flag(self, tmp_path):
-        """raki report -i works as shorthand for --input."""
-        report_json = tmp_path / "report.json"
-        _write_report_json(report_json, include_sessions=True)
-        runner = CliRunner()
-        result = runner.invoke(main, ["report", "-i", str(report_json)])
-        assert result.exit_code == 0
-        assert "Operational Health" in result.output
 
     def test_report_html_default_alongside_json(self, tmp_path):
         """When --html is not given, no HTML file is generated."""
         report_json = tmp_path / "report.json"
         _write_report_json(report_json, include_sessions=True)
         runner = CliRunner()
-        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        result = runner.invoke(main, ["report", str(report_json)])
         assert result.exit_code == 0
         html_files = list(tmp_path.glob("*.html"))
         assert len(html_files) == 0
@@ -869,7 +857,7 @@ class TestCliReport:
         report_json = tmp_path / "report.json"
         _write_report_json(report_json, include_sessions=True)
         runner = CliRunner()
-        result = runner.invoke(main, ["report", "--input", str(report_json)])
+        result = runner.invoke(main, ["report", str(report_json)])
         assert result.exit_code == 0
         # Should use display names from METRIC_METADATA, not raw metric keys
         assert "Verify rate" in result.output
@@ -1216,16 +1204,79 @@ class TestCliReportDiff:
         assert "Improvement" in result.output or "improvement" in result.output.lower()
 
 
-class TestCliUnimplementedOptions:
-    def test_tenant_warning(self, empty_manifest):
-        """--tenant is still unimplemented and should produce a warning."""
+class TestTenantRemoved:
+    def test_tenant_option_no_longer_exists(self):
+        """--tenant was removed in v0.6.0 and should produce a Click error."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "--tenant", "foo"])
+        assert result.exit_code == 2
+
+    def test_tenant_option_shows_no_such_option(self):
+        """Click should report --tenant as an unrecognized option."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "--tenant", "foo"])
+        assert "No such option" in result.output or "no such option" in result.output
+
+
+class TestThresholdWarningUpdated:
+    def test_threshold_with_no_llm_warns_no_retrieval_metrics_active(self, empty_manifest):
+        """--threshold + --no-llm should warn about no retrieval metrics being active."""
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["run", "-m", str(empty_manifest), "--no-llm", "--tenant", "acme-corp"],
+            ["run", "-m", str(empty_manifest), "--no-llm", "--threshold", "0.5"],
         )
+        assert "No retrieval metrics active" in result.output
+
+    def test_threshold_warning_mentions_operational_scales(self, empty_manifest):
+        """Warning should explain that operational metrics use non-0-1 scales."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm", "--threshold", "0.5"],
+        )
+        assert "non-0-1 scales" in result.output
+
+    def test_threshold_warning_mentions_v070(self, empty_manifest):
+        """Warning should mention per-metric thresholds planned for v0.7.0."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm", "--threshold", "0.5"],
+        )
+        assert "v0.7.0" in result.output
+
+
+class TestReportPositionalArg:
+    def test_report_accepts_positional_path(self, tmp_path):
+        """raki report file.json should work (positional argument)."""
+        report_json = tmp_path / "report.json"
+        _write_report_json(report_json, include_sessions=True)
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", str(report_json)])
         assert result.exit_code == 0
-        assert "Warning: --tenant is not yet implemented" in result.output
+        assert "Operational Health" in result.output
+
+    def test_report_positional_shows_aggregate_scores(self, tmp_path):
+        """Positional report path should display aggregate scores."""
+        report_json = tmp_path / "report.json"
+        _write_report_json(report_json, include_sessions=True)
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", str(report_json)])
+        assert result.exit_code == 0
+        assert "0.85" in result.output
+
+    def test_report_without_path_or_diff_errors(self):
+        """raki report with no arguments should error with exit code 2."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["report"])
+        assert result.exit_code == 2
+
+    def test_report_missing_positional_file_errors(self, tmp_path):
+        """Positional path to nonexistent file should produce exit code 2."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", str(tmp_path / "nonexistent.json")])
+        assert result.exit_code == 2
 
 
 class TestRagasMetricsSync:


### PR DESCRIPTION
## Summary

- Remove unused `--tenant` option entirely (breaking change)
- Update `--threshold` + `--no-llm` warning to explain non-0-1 scales and v0.7.0 roadmap
- Change `raki report --input` to positional argument (breaking change)
- Add CHANGELOG.md with migration notes

Refs #81

## Review
- Python Specialist: clean (4 MINOR — test duplication, positional+diff ambiguity)
- Security Specialist: clean (0 findings)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko