### PR TITLE
feat(metrics): add token efficiency metric

### DIFF
--- a/docs/interpretation-reference.md
+++ b/docs/interpretation-reference.md
@@ -67,6 +67,30 @@ Fraction of rework-triggering findings where the relevant knowledge was not in t
 
 **Red zone action:** Extract the topics from missed findings and add them to your knowledge base. This is the single most direct way to improve agent quality.
 
+### phase_execution_time -- Phase execution time
+
+Mean total phase execution time per session in seconds (lower is better). Sums `duration_ms` across all phases in each session and converts to seconds. Does not capture inter-phase gaps, orchestration overhead, or human-in-the-loop pauses.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | < 60s | Phases complete quickly |
+| Yellow | 60s -- 300s | Noticeable execution time |
+| Red | > 300s | Phases are taking a long time to execute |
+
+**Red zone action:** Examine which phases are slowest. Long execution times usually come from expensive tool calls, large context processing, or excessive retry loops within a single phase.
+
+### token_efficiency -- Tokens / phase
+
+Average tokens (input + output) consumed per phase (lower is better). Measures how efficiently each phase uses context. Phases where both `tokens_in` and `tokens_out` are missing are skipped.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | < 2,000 | Phases are lean and efficient |
+| Yellow | 2,000 -- 8,000 | Moderate token usage per phase |
+| Red | > 8,000 | Phases consume excessive tokens |
+
+**Red zone action:** Check whether phases are receiving overly large context windows or generating verbose output. Reducing retrieved context size and tightening prompts are the most effective levers. High token counts combined with high cost_per_session confirm that token volume is driving spend.
+
 ## Retrieval Quality Metrics
 
 These metrics use LLM-backed evaluation via Ragas and require ground truth data.

--- a/src/raki/metrics/operational/__init__.py
+++ b/src/raki/metrics/operational/__init__.py
@@ -3,6 +3,7 @@ from raki.metrics.operational.knowledge_miss_rate import KnowledgeRetrievalMissR
 from raki.metrics.operational.latency import PhaseExecutionTimeMetric
 from raki.metrics.operational.rework import ReworkCycles
 from raki.metrics.operational.severity import ReviewSeverityDistribution
+from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
 from raki.metrics.operational.verify_rate import FirstPassVerifyRate
 
 ALL_OPERATIONAL = [
@@ -12,6 +13,7 @@ ALL_OPERATIONAL = [
     CostEfficiency(),
     KnowledgeRetrievalMissRate(),
     PhaseExecutionTimeMetric(),
+    TokenEfficiencyMetric(),
 ]
 
 __all__ = [
@@ -22,4 +24,5 @@ __all__ = [
     "PhaseExecutionTimeMetric",
     "ReviewSeverityDistribution",
     "ReworkCycles",
+    "TokenEfficiencyMetric",
 ]

--- a/src/raki/metrics/operational/token_efficiency.py
+++ b/src/raki/metrics/operational/token_efficiency.py
@@ -1,0 +1,47 @@
+import statistics
+
+from raki.metrics.protocol import MetricConfig
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+
+class TokenEfficiencyMetric:
+    name: str = "token_efficiency"
+    requires_ground_truth: bool = False
+    requires_llm: bool = False
+    higher_is_better: bool = False
+    display_format: str = "count"
+    display_name: str = "Tokens / phase"
+    description: str = "Average tokens (in + out) per phase"
+
+    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:
+        sample_scores: dict[str, float] = {}
+        session_averages: list[float] = []
+
+        for sample in dataset.samples:
+            phase_totals: list[int] = []
+            for phase in sample.phases:
+                if phase.tokens_in is None and phase.tokens_out is None:
+                    continue
+                phase_totals.append((phase.tokens_in or 0) + (phase.tokens_out or 0))
+
+            if not phase_totals:
+                continue
+
+            avg_per_phase = statistics.mean(phase_totals)
+            session_averages.append(avg_per_phase)
+            sample_scores[sample.session.session_id] = avg_per_phase
+
+        mean_avg = statistics.mean(session_averages) if session_averages else 0.0
+
+        details: dict[str, float | int] = {
+            "mean_tokens_per_phase": mean_avg,
+            "sessions_with_tokens": len(session_averages),
+        }
+
+        return MetricResult(
+            name=self.name,
+            score=mean_avg,
+            details=details,
+            sample_scores=sample_scores,
+        )

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -21,6 +21,7 @@ OPERATIONAL_METRICS = {
     "cost_efficiency",
     "knowledge_retrieval_miss_rate",
     "phase_execution_time",
+    "token_efficiency",
 }
 
 EXPERIMENTAL_METRICS = {

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -85,6 +85,16 @@ METRIC_METADATA: dict[str, dict[str, str | bool]] = {
         "threshold": "",
         "docs_anchor": "phase-execution-time",
     },
+    "token_efficiency": {
+        "display_name": "Tokens / phase",
+        "higher_is_better": False,
+        "display_format": "count",
+        "description": "Average tokens (in + out) per phase",
+        "subtitle": "How many tokens the agent uses per phase on average",
+        "direction": "lower is better",
+        "threshold": "",
+        "docs_anchor": "token-efficiency",
+    },
     "faithfulness": {
         "display_name": "Faithfulness",
         "higher_is_better": True,

--- a/tests/test_metrics_operational.py
+++ b/tests/test_metrics_operational.py
@@ -652,3 +652,98 @@ class TestPhaseExecutionTime:
         assert metric.requires_ground_truth is False
         assert metric.requires_llm is False
         assert metric.display_name == "Phase execution time"
+
+
+# --- TokenEfficiencyMetric ---
+
+
+class TestTokenEfficiency:
+    def test_computes_tokens_per_phase(self):
+        """Each phase gets tokens_in=1000 + tokens_out=500 = 1500 per phase."""
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+
+        sample = make_sample("s1", tokens_in=1000, tokens_out=500)
+        dataset = make_dataset(sample)
+        metric = TokenEfficiencyMetric()
+        result = metric.compute(dataset, MetricConfig())
+        # 2 phases, each with 1000+500=1500 tokens -> mean per phase = 1500.0
+        assert result.score == pytest.approx(1500.0)
+
+    def test_skips_phases_with_both_none_tokens(self):
+        """Sessions with all None tokens should be excluded from the aggregate."""
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+
+        sample = make_sample("s1", tokens_in=None, tokens_out=None)
+        dataset = make_dataset(sample)
+        metric = TokenEfficiencyMetric()
+        result = metric.compute(dataset, MetricConfig())
+        assert result.score == 0.0
+
+    def test_partial_none_tokens_treated_as_zero(self):
+        """Phases with only tokens_in=None but tokens_out set should count tokens_out."""
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+
+        sample = make_sample("s1", tokens_in=None, tokens_out=500)
+        dataset = make_dataset(sample)
+        metric = TokenEfficiencyMetric()
+        result = metric.compute(dataset, MetricConfig())
+        # Each phase: (0 + 500) = 500 tokens -> mean per phase = 500.0
+        assert result.score == pytest.approx(500.0)
+
+    def test_per_session_scores(self):
+        """Per-session scores should reflect average tokens per phase."""
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+
+        sample_a = make_sample("s1", tokens_in=500, tokens_out=200)
+        sample_b = make_sample("s2", tokens_in=2000, tokens_out=1000)
+        dataset = make_dataset(sample_a, sample_b)
+        metric = TokenEfficiencyMetric()
+        result = metric.compute(dataset, MetricConfig())
+        # s1: each phase = 700, mean = 700.0
+        assert result.sample_scores["s1"] == pytest.approx(700.0)
+        # s2: each phase = 3000, mean = 3000.0
+        assert result.sample_scores["s2"] == pytest.approx(3000.0)
+
+    def test_aggregate_is_mean_of_session_averages(self):
+        """Aggregate score should be the mean of per-session averages."""
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+
+        sample_a = make_sample("s1", tokens_in=500, tokens_out=200)
+        sample_b = make_sample("s2", tokens_in=2000, tokens_out=1000)
+        dataset = make_dataset(sample_a, sample_b)
+        metric = TokenEfficiencyMetric()
+        result = metric.compute(dataset, MetricConfig())
+        # mean of 700.0 and 3000.0 = 1850.0
+        assert result.score == pytest.approx(1850.0)
+
+    def test_empty_dataset(self):
+        """Empty dataset should produce score 0.0."""
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+
+        dataset = EvalDataset(samples=[])
+        metric = TokenEfficiencyMetric()
+        result = metric.compute(dataset, MetricConfig())
+        assert result.score == 0.0
+
+    def test_details_include_session_count(self):
+        """Details dict should include sessions_with_tokens count."""
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+
+        sample_a = make_sample("s1", tokens_in=500, tokens_out=200)
+        sample_b = make_sample("s2", tokens_in=None, tokens_out=None)
+        dataset = make_dataset(sample_a, sample_b)
+        metric = TokenEfficiencyMetric()
+        result = metric.compute(dataset, MetricConfig())
+        assert result.details["sessions_with_tokens"] == 1
+
+    def test_metric_properties(self):
+        """Verify Protocol-required class attributes."""
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+
+        metric = TokenEfficiencyMetric()
+        assert metric.name == "token_efficiency"
+        assert metric.higher_is_better is False
+        assert metric.display_format == "count"
+        assert metric.requires_ground_truth is False
+        assert metric.requires_llm is False
+        assert metric.display_name == "Tokens / phase"


### PR DESCRIPTION
## Summary

- Add `TokenEfficiencyMetric` computing mean tokens (in + out) per phase per session
- Skips phases with both token counts as None, treats single None as zero
- Zone tables added to interpretation reference for both new metrics
- 8 new tests covering computation, None handling, empty dataset, Protocol conformance

Refs #84

## Review
- Python Specialist: clean (2 MINOR — docs_anchor convention, inline imports)
- Security Specialist: not applicable (no I/O or user input)
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko