### PR TITLE
fix(report): show N/A for metrics with no applicable data

### DIFF
--- a/src/raki/metrics/engine.py
+++ b/src/raki/metrics/engine.py
@@ -26,6 +26,7 @@ class MetricsEngine:
             result = metric.compute(dataset, self._config)
             results.append(result)
         aggregate = {result.name: result.score for result in results}
+        details = {result.name: result.details for result in results if result.details}
         sample_results = self._build_sample_results(dataset, results)
         return EvalReport(
             run_id=f"eval-{uuid.uuid4().hex[:8]}",
@@ -35,6 +36,7 @@ class MetricsEngine:
                 "skip_llm": skip_llm,
             },
             aggregate_scores=aggregate,
+            metric_details=details,
             sample_results=sample_results,
             manifest_hash=dataset.manifest_hash,
         )

--- a/src/raki/model/report.py
+++ b/src/raki/model/report.py
@@ -22,5 +22,6 @@ class EvalReport(BaseModel):
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     config: dict = Field(default_factory=dict)
     aggregate_scores: dict[str, float] = Field(default_factory=dict)
+    metric_details: dict[str, dict] = Field(default_factory=dict)
     sample_results: list[SampleResult] = Field(default_factory=list)
     manifest_hash: str | None = None

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -81,6 +81,15 @@ def color_for_score(
         return "red"
 
 
+def _has_no_data(metric_details: dict[str, dict], metric_name: str) -> bool:
+    """Check if a metric has no applicable data based on its details dict."""
+    details = metric_details.get(metric_name, {})
+    for key, value in details.items():
+        if key.startswith("sessions_with_") and value == 0:
+            return True
+    return False
+
+
 def format_metric_line(
     name: str,
     score: float,
@@ -89,10 +98,13 @@ def format_metric_line(
     higher_is_better: bool = True,
     sample_count: int | None = None,
     display_name: str | None = None,
+    no_data: bool = False,
 ) -> str:
     """Format a single metric line with color, display format, and sample count."""
-    color = color_for_score(score, higher_is_better, display_format)
     label = display_name or name
+    if no_data:
+        return f"[dim]  {label:<35} N/A    (no data)[/dim]"
+    color = color_for_score(score, higher_is_better, display_format)
     if display_format == "currency":
         score_str = f"${score:.2f}"
     elif display_format == "count":
@@ -207,6 +219,7 @@ def print_summary(
                     display_format=meta.display_format(name),
                     higher_is_better=meta.higher_is_better(name),
                     display_name=meta.display_name(name),
+                    no_data=_has_no_data(report.metric_details, name),
                 )
             )
         if session_count < 50:
@@ -228,6 +241,7 @@ def print_summary(
                     display_format=meta.display_format(name),
                     higher_is_better=meta.higher_is_better(name),
                     display_name=meta.display_name(name),
+                    no_data=_has_no_data(report.metric_details, name),
                 )
                 + tag
             )

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -84,10 +84,21 @@ def color_for_score(
 def _has_no_data(metric_details: dict[str, dict], metric_name: str) -> bool:
     """Check if a metric has no applicable data based on its details dict."""
     details = metric_details.get(metric_name, {})
+    if "skipped" in details:
+        return True
     for key, value in details.items():
         if key.startswith("sessions_with_") and value == 0:
             return True
     return False
+
+
+def _no_data_reason(metric_details: dict[str, dict], metric_name: str) -> str:
+    """Return a human-readable reason why a metric has no data."""
+    details = metric_details.get(metric_name, {})
+    skipped = details.get("skipped")
+    if skipped:
+        return str(skipped)
+    return "no data"
 
 
 def format_metric_line(
@@ -99,11 +110,12 @@ def format_metric_line(
     sample_count: int | None = None,
     display_name: str | None = None,
     no_data: bool = False,
+    no_data_reason: str = "no data",
 ) -> str:
     """Format a single metric line with color, display format, and sample count."""
     label = display_name or name
     if no_data:
-        return f"[dim]  {label:<35} N/A    (no data)[/dim]"
+        return f"[dim]  {label:<35} N/A    ({no_data_reason})[/dim]"
     color = color_for_score(score, higher_is_better, display_format)
     if display_format == "currency":
         score_str = f"${score:.2f}"
@@ -211,6 +223,7 @@ def print_summary(
     if operational:
         output_console.print("[bold]Operational Health[/bold]")
         for name, score in operational.items():
+            metric_no_data = _has_no_data(report.metric_details, name)
             output_console.print(
                 format_metric_line(
                     name,
@@ -219,7 +232,10 @@ def print_summary(
                     display_format=meta.display_format(name),
                     higher_is_better=meta.higher_is_better(name),
                     display_name=meta.display_name(name),
-                    no_data=_has_no_data(report.metric_details, name),
+                    no_data=metric_no_data,
+                    no_data_reason=_no_data_reason(report.metric_details, name)
+                    if metric_no_data
+                    else "no data",
                 )
             )
         if session_count < 50:
@@ -233,6 +249,7 @@ def print_summary(
         output_console.print("[bold]Retrieval Quality[/bold]")
         for name, score in retrieval.items():
             tag = " [yellow]\\[experimental][/yellow]" if name in EXPERIMENTAL_METRICS else ""
+            metric_no_data = _has_no_data(report.metric_details, name)
             output_console.print(
                 format_metric_line(
                     name,
@@ -241,9 +258,12 @@ def print_summary(
                     display_format=meta.display_format(name),
                     higher_is_better=meta.higher_is_better(name),
                     display_name=meta.display_name(name),
-                    no_data=_has_no_data(report.metric_details, name),
+                    no_data=metric_no_data,
+                    no_data_reason=_no_data_reason(report.metric_details, name)
+                    if metric_no_data
+                    else "no data",
                 )
-                + tag
+                + ("" if metric_no_data else tag)
             )
         if session_count < 50:
             output_console.print(

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -549,6 +549,12 @@ def write_html_report(
     recurring_failures = _collect_recurring_failures(report)
     worst_sessions = compute_worst_sessions(report, limit=5)
 
+    no_data_metrics: set[str] = set()
+    for metric_name, details in report.metric_details.items():
+        for key, value in details.items():
+            if key.startswith("sessions_with_") and value == 0:
+                no_data_metrics.add(metric_name)
+
     env = _build_jinja_env()
     template = env.get_template("report.html.j2")
 
@@ -591,6 +597,7 @@ def write_html_report(
         needs_attention_rows=needs_attention_rows,
         needs_attention_count=needs_attention_count,
         format_duration=_format_duration,
+        no_data_metrics=no_data_metrics,
     )
 
     output.write_text(html_content, encoding="utf-8")

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -549,11 +549,14 @@ def write_html_report(
     recurring_failures = _collect_recurring_failures(report)
     worst_sessions = compute_worst_sessions(report, limit=5)
 
-    no_data_metrics: set[str] = set()
+    no_data_metrics: dict[str, str] = {}
     for metric_name, details in report.metric_details.items():
+        if "skipped" in details:
+            no_data_metrics[metric_name] = str(details["skipped"])
+            continue
         for key, value in details.items():
             if key.startswith("sessions_with_") and value == 0:
-                no_data_metrics.add(metric_name)
+                no_data_metrics[metric_name] = "no data in sessions"
 
     env = _build_jinja_env()
     template = env.get_template("report.html.j2")

--- a/src/raki/report/templates/report.html.j2
+++ b/src/raki/report/templates/report.html.j2
@@ -753,7 +753,7 @@
           {% if meta.subtitle %}<div class="metric-subtitle">{{ meta.subtitle }}</div>{% endif %}
           {% if name in no_data_metrics %}
           <div class="metric-value" style="color: #666;">N/A</div>
-          <div class="metric-subtitle" style="color: #888; font-size: 0.75rem;">no data in sessions</div>
+          <div class="metric-subtitle" style="color: #888; font-size: 0.75rem;">{{ no_data_metrics[name] }}</div>
           {% else %}
           <div class="metric-value {{ color_class(score, name) }}">{% if meta.display_format == "currency" %}${{ "%.2f"|format(score) }}{% elif meta.display_format == "count" %}{{ "%.1f"|format(score) }}{% elif meta.display_format == "percent" %}{{ "%.0f"|format(score * 100) }}%{% elif meta.display_format == "duration" %}{{ "%.1f"|format(score) }}s{% else %}{{ "%.2f"|format(score) }}{% endif %}</div>
           {% endif %}

--- a/src/raki/report/templates/report.html.j2
+++ b/src/raki/report/templates/report.html.j2
@@ -751,11 +751,17 @@
             {% if meta.docs_anchor %}<a href="{{ docs_base_url }}#{{ meta.docs_anchor }}">{{ meta.display_name }}</a>{% else %}{{ meta.display_name }}{% endif %}
           </div>
           {% if meta.subtitle %}<div class="metric-subtitle">{{ meta.subtitle }}</div>{% endif %}
-          <div class="metric-value {{ color_class(score, name) }}">{% if meta.display_format == "currency" %}${{ "%.2f"|format(score) }}{% elif meta.display_format == "count" %}{{ "%.1f"|format(score) }}{% elif meta.display_format == "percent" %}{{ "%.0f"|format(score * 100) }}%{% else %}{{ "%.2f"|format(score) }}{% endif %}</div>
+          {% if name in no_data_metrics %}
+          <div class="metric-value" style="color: #666;">N/A</div>
+          <div class="metric-subtitle" style="color: #888; font-size: 0.75rem;">no data in sessions</div>
+          {% else %}
+          <div class="metric-value {{ color_class(score, name) }}">{% if meta.display_format == "currency" %}${{ "%.2f"|format(score) }}{% elif meta.display_format == "count" %}{{ "%.1f"|format(score) }}{% elif meta.display_format == "percent" %}{{ "%.0f"|format(score * 100) }}%{% elif meta.display_format == "duration" %}{{ "%.1f"|format(score) }}s{% else %}{{ "%.2f"|format(score) }}{% endif %}</div>
+          {% endif %}
+          {% if name not in no_data_metrics %}
           {% if name == "cost_efficiency" and cost_range %}
           <div class="cost-range">Range: ${{ "%.2f"|format(cost_range[0]) }} &ndash; ${{ "%.2f"|format(cost_range[1]) }}</div>
           {% endif %}
-          {% if meta.display_format not in ("currency", "count") and score <= 1.0 and score >= 0.0 %}
+          {% if meta.display_format not in ("currency", "count", "duration") and score <= 1.0 and score >= 0.0 %}
           <div class="metric-bar">
             <div class="metric-bar-fill bg-{{ color_name(score, name) }}" style="width: {{ (score * 100)|int }}%"></div>
           </div>
@@ -764,6 +770,7 @@
             {% if meta.direction %}<span class="direction-badge">{{ meta.direction }}</span>{% endif %}
             {% if meta.threshold %}<span class="threshold-label">{{ meta.threshold }}</span>{% endif %}
           </div>
+          {% endif %}
         </div>
         {% endif %}
         {% endfor %}

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -606,6 +606,14 @@ class TestNoDataMetricDisplay:
         }
         assert _has_no_data(details, "token_efficiency") is True
 
+    def test_has_no_data_detects_skipped(self) -> None:
+        from raki.report.cli_summary import _has_no_data
+
+        details = {
+            "faithfulness": {"skipped": "no samples"},
+        }
+        assert _has_no_data(details, "faithfulness") is True
+
     def test_has_no_data_returns_false_when_sessions_present(self) -> None:
         from raki.report.cli_summary import _has_no_data
 
@@ -618,6 +626,45 @@ class TestNoDataMetricDisplay:
         from raki.report.cli_summary import _has_no_data
 
         assert _has_no_data({}, "token_efficiency") is False
+
+    def test_no_data_reason_returns_skipped_message(self) -> None:
+        from raki.report.cli_summary import _no_data_reason
+
+        details = {
+            "faithfulness": {"skipped": "no samples"},
+        }
+        assert _no_data_reason(details, "faithfulness") == "no samples"
+
+    def test_no_data_reason_returns_default_for_sessions_with(self) -> None:
+        from raki.report.cli_summary import _no_data_reason
+
+        details = {
+            "token_efficiency": {"sessions_with_tokens": 0},
+        }
+        assert _no_data_reason(details, "token_efficiency") == "no data"
+
+    def test_print_summary_shows_skipped_reason_for_ragas_metrics(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        report = EvalReport(
+            run_id="test-skipped-ragas",
+            aggregate_scores={
+                "faithfulness": 0.0,
+                "context_precision": 0.0,
+            },
+            metric_details={
+                "faithfulness": {"skipped": "no samples"},
+                "context_precision": {"skipped": "no ground truth"},
+            },
+        )
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True)
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "N/A" in output
+        assert "no samples" in output or "no ground truth" in output
 
     def test_metric_details_populated_by_engine(self) -> None:
         from raki.metrics.engine import MetricsEngine

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -17,7 +17,7 @@ from raki.report.cli_summary import (
 )
 from raki.report.json_report import load_json_report, write_json_report
 
-from conftest import make_sample
+from conftest import make_dataset, make_sample
 
 
 def _make_report() -> EvalReport:
@@ -522,3 +522,111 @@ class TestGenerateSummarySentence:
         )
         sentence = generate_summary_sentence(report, session_count=0)
         assert isinstance(sentence, str)
+
+
+# --- No-data metric display tests ---
+
+
+class TestNoDataMetricDisplay:
+    def test_format_metric_line_shows_na_when_no_data(self) -> None:
+        line = format_metric_line(
+            "token_efficiency",
+            0.0,
+            display_name="Tokens / phase",
+            no_data=True,
+        )
+        assert "N/A" in line
+        assert "no data" in line
+        assert "[dim]" in line
+
+    def test_format_metric_line_shows_score_when_data_exists(self) -> None:
+        line = format_metric_line(
+            "token_efficiency",
+            1500.0,
+            display_format="count",
+            display_name="Tokens / phase",
+            no_data=False,
+        )
+        assert "1500.0" in line
+        assert "N/A" not in line
+
+    def test_print_summary_shows_na_for_no_data_metric(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        report = EvalReport(
+            run_id="test-no-data",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.8,
+                "token_efficiency": 0.0,
+            },
+            metric_details={
+                "first_pass_verify_rate": {"passed": 8, "total": 10},
+                "token_efficiency": {
+                    "mean_tokens_per_phase": 0.0,
+                    "sessions_with_tokens": 0,
+                },
+            },
+        )
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True)
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "N/A" in output
+
+    def test_print_summary_shows_score_when_data_present(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        report = EvalReport(
+            run_id="test-with-data",
+            aggregate_scores={
+                "token_efficiency": 1500.0,
+            },
+            metric_details={
+                "token_efficiency": {
+                    "mean_tokens_per_phase": 1500.0,
+                    "sessions_with_tokens": 5,
+                },
+            },
+        )
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True)
+        print_summary(report, session_count=5, console=test_console)
+        output = string_io.getvalue()
+        assert "N/A" not in output
+
+    def test_has_no_data_detects_sessions_with_zero(self) -> None:
+        from raki.report.cli_summary import _has_no_data
+
+        details = {
+            "token_efficiency": {"sessions_with_tokens": 0, "mean_tokens_per_phase": 0.0},
+        }
+        assert _has_no_data(details, "token_efficiency") is True
+
+    def test_has_no_data_returns_false_when_sessions_present(self) -> None:
+        from raki.report.cli_summary import _has_no_data
+
+        details = {
+            "token_efficiency": {"sessions_with_tokens": 5, "mean_tokens_per_phase": 1500.0},
+        }
+        assert _has_no_data(details, "token_efficiency") is False
+
+    def test_has_no_data_returns_false_for_missing_metric(self) -> None:
+        from raki.report.cli_summary import _has_no_data
+
+        assert _has_no_data({}, "token_efficiency") is False
+
+    def test_metric_details_populated_by_engine(self) -> None:
+        from raki.metrics.engine import MetricsEngine
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+        from raki.metrics.protocol import MetricConfig
+
+        sample = make_sample("s1", tokens_in=None, tokens_out=None)
+        dataset = make_dataset(sample)
+        engine = MetricsEngine([TokenEfficiencyMetric()], config=MetricConfig())
+        report = engine.run(dataset)
+        assert "token_efficiency" in report.metric_details
+        assert report.metric_details["token_efficiency"]["sessions_with_tokens"] == 0


### PR DESCRIPTION
## Summary

When session data lacks token counts or duration data, metrics now display
"N/A (no data)" instead of a misleading 0.0 score.

- CLI: dim style, "N/A (no data)" replaces the score value
- HTML: gray card with "N/A" and "no data in sessions" subtitle, no color bar
- JSON: unchanged (0.0 + details.sessions_with_tokens: 0 is unambiguous for machines)

Found during pre-release testing against real SODA session data that lacks
tokens_in/tokens_out fields.

Refs #101

## Changes

- `EvalReport.metric_details` field added (backward-compatible, defaults to empty dict)
- `MetricsEngine.run()` populates metric_details from computed results
- `cli_summary.py`: `_has_no_data()` helper + `no_data` param on `format_metric_line`
- `report.html.j2`: conditional gray card rendering for no-data metrics
- 8 new tests covering all paths

## Review

- Verified against SODA data (token_efficiency shows N/A)
- Verified against example data (token_efficiency shows 20105.8)
- 580 tests pass, ruff clean

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko