### PR TITLE
feat(cli): add validate --deep for smoke testing

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,13 @@ Validate the example manifest:
 uv run raki validate --manifest examples/raki-minimal.yaml
 ```
 
+For a deeper smoke test that checks adapter loading, ground truth wiring, and
+operational metrics against a single sample (no LLM calls, no full run):
+
+```bash
+uv run raki validate --manifest examples/raki-minimal.yaml --deep
+```
+
 Run an evaluation using only operational metrics (no LLM required):
 
 ```bash

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from pathlib import Path
 
 import click
@@ -11,6 +11,12 @@ from rich.console import Console
 
 from raki.adapters.redact import redact_sensitive
 from raki.report.rerender import is_session_data_stripped, metric_stubs_from_metadata
+
+if TYPE_CHECKING:
+    from raki.adapters.loader import DatasetLoader
+    from raki.adapters.registry import AdapterRegistry
+    from raki.ground_truth.manifest import EvalManifest
+    from raki.model import EvalDataset
 
 console = Console()
 
@@ -348,7 +354,8 @@ def run(
 @click.option("-m", "--manifest", "manifest_path", default=None, help="Path to manifest file")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress auto-discovery messages")
 @click.option("-v", "--verbose", is_flag=True, help="Show debug output")
-def validate(manifest_path: str | None, quiet: bool, verbose: bool) -> None:
+@click.option("--deep", is_flag=True, help="Run smoke-test checks (adapter loading, metrics)")
+def validate(manifest_path: str | None, quiet: bool, verbose: bool, deep: bool) -> None:
     """Check manifest and session data without running metrics."""
     manifest_file = _resolve_manifest(manifest_path, quiet=quiet)
 
@@ -408,6 +415,116 @@ def validate(manifest_path: str | None, quiet: bool, verbose: bool) -> None:
         f"\nReady to evaluate [bold]{len(dataset.samples)}[/bold] sessions"
         f" ({len(loader.skipped)} skipped, {len(loader.errors)} errors)."
     )
+
+    if deep:
+        _run_deep_checks(registry, dataset, manifest, loader)
+
+
+def _run_deep_checks(
+    registry: AdapterRegistry,
+    dataset: EvalDataset,
+    manifest: EvalManifest,
+    loader: DatasetLoader,
+) -> None:
+    """Run deep smoke-test checks: adapter loading, ground truth, operational metrics.
+
+    No LLM calls, no full evaluation run, no report generation.
+    """
+    from raki.model import EvalDataset
+
+    console.print("\n[bold]Deep checks[/bold]")
+
+    # --- Check 1: Adapter loading ---
+    # Try loading one session through each registered adapter that detected sessions
+    if not dataset.samples:
+        console.print("[yellow]\u26a0[/yellow] No sessions loaded — skipping adapter checks")
+    else:
+        session_paths = sorted(p for p in manifest.sessions.path.iterdir() if p.is_dir())
+        for adapter in registry.list_all():
+            adapter_name = adapter.name
+            try:
+                # Find a path that this adapter can detect and load
+                loaded_any = False
+                for session_path in session_paths:
+                    if adapter.detect(session_path):
+                        sample = adapter.load(session_path)
+                        console.print(
+                            f"[green]\u2713[/green] Adapter [bold]{adapter_name}[/bold] "
+                            f"loaded session: {sample.session.session_id}"
+                        )
+                        loaded_any = True
+                        break
+                if not loaded_any:
+                    console.print(
+                        f"[dim]\u2014[/dim] Adapter [bold]{adapter_name}[/bold] "
+                        f"— no matching sessions found"
+                    )
+            except Exception as exc:
+                console.print(
+                    f"[red]\u2717[/red] Adapter [bold]{adapter_name}[/bold] "
+                    f"failed: {redact_sensitive(str(exc))}"
+                )
+
+    # --- Check 2: Ground truth loading and matching ---
+    if manifest.ground_truth.path is not None:
+        try:
+            from raki.ground_truth.matcher import load_ground_truth, match_ground_truth
+
+            gt_entries = load_ground_truth(manifest.ground_truth.path)
+            console.print(
+                f"[green]\u2713[/green] Ground truth loading: {len(gt_entries)} entries loaded"
+            )
+            if dataset.samples:
+                matched = sum(
+                    1
+                    for sample in dataset.samples
+                    if match_ground_truth(sample, gt_entries) is not None
+                )
+                console.print(
+                    f"[green]\u2713[/green] Ground truth matching: "
+                    f"{matched}/{len(dataset.samples)} sessions matched"
+                )
+            else:
+                console.print(
+                    "[yellow]\u26a0[/yellow] Ground truth matching: no sessions to match against"
+                )
+        except Exception as exc:
+            console.print(
+                f"[red]\u2717[/red] Ground truth loading failed: {redact_sensitive(str(exc))}"
+            )
+
+    # --- Check 3: Operational metrics against a single sample ---
+    if not dataset.samples:
+        console.print(
+            "[yellow]\u26a0[/yellow] Operational metrics — no sessions available, skipping"
+        )
+    else:
+        from raki.metrics.operational import ALL_OPERATIONAL
+        from raki.metrics.protocol import MetricConfig
+
+        single_dataset = EvalDataset(samples=[dataset.samples[0]])
+        config = MetricConfig()
+        all_passed = True
+        metric_lines: list[str] = []
+        for metric in ALL_OPERATIONAL:
+            try:
+                result = metric.compute(single_dataset, config)
+                metric_lines.append(f"    {metric.display_name}: {result.score}")
+            except Exception as exc:
+                all_passed = False
+                metric_lines.append(
+                    f"    [red]\u2717[/red] {metric.display_name}: "
+                    f"failed — {redact_sensitive(str(exc))}"
+                )
+        if all_passed:
+            console.print(
+                "[green]\u2713[/green] Operational metrics — "
+                "all computed successfully against 1 sample"
+            )
+        else:
+            console.print("[red]\u2717[/red] Operational metrics — some metrics failed")
+        for line in metric_lines:
+            console.print(line)
 
 
 @main.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1358,3 +1358,116 @@ class TestRagasMetricsSync:
             f"_RAGAS_METRICS keys {dict_keys} do not match "
             f"Ragas metric class .name attributes {class_names}"
         )
+
+
+class TestValidateDeep:
+    """Tests for raki validate --deep flag."""
+
+    def test_deep_flag_accepted(self, manifest_with_session):
+        """--deep should be an accepted option on the validate command."""
+        manifest, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest), "--deep"])
+        assert result.exit_code == 0
+
+    def test_deep_runs_adapter_check(self, manifest_with_session):
+        """--deep should check that each adapter can load a session."""
+        manifest, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest), "--deep"])
+        assert result.exit_code == 0
+        assert "Adapter" in result.output
+        assert "session-schema" in result.output
+
+    def test_deep_runs_operational_metrics_check(self, manifest_with_session):
+        """--deep should run operational metrics against a single sample."""
+        manifest, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest), "--deep"])
+        assert result.exit_code == 0
+        assert "Operational metrics" in result.output
+
+    def test_deep_shows_pass_indicators(self, manifest_with_session):
+        """--deep should show pass/fail indicators per check."""
+        manifest, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest), "--deep"])
+        assert result.exit_code == 0
+        # Should contain checkmark or PASS indicators
+        assert "\u2713" in result.output
+
+    def test_deep_checks_ground_truth_when_configured(self, manifest_with_ground_truth):
+        """--deep should check ground truth loading and matching when configured."""
+        manifest_path, _sessions, _gt = manifest_with_ground_truth
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest_path), "--deep"])
+        assert result.exit_code == 0
+        assert "ground truth" in result.output.lower()
+
+    def test_deep_no_ground_truth_skips_check(self, manifest_with_session):
+        """--deep should skip ground truth check when not configured."""
+        manifest, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest), "--deep"])
+        assert result.exit_code == 0
+        # Should not mention ground truth loading/matching (only the standard validate output)
+        # The deep section should not have ground truth checks
+        assert "Ground truth loading" not in result.output
+
+    def test_deep_no_llm_calls(self, manifest_with_session):
+        """--deep should not trigger any LLM metric computation."""
+        manifest, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest), "--deep"])
+        assert result.exit_code == 0
+        # Should not mention any LLM/Ragas metrics
+        assert "faithfulness" not in result.output.lower()
+        assert "context_precision" not in result.output.lower()
+
+    def test_deep_no_report_generation(self, manifest_with_session, tmp_path):
+        """--deep should not generate any report files."""
+        manifest, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest), "--deep"])
+        assert result.exit_code == 0
+        # No report files should be created in the current or results directory
+        json_files = list(tmp_path.glob("**/*.json"))
+        html_files = list(tmp_path.glob("**/*.html"))
+        # Only the manifest yaml should exist, no report outputs
+        assert not any("raki-report" in str(filepath) for filepath in json_files)
+        assert not any("raki-report" in str(filepath) for filepath in html_files)
+
+    def test_deep_with_empty_sessions_shows_skip(self, empty_manifest):
+        """--deep with no sessions should report that adapter checks are skipped."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(empty_manifest), "--deep"])
+        assert result.exit_code == 0
+        # Should indicate no sessions are available for deep checks
+        assert "no sessions" in result.output.lower() or "skip" in result.output.lower()
+
+    def test_deep_shows_metric_results(self, manifest_with_session):
+        """--deep should show individual metric results from the single-sample run."""
+        manifest, _sessions = manifest_with_session
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest), "--deep"])
+        assert result.exit_code == 0
+        # Should show at least one metric name or display name
+        assert "Verify rate" in result.output or "first_pass_verify_rate" in result.output
+
+    def test_deep_adapter_failure_shows_fail(self, tmp_path):
+        """--deep should show a failure indicator when an adapter fails to load."""
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        # Create a malformed session directory that will fail to load
+        bad_session = sessions / "bad-session"
+        bad_session.mkdir()
+        # session-schema expects meta.json; create one with invalid content
+        (bad_session / "meta.json").write_text("not valid json {{{")
+        manifest = tmp_path / "raki.yaml"
+        manifest.write_text(f"sessions:\n  path: {sessions}\n  format: auto\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "-m", str(manifest), "--deep"])
+        # Should still exit 0 (deep is informational) but show failure indicators
+        assert result.exit_code == 0
+        # Should contain a failure indicator
+        assert "\u2717" in result.output or "fail" in result.output.lower()


### PR DESCRIPTION
## Summary

- Add `--deep` flag to the `validate` command that smoke-tests adapters (loading sessions), ground truth (loading and matching when configured), and operational metrics (against a single sample)
- No LLM calls, no full run, no report generation — just quick per-check pass/fail with Rich output
- 11 new tests, docs/getting-started.md updated

Refs #88

## Review
- Python Specialist: 2 IMPORTANT fixed (type annotations on `_run_deep_checks`, unfiltered iterdir hoisted above loop), 3 MINOR accepted
- Security Specialist: clean (2 MINOR — same as Python findings, already fixed)

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko