### PR TITLE
feat(metrics): add phase execution time metric

### DIFF
--- a/src/raki/metrics/operational/__init__.py
+++ b/src/raki/metrics/operational/__init__.py
@@ -1,5 +1,6 @@
 from raki.metrics.operational.cost import CostEfficiency
 from raki.metrics.operational.knowledge_miss_rate import KnowledgeRetrievalMissRate
+from raki.metrics.operational.latency import PhaseExecutionTimeMetric
 from raki.metrics.operational.rework import ReworkCycles
 from raki.metrics.operational.severity import ReviewSeverityDistribution
 from raki.metrics.operational.verify_rate import FirstPassVerifyRate
@@ -10,6 +11,7 @@ ALL_OPERATIONAL = [
     ReviewSeverityDistribution(),
     CostEfficiency(),
     KnowledgeRetrievalMissRate(),
+    PhaseExecutionTimeMetric(),
 ]
 
 __all__ = [
@@ -17,6 +19,7 @@ __all__ = [
     "CostEfficiency",
     "FirstPassVerifyRate",
     "KnowledgeRetrievalMissRate",
+    "PhaseExecutionTimeMetric",
     "ReviewSeverityDistribution",
     "ReworkCycles",
 ]

--- a/src/raki/metrics/operational/latency.py
+++ b/src/raki/metrics/operational/latency.py
@@ -1,0 +1,50 @@
+import statistics
+
+from raki.metrics.protocol import MetricConfig
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+
+class PhaseExecutionTimeMetric:
+    name: str = "phase_execution_time"
+    requires_ground_truth: bool = False
+    requires_llm: bool = False
+    higher_is_better: bool = False
+    display_format: str = "duration"
+    display_name: str = "Phase execution time"
+    description: str = "Mean total phase execution time per session (seconds)"
+
+    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:
+        sample_scores: dict[str, float] = {}
+        session_totals: list[float] = []
+
+        for sample in dataset.samples:
+            durations = [
+                phase.duration_ms for phase in sample.phases if phase.duration_ms is not None
+            ]
+            if not durations:
+                continue
+            total_seconds = sum(durations) / 1000.0
+            session_totals.append(total_seconds)
+            sample_scores[sample.session.session_id] = total_seconds
+
+        mean_total = statistics.mean(session_totals) if session_totals else 0.0
+        sorted_totals = sorted(session_totals) if session_totals else []
+
+        details: dict[str, float | int] = {
+            "mean": mean_total,
+            "sessions_with_duration": len(session_totals),
+        }
+        if sorted_totals:
+            details["min"] = sorted_totals[0]
+            details["max"] = sorted_totals[-1]
+            details["p50"] = statistics.median(sorted_totals)
+            idx_95 = min(int(len(sorted_totals) * 0.95), len(sorted_totals) - 1)
+            details["p95"] = sorted_totals[idx_95]
+
+        return MetricResult(
+            name=self.name,
+            score=mean_total,
+            details=details,
+            sample_scores=sample_scores,
+        )

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -20,6 +20,7 @@ OPERATIONAL_METRICS = {
     "review_severity_distribution",
     "cost_efficiency",
     "knowledge_retrieval_miss_rate",
+    "phase_execution_time",
 }
 
 EXPERIMENTAL_METRICS = {
@@ -62,7 +63,7 @@ def color_for_score(
     Skip color for non-ratio metrics (currency, count) where higher_is_better
     is False -- those values are not on a 0-1 scale.
     """
-    if not higher_is_better and display_format in ("currency", "count"):
+    if not higher_is_better and display_format in ("currency", "count", "duration"):
         return "white"
     if higher_is_better:
         if score >= 0.8:
@@ -97,6 +98,8 @@ def format_metric_line(
         score_str = f"{score:.1f}"
     elif display_format == "percent":
         score_str = f"{score:.2f}"
+    elif display_format == "duration":
+        score_str = f"{score:.1f}s"
     else:
         score_str = f"{score:.2f}"
     count_str = f" (n={sample_count})" if sample_count is not None else ""
@@ -252,6 +255,8 @@ def _format_delta_value(value: float, display_format: str) -> str:
         return f"{value:.1f}"
     if display_format == "percent":
         return f"{value * 100:.0f}%"
+    if display_format == "duration":
+        return f"{value:.1f}s"
     return f"{value:.2f}"
 
 
@@ -266,6 +271,8 @@ def _format_delta_change(delta: float, display_format: str) -> str:
         return f"{sign}{delta:.1f}"
     if display_format == "percent":
         return f"{sign}{delta * 100:.0f}%"
+    if display_format == "duration":
+        return f"{sign}{delta:.1f}s"
     return f"{sign}{delta:.2f}"
 
 

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -75,6 +75,16 @@ METRIC_METADATA: dict[str, dict[str, str | bool]] = {
         "threshold": "Target: <0.20",
         "docs_anchor": "knowledge-miss-rate",
     },
+    "phase_execution_time": {
+        "display_name": "Phase execution time",
+        "higher_is_better": False,
+        "display_format": "duration",
+        "description": "Mean total phase execution time per session (seconds)",
+        "subtitle": "How long the agent spends executing phases per session",
+        "direction": "lower is better",
+        "threshold": "",
+        "docs_anchor": "phase-execution-time",
+    },
     "faithfulness": {
         "display_name": "Faithfulness",
         "higher_is_better": True,
@@ -267,7 +277,7 @@ def html_color_for_score(
     Skip color for non-ratio metrics (currency, count) where higher_is_better
     is False -- those values are not on a 0-1 scale.
     """
-    if not higher_is_better and display_format in ("currency", "count"):
+    if not higher_is_better and display_format in ("currency", "count", "duration"):
         return "white"
     if higher_is_better:
         if score >= 0.8:
@@ -607,6 +617,8 @@ def write_diff_html_report(
             return f"{value:.1f}"
         if display_format == "percent":
             return f"{value * 100:.0f}%"
+        if display_format == "duration":
+            return f"{value:.1f}s"
         return f"{value:.2f}"
 
     def format_delta(delta: float, metric_name: str) -> str:
@@ -621,6 +633,8 @@ def write_diff_html_report(
             return f"{sign}{delta:.1f}"
         if display_format == "percent":
             return f"{sign}{delta * 100:.0f}%"
+        if display_format == "duration":
+            return f"{sign}{delta:.1f}s"
         return f"{sign}{delta:.2f}"
 
     env = _build_jinja_env()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,9 @@ def make_sample(
     verify_gen: int = 1,
     verify_status: Literal["completed", "failed", "skipped"] = "completed",
     findings: list[ReviewFinding] | None = None,
+    duration_ms: int | None = None,
+    tokens_in: int | None = None,
+    tokens_out: int | None = None,
 ) -> EvalSample:
     meta = SessionMeta(
         session_id=session_id,
@@ -35,13 +38,24 @@ def make_sample(
     )
     verify_output = "PASS" if verify_status == "completed" else "FAIL"
     phases = [
-        PhaseResult(name="implement", generation=1, status="completed", output="done"),
+        PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
+            output="done",
+            duration_ms=duration_ms,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+        ),
         PhaseResult(
             name="verify",
             generation=verify_gen,
             status=verify_status,
             output=verify_output,
             output_structured={"verdict": verify_output},
+            duration_ms=duration_ms,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
         ),
     ]
     return EvalSample(

--- a/tests/test_metrics_operational.py
+++ b/tests/test_metrics_operational.py
@@ -554,3 +554,101 @@ def test_knowledge_miss_rate_uses_session_phase_fallback():
     # "authentication" appears in knowledge_context, so it's a capability gap
     assert result.details["capability_gaps"] == 1
     assert result.details["retrieval_gaps"] == 0
+
+
+# --- PhaseExecutionTimeMetric ---
+
+
+class TestPhaseExecutionTime:
+    def test_computes_total_duration_per_session(self):
+        """Two phases with 5000ms each = 10.0s total per session."""
+        from raki.metrics.operational.latency import PhaseExecutionTimeMetric
+
+        sample = make_sample("s1", duration_ms=5000)
+        dataset = make_dataset(sample)
+        metric = PhaseExecutionTimeMetric()
+        result = metric.compute(dataset, MetricConfig())
+        # 2 phases * 5000ms = 10000ms = 10.0s
+        assert result.score == pytest.approx(10.0)
+
+    def test_skips_none_durations(self):
+        """Sessions with all None durations should be excluded from the aggregate."""
+        from raki.metrics.operational.latency import PhaseExecutionTimeMetric
+
+        sample = make_sample("s1", duration_ms=None)
+        dataset = make_dataset(sample)
+        metric = PhaseExecutionTimeMetric()
+        result = metric.compute(dataset, MetricConfig())
+        assert result.score == 0.0
+
+    def test_per_session_scores(self):
+        """Per-session scores should reflect total phase time in seconds."""
+        from raki.metrics.operational.latency import PhaseExecutionTimeMetric
+
+        sample_a = make_sample("s1", duration_ms=3000)
+        sample_b = make_sample("s2", duration_ms=6000)
+        dataset = make_dataset(sample_a, sample_b)
+        metric = PhaseExecutionTimeMetric()
+        result = metric.compute(dataset, MetricConfig())
+        # s1: 2 phases * 3000ms = 6.0s
+        assert result.sample_scores["s1"] == pytest.approx(6.0)
+        # s2: 2 phases * 6000ms = 12.0s
+        assert result.sample_scores["s2"] == pytest.approx(12.0)
+
+    def test_aggregate_is_mean_of_session_totals(self):
+        """Aggregate score should be the mean of per-session totals."""
+        from raki.metrics.operational.latency import PhaseExecutionTimeMetric
+
+        sample_a = make_sample("s1", duration_ms=3000)
+        sample_b = make_sample("s2", duration_ms=6000)
+        dataset = make_dataset(sample_a, sample_b)
+        metric = PhaseExecutionTimeMetric()
+        result = metric.compute(dataset, MetricConfig())
+        # mean of 6.0s and 12.0s = 9.0s
+        assert result.score == pytest.approx(9.0)
+
+    def test_details_include_percentiles(self):
+        """Details dict should include p50, p95, min, max keys."""
+        from raki.metrics.operational.latency import PhaseExecutionTimeMetric
+
+        samples = [make_sample(f"s{idx}", duration_ms=idx * 1000) for idx in range(1, 6)]
+        dataset = make_dataset(*samples)
+        metric = PhaseExecutionTimeMetric()
+        result = metric.compute(dataset, MetricConfig())
+        assert "p50" in result.details
+        assert "p95" in result.details
+        assert "min" in result.details
+        assert "max" in result.details
+
+    def test_details_min_max_values(self):
+        """Min and max should match the smallest and largest session totals."""
+        from raki.metrics.operational.latency import PhaseExecutionTimeMetric
+
+        sample_a = make_sample("s1", duration_ms=2000)  # 4.0s total
+        sample_b = make_sample("s2", duration_ms=8000)  # 16.0s total
+        dataset = make_dataset(sample_a, sample_b)
+        metric = PhaseExecutionTimeMetric()
+        result = metric.compute(dataset, MetricConfig())
+        assert result.details["min"] == pytest.approx(4.0)
+        assert result.details["max"] == pytest.approx(16.0)
+
+    def test_empty_dataset(self):
+        """Empty dataset should produce score 0.0."""
+        from raki.metrics.operational.latency import PhaseExecutionTimeMetric
+
+        dataset = EvalDataset(samples=[])
+        metric = PhaseExecutionTimeMetric()
+        result = metric.compute(dataset, MetricConfig())
+        assert result.score == 0.0
+
+    def test_metric_properties(self):
+        """Verify Protocol-required class attributes."""
+        from raki.metrics.operational.latency import PhaseExecutionTimeMetric
+
+        metric = PhaseExecutionTimeMetric()
+        assert metric.name == "phase_execution_time"
+        assert metric.higher_is_better is False
+        assert metric.display_format == "duration"
+        assert metric.requires_ground_truth is False
+        assert metric.requires_llm is False
+        assert metric.display_name == "Phase execution time"


### PR DESCRIPTION
## Summary

- Add `PhaseExecutionTimeMetric` with mean total phase duration, p50/p95/min/max details
- Support `duration` display format in CLI and HTML reports
- Extend `make_sample` factory with `duration_ms`, `tokens_in`, `tokens_out` kwargs
- 8 new tests covering computation, None handling, empty dataset, Protocol conformance

Refs #83

## Review
- Python Specialist: clean (3 MINOR — percentile calculation style, inline imports, test overlap)
- Security Specialist: not applicable (no I/O or user input)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko