### PR TITLE
feat(metrics): add --judge-provider for LLM provider selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,17 @@ uv run raki run --manifest raki.yaml --no-llm
 
 The `--no-llm` flag runs operational metrics only (no API keys needed).
 To include Ragas retrieval metrics, omit the flag and configure an LLM provider.
+Use `--judge-provider anthropic` for direct Anthropic API access, or
+`--judge-provider vertex-anthropic` (default) for Vertex AI.
 
 ## Usage
 
 ```bash
-# Run all metrics (requires LLM provider)
+# Run all metrics (requires LLM provider -- Vertex AI Anthropic by default)
 uv run raki run --manifest raki.yaml
+
+# Run all metrics with direct Anthropic API
+uv run raki run --manifest raki.yaml --judge-provider anthropic
 
 # Run operational metrics only
 uv run raki run --manifest raki.yaml --no-llm

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,6 +18,11 @@ uv sync --python 3.12 --extra html
 > **LLM-backed metrics**: if you plan to use Ragas retrieval metrics, install
 > with `uv sync --python 3.12 --all-extras` instead. This pulls in
 > `scikit-network`, which requires a C++ compiler.
+>
+> By default, RAKI uses **Vertex AI Anthropic** (`--judge-provider vertex-anthropic`)
+> for LLM judge calls. If you have a direct Anthropic API key instead, use
+> `--judge-provider anthropic`. Set the `ANTHROPIC_API_KEY` environment variable
+> for direct API access, or configure Google Cloud credentials for Vertex AI.
 
 Verify the install:
 

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import cast
 from pathlib import Path
 
 import click
@@ -120,6 +121,13 @@ def main():
     help="LLM model for judge metrics (default: claude-sonnet-4-6)",
 )
 @click.option(
+    "--judge-provider",
+    "judge_provider",
+    type=click.Choice(["vertex-anthropic", "anthropic"]),
+    default="vertex-anthropic",
+    help="LLM provider for judge metrics (default: vertex-anthropic)",
+)
+@click.option(
     "--include-sessions",
     is_flag=True,
     help="Include full session data in JSON report",
@@ -136,6 +144,7 @@ def run(
     metric_names: str | None,
     parallel_count: int,
     judge_model: str,
+    judge_provider: str,
     include_sessions: bool,
     json_stdout: bool,
     verbose: bool,
@@ -223,9 +232,10 @@ def run(
 
     from raki.metrics import MetricsEngine
     from raki.metrics.operational import ALL_OPERATIONAL
-    from raki.metrics.protocol import Metric, MetricConfig
+    from raki.metrics.protocol import LLMProvider, Metric, MetricConfig
 
     config = MetricConfig(
+        llm_provider=cast(LLMProvider, judge_provider),
         llm_model=judge_model,
         batch_size=parallel_count,
         project_root=manifest_file.parent.resolve(),

--- a/src/raki/metrics/protocol.py
+++ b/src/raki/metrics/protocol.py
@@ -1,14 +1,16 @@
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel
 
 from raki.model import EvalDataset
 from raki.model.report import MetricResult
 
+LLMProvider = Literal["vertex-anthropic", "anthropic"]
+
 
 class MetricConfig(BaseModel):
-    llm_provider: str = "vertex-anthropic"
+    llm_provider: LLMProvider = "vertex-anthropic"
     llm_model: str = "claude-sonnet-4-6"
     temperature: float = 0.0
     batch_size: int = 4

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -32,8 +32,6 @@ def create_ragas_llm(config: MetricConfig):
     Raises:
         ValueError: If ``config.llm_provider`` is not a supported provider.
     """
-    from ragas.llms import llm_factory  # ty: ignore[unresolved-import]
-
     if config.llm_provider == "vertex-anthropic":
         from anthropic import AsyncAnthropicVertex  # ty: ignore[unresolved-import]
 
@@ -47,6 +45,8 @@ def create_ragas_llm(config: MetricConfig):
         raise ValueError(
             f"Unknown LLM provider: '{config.llm_provider}'. Supported providers: {supported_list}"
         )
+
+    from ragas.llms import llm_factory  # ty: ignore[unresolved-import]
 
     return llm_factory(
         config.llm_model,

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -1,29 +1,53 @@
 """LLM setup and judge logging for Ragas metrics.
 
-Uses Ragas 0.4 llm_factory with AsyncAnthropicVertex for Anthropic models
-on Google Cloud Vertex AI.
+Uses Ragas 0.4 llm_factory with configurable Anthropic client:
+- vertex-anthropic (default): AsyncAnthropicVertex for Vertex AI
+- anthropic: AsyncAnthropic for direct Anthropic API
 """
 
 import json
 import logging
 from pathlib import Path
+from typing import get_args
 
 from raki.adapters.redact import redact_sensitive
-from raki.metrics.protocol import MetricConfig
+from raki.metrics.protocol import LLMProvider, MetricConfig
 
 logger = logging.getLogger(__name__)
+
+SUPPORTED_PROVIDERS = get_args(LLMProvider)
 
 
 def create_ragas_llm(config: MetricConfig):
     """Create a Ragas LLM using the 0.4 llm_factory.
 
+    Dispatches on ``config.llm_provider``:
+
+    - ``vertex-anthropic`` (default) -- uses ``AsyncAnthropicVertex``
+    - ``anthropic`` -- uses ``AsyncAnthropic`` (direct Anthropic API)
+
     Defers ragas and anthropic imports so this module can be imported
     without those packages installed.
+
+    Raises:
+        ValueError: If ``config.llm_provider`` is not a supported provider.
     """
-    from anthropic import AsyncAnthropicVertex  # ty: ignore[unresolved-import]
     from ragas.llms import llm_factory  # ty: ignore[unresolved-import]
 
-    client = AsyncAnthropicVertex()
+    if config.llm_provider == "vertex-anthropic":
+        from anthropic import AsyncAnthropicVertex  # ty: ignore[unresolved-import]
+
+        client = AsyncAnthropicVertex()
+    elif config.llm_provider == "anthropic":
+        from anthropic import AsyncAnthropic  # ty: ignore[unresolved-import]
+
+        client = AsyncAnthropic()
+    else:
+        supported_list = ", ".join(SUPPORTED_PROVIDERS)
+        raise ValueError(
+            f"Unknown LLM provider: '{config.llm_provider}'. Supported providers: {supported_list}"
+        )
+
     return llm_factory(
         config.llm_model,
         client=client,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -604,6 +604,62 @@ class TestCliJudgeModel:
         assert result.exit_code == 0
 
 
+class TestCliJudgeProvider:
+    def test_judge_provider_vertex_anthropic_accepted(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--no-llm",
+                "--judge-provider",
+                "vertex-anthropic",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_judge_provider_anthropic_accepted(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--no-llm",
+                "--judge-provider",
+                "anthropic",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_judge_provider_invalid_rejected(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--no-llm",
+                "--judge-provider",
+                "openai",
+            ],
+        )
+        assert result.exit_code == 2
+
+    def test_judge_provider_default(self, empty_manifest):
+        """Default judge provider (vertex-anthropic) should be accepted without errors."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(empty_manifest), "--no-llm"],
+        )
+        assert result.exit_code == 0
+
+
 class TestCliParallelWiring:
     def test_parallel_option_accepted(self, empty_manifest):
         """--parallel should be accepted without 'not yet implemented' warning."""

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -1044,6 +1044,92 @@ class TestCreateRagasLlm:
         assert call_kwargs.kwargs["temperature"] == 0.0
 
 
+class TestLLMProviderDispatch:
+    """Tests for provider dispatch in create_ragas_llm()."""
+
+    def test_vertex_anthropic_uses_async_anthropic_vertex(self, monkeypatch: pytest.MonkeyPatch):
+        """vertex-anthropic provider should instantiate AsyncAnthropicVertex."""
+        import sys
+
+        mock_llm_factory = MagicMock(return_value=MagicMock())
+        mock_llms = MagicMock()
+        mock_llms.llm_factory = mock_llm_factory
+
+        mock_anthropic = MagicMock()
+        mock_vertex_instance = MagicMock()
+        mock_anthropic.AsyncAnthropicVertex = MagicMock(return_value=mock_vertex_instance)
+
+        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+        monkeypatch.setitem(sys.modules, "ragas", MagicMock())
+        monkeypatch.setitem(sys.modules, "ragas.llms", mock_llms)
+
+        from raki.metrics.ragas.llm_setup import create_ragas_llm
+
+        config = MetricConfig(llm_provider="vertex-anthropic")
+        create_ragas_llm(config)
+
+        mock_anthropic.AsyncAnthropicVertex.assert_called_once()
+        mock_llm_factory.assert_called_once()
+        call_kwargs = mock_llm_factory.call_args
+        assert call_kwargs.kwargs["client"] is mock_vertex_instance
+
+    def test_anthropic_uses_async_anthropic(self, monkeypatch: pytest.MonkeyPatch):
+        """anthropic provider should instantiate AsyncAnthropic (direct API)."""
+        import sys
+
+        mock_llm_factory = MagicMock(return_value=MagicMock())
+        mock_llms = MagicMock()
+        mock_llms.llm_factory = mock_llm_factory
+
+        mock_anthropic = MagicMock()
+        mock_direct_instance = MagicMock()
+        mock_anthropic.AsyncAnthropic = MagicMock(return_value=mock_direct_instance)
+
+        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+        monkeypatch.setitem(sys.modules, "ragas", MagicMock())
+        monkeypatch.setitem(sys.modules, "ragas.llms", mock_llms)
+
+        from raki.metrics.ragas.llm_setup import create_ragas_llm
+
+        config = MetricConfig(llm_provider="anthropic")
+        create_ragas_llm(config)
+
+        mock_anthropic.AsyncAnthropic.assert_called_once()
+        mock_llm_factory.assert_called_once()
+        call_kwargs = mock_llm_factory.call_args
+        assert call_kwargs.kwargs["client"] is mock_direct_instance
+
+    def test_unknown_provider_rejected_by_pydantic(self):
+        """Pydantic Literal type rejects unknown providers at config construction."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="literal_error"):
+            MetricConfig(llm_provider="openai")  # type: ignore[arg-type]
+
+    def test_unknown_provider_error_lists_valid_options(self):
+        """Pydantic error message should mention supported providers."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="vertex-anthropic") as exc_info:
+            MetricConfig(llm_provider="bedrock")  # type: ignore[arg-type]
+        assert "anthropic" in str(exc_info.value)
+
+    def test_create_ragas_llm_raises_on_invalid_provider(self):
+        """Defense-in-depth: create_ragas_llm raises ValueError for unknown providers."""
+        from raki.metrics.ragas.llm_setup import create_ragas_llm
+
+        # Bypass Pydantic validation to test the runtime guard
+        config = MetricConfig()
+        object.__setattr__(config, "llm_provider", "unknown")
+        with pytest.raises(ValueError, match="Unknown LLM provider"):
+            create_ragas_llm(config)
+
+    def test_default_provider_is_vertex_anthropic(self):
+        """MetricConfig default llm_provider should be vertex-anthropic."""
+        config = MetricConfig()
+        assert config.llm_provider == "vertex-anthropic"
+
+
 class TestCreateRagasEmbeddings:
     def test_uses_vertex_ai_embeddings(self, monkeypatch: pytest.MonkeyPatch):
         """create_ragas_embeddings() should use VertexAIEmbeddings, not OpenAI default."""


### PR DESCRIPTION
## Summary

- Add `LLMProvider` Literal type and provider dispatch to `create_ragas_llm()` — supports `vertex-anthropic` (default, uses `AsyncAnthropicVertex`) and `anthropic` (direct API, uses `AsyncAnthropic`)
- Wire `--judge-provider` CLI option to `MetricConfig.llm_provider`
- Add unit tests for both provider paths, invalid-provider rejection, and CLI integration
- Update docs/getting-started.md and README.md with LLM provider guidance

Refs #86

## Review
- Python Specialist: 1 CRITICAL fixed (ty type error in cli.py — cast for Literal), 1 IMPORTANT noted (embeddings provider dispatch out of scope), 2 MINOR accepted
- Security Specialist: not applicable
- RAG Specialist: not applicable

**Note:** `create_ragas_embeddings()` still always uses VertexAI — embeddings provider dispatch was not in scope for this issue. A follow-up may be needed for users on direct Anthropic API who want `answer_relevancy`.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko