### PR TITLE
feat(build): lower Python floor from >=3.14 to >=3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           version: "latest"
-      - run: uv sync --python 3.14 --extra dev
+      - run: uv sync --python 3.12 --extra dev
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
 
@@ -25,16 +25,18 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           version: "latest"
-      - run: uv sync --python 3.14 --extra dev
+      - run: uv sync --python 3.12 --extra dev
       - run: uv run ty check src/raki/
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
         with:
           version: "latest"
-      - run: uv sync --python 3.14 --extra dev
+      - run: uv sync --python ${{ matrix.python-version }} --extra dev
       - run: uv run pytest tests/ -v --tb=short
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,15 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
         with:
           version: "latest"
-      - run: uv sync --python 3.14 --extra dev
+      - run: uv sync --python ${{ matrix.python-version }} --extra dev
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
       - run: uv run ty check src/raki/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## Tech stack
 
-- **Language**: Python 3.14
+- **Language**: Python >=3.12
 - **Package manager**: uv (not pip, not poetry, not conda)
 - **Build backend**: hatchling
 - **Models**: Pydantic 2 (`Field(default_factory=...)` for mutable defaults, `Literal` for constrained strings)
@@ -45,7 +45,7 @@ pyproject.toml
 ## Commands reference
 
 ```bash
-uv sync --python 3.14 --all-extras       # Install all dependencies
+uv sync --python 3.12 --all-extras       # Install all dependencies
 uv run pytest tests/ -v                   # Run tests
 uv run ruff check src/ tests/             # Lint
 uv run ruff format src/ tests/            # Format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for your interest in RAKI! This guide covers the workflow for contributin
 2. Set up your development environment:
 
 ```bash
-uv sync --python 3.14 --all-extras
+uv sync --python 3.12 --all-extras
 ```
 
 ## Branch Naming

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ uv run raki metrics --json
 ## Development
 
 ```bash
-uv sync --python 3.14 --all-extras
+uv sync --python 3.12 --all-extras
 uv run pytest tests/ -v
 uv run ruff check src/ tests/
 uv run ruff format src/ tests/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ Evaluate your agentic RAG sessions in under 10 minutes.
 
 ## Prerequisites
 
-- **Python 3.14** or later
+- **Python 3.12** or later
 - **[uv](https://docs.astral.sh/uv/)** package manager
 
 ## Install
@@ -12,11 +12,11 @@ Evaluate your agentic RAG sessions in under 10 minutes.
 ```bash
 git clone https://github.com/decko/raki.git
 cd raki
-uv sync --python 3.14 --extra html
+uv sync --python 3.12 --extra html
 ```
 
 > **LLM-backed metrics**: if you plan to use Ragas retrieval metrics, install
-> with `uv sync --python 3.14 --all-extras` instead. This pulls in
+> with `uv sync --python 3.12 --all-extras` instead. This pulls in
 > `scikit-network`, which requires a C++ compiler.
 
 Verify the install:

--- a/docs/orchestrator-prompt.md
+++ b/docs/orchestrator-prompt.md
@@ -17,7 +17,7 @@ You never write implementation code yourself. You manage the loop, track state, 
 - Milestone 5 (v0.4.0 — Security & Data Completeness): Issues #35, #36, #37 (ALL CLOSED)
 - Milestone 6 (Documentation): Issues #49, #50, #51, #52, #53, #54, #55, #56, #57 (ALL CLOSED)
 - Milestone 7 (v0.5.0 — Understand Your Results): Issues #68, #69, #70, #71
-- Tooling: Python 3.14, uv, ruff, ty (no mypy), pytest
+- Tooling: Python >=3.12, uv, ruff, ty (no mypy), pytest
 - Base branch: main
 
 ## Issue-to-Task Mapping
@@ -176,14 +176,14 @@ Acceptance criteria for issue #<N>:
 
 Working directory: <WORKTREE_PATH>
 
-Run: `uv sync --python 3.14 --extra ragas`
+Run: `uv sync --python 3.12 --extra ragas`
 
 Then inspect the installed Ragas package to discover the actual API:
 - `uv run python -c \"import ragas; print(ragas.__version__)\"`
 - `uv run python -c \"from ragas.metrics import collections; print(dir(collections))\"`
 - `uv run python -c \"from ragas.dataset_schema import SingleTurnSample; help(SingleTurnSample)\"`
 - `uv run python -c \"from ragas.llms import llm_factory; help(llm_factory)\"`
-- Read key source files in `.venv/lib/python3.14/site-packages/ragas/`
+- Read key source files in `.venv/lib/python3.12/site-packages/ragas/`
 
 Report the actual imports, class names, method signatures, and constructor parameters.
 Do NOT write any implementation code."
@@ -203,7 +203,7 @@ Read these files BEFORE writing any code:
 - For issues #29+: the spec under <WORKTREE_PATH>/docs/specs/ for the issue's milestone
 
 IMPORTANT:
-- Python 3.14, use modern syntax (X | Y unions, not Optional)
+- Python >=3.12, use modern syntax (X | Y unions, not Optional)
 - All defaults use Field(default_factory=...) for mutable types
 - Use Literal types for constrained strings (severity, difficulty, etc.)
 - TDD: write failing tests first, then implement

--- a/docs/specs/docs-milestone.md
+++ b/docs/specs/docs-milestone.md
@@ -86,7 +86,7 @@ Inline YAML comments explain each field. No separate manifest documentation — 
 
 `docs/getting-started.md` — under 100 lines. Structure:
 
-1. **Prerequisites** — Python 3.14, uv
+1. **Prerequisites** — Python 3.12+, uv
 2. **Install** — `uv pip install raki` or clone + `uv sync`
 3. **Quick Start** — run against bundled examples (copy-pasteable commands, 60 seconds to output)
 4. **Prepare Your Data** — what session data looks like, link to schema reference and examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "raki"
 version = "0.5.1"
 description = "Retrieval Assessment for Knowledge Impact — evaluate agentic RAG quality"
-requires-python = ">=3.14"
+requires-python = ">=3.12"
 license = "Apache-2.0"
 readme = "README.md"
 
@@ -42,7 +42,7 @@ raki = "raki.cli:main"
 line-length = 100
 
 [tool.ty.environment]
-python-version = "3.14"
+python-version = "3.12"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -201,7 +201,7 @@ class SessionSchemaAdapter:
                             else None,
                         )
                     )
-                except KeyError, ValueError:
+                except (KeyError, ValueError):
                     continue
         return findings
 
@@ -227,6 +227,6 @@ class SessionSchemaAdapter:
                         data=redact_dict(raw.get("data", {})),
                     )
                 )
-            except KeyError, ValueError, ValidationError:
+            except (KeyError, ValueError, ValidationError):
                 continue
         return events


### PR DESCRIPTION
## Summary

- Lower `requires-python` from `>=3.14` to `>=3.12` for broader CI/adoption
- CI matrix tests both Python 3.12 and 3.14
- Fix unparenthesized `except KeyError, ValueError:` in session_schema.py (3.12 compat)
- Update all docs, config, and spec references

Refs #85

## Review
- Python Specialist: clean after 1 fix (1 IMPORTANT: stale 3.14 ref in docs-milestone.md — fixed)
- Security Specialist: not applicable
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko