### PR TITLE
fix(ragas): pass provider='anthropic' to llm_factory, fix top_p conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ ragas = [
     "ragas>=0.4,<0.5",
     "anthropic>=0.40",
     "google-auth>=2.0",
+    "google-genai>=1.0",
     "langchain-google-vertexai>=2.0",
 ]
 html = [

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -48,25 +48,41 @@ def create_ragas_llm(config: MetricConfig):
 
     from ragas.llms import llm_factory  # ty: ignore[unresolved-import]
 
-    return llm_factory(
+    llm = llm_factory(
         config.llm_model,
+        provider="anthropic",
         client=client,
         temperature=config.temperature,
     )
+    llm.model_args.pop("top_p", None)
+    return llm
 
 
 def create_ragas_embeddings():
     """Create embeddings for answer_relevancy metric.
 
-    Uses VertexAIEmbeddings from langchain-google-vertexai for consistency
-    with the Vertex AI LLM setup. The previous embedding_factory() defaulted
-    to OpenAI, which was inconsistent with the Anthropic/Vertex AI LLM config.
+    Uses Ragas embedding_factory with a pre-configured Google genai Client
+    for Vertex AI. Resolves project/location from VERTEXAI_PROJECT and
+    VERTEXAI_LOCATION environment variables.
 
     Defers imports so this module can be imported without dependencies installed.
     """
-    from langchain_google_vertexai import VertexAIEmbeddings  # ty: ignore[unresolved-import]
+    import os
 
-    return VertexAIEmbeddings(model_name="text-embedding-005")
+    from google import genai  # ty: ignore[unresolved-import]
+    from ragas.embeddings.base import embedding_factory  # ty: ignore[unresolved-import]
+
+    project = os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("VERTEXAI_PROJECT")
+    location = os.environ.get("VERTEXAI_LOCATION", "us-central1")
+
+    client = genai.Client(vertexai=True, project=project, location=location)
+
+    return embedding_factory(
+        "google",
+        model="text-embedding-005",
+        client=client,
+        interface="modern",
+    )
 
 
 def _validate_judge_log_path(log_path: Path, project_root: Path | None = None) -> Path:

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -1131,45 +1131,76 @@ class TestLLMProviderDispatch:
 
 
 class TestCreateRagasEmbeddings:
-    def test_uses_vertex_ai_embeddings(self, monkeypatch: pytest.MonkeyPatch):
-        """create_ragas_embeddings() should use VertexAIEmbeddings, not OpenAI default."""
+    def test_uses_ragas_embedding_factory_with_google(self, monkeypatch: pytest.MonkeyPatch):
+        """create_ragas_embeddings() should use Ragas embedding_factory with Google provider."""
         import sys
 
-        mock_vertex_instance = MagicMock()
-        mock_vertex_class = MagicMock(return_value=mock_vertex_instance)
+        mock_embeddings_result = MagicMock()
+        mock_factory = MagicMock(return_value=mock_embeddings_result)
+        mock_embeddings_base = MagicMock()
+        mock_embeddings_base.embedding_factory = mock_factory
 
-        mock_langchain_vertex = MagicMock()
-        mock_langchain_vertex.VertexAIEmbeddings = mock_vertex_class
+        mock_genai_client = MagicMock()
+        mock_genai = MagicMock()
+        mock_genai.Client.return_value = mock_genai_client
 
-        monkeypatch.setitem(sys.modules, "langchain_google_vertexai", mock_langchain_vertex)
+        mock_google = MagicMock()
+        mock_google.genai = mock_genai
 
+        monkeypatch.setitem(sys.modules, "google", mock_google)
+        monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
+        monkeypatch.setitem(sys.modules, "ragas.embeddings", MagicMock())
+        monkeypatch.setitem(sys.modules, "ragas.embeddings.base", mock_embeddings_base)
+        monkeypatch.setenv("VERTEXAI_PROJECT", "test-project")
+        monkeypatch.setenv("VERTEXAI_LOCATION", "us-east5")
+
+        import importlib
+
+        import raki.metrics.ragas.llm_setup
+
+        importlib.reload(raki.metrics.ragas.llm_setup)
         from raki.metrics.ragas.llm_setup import create_ragas_embeddings
 
         result = create_ragas_embeddings()
-        mock_vertex_class.assert_called_once_with(model_name="text-embedding-005")
-        assert result is mock_vertex_instance
+        mock_factory.assert_called_once()
+        call_kwargs = mock_factory.call_args
+        assert call_kwargs[0][0] == "google"
+        assert call_kwargs[1]["model"] == "text-embedding-005"
+        assert call_kwargs[1]["interface"] == "modern"
+        assert result is mock_embeddings_result
 
-    def test_does_not_use_openai_default(self, monkeypatch: pytest.MonkeyPatch):
-        """Verify we don't call the OpenAI-defaulting embedding_factory()."""
+    def test_passes_vertex_project_to_genai_client(self, monkeypatch: pytest.MonkeyPatch):
+        """Verify genai.Client is created with vertexai=True and project from env."""
         import sys
 
-        mock_embedding_factory = MagicMock()
-        mock_embeddings_module = MagicMock()
-        mock_embeddings_module.embedding_factory = mock_embedding_factory
+        mock_genai_client = MagicMock()
+        mock_genai = MagicMock()
+        mock_genai.Client.return_value = mock_genai_client
 
-        mock_vertex_class = MagicMock(return_value=MagicMock())
-        mock_langchain_vertex = MagicMock()
-        mock_langchain_vertex.VertexAIEmbeddings = mock_vertex_class
+        mock_google = MagicMock()
+        mock_google.genai = mock_genai
 
-        monkeypatch.setitem(sys.modules, "ragas", MagicMock())
-        monkeypatch.setitem(sys.modules, "ragas.embeddings", mock_embeddings_module)
-        monkeypatch.setitem(sys.modules, "langchain_google_vertexai", mock_langchain_vertex)
+        mock_embeddings_base = MagicMock()
+        mock_embeddings_base.embedding_factory = MagicMock(return_value=MagicMock())
 
+        monkeypatch.setitem(sys.modules, "google", mock_google)
+        monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
+        monkeypatch.setitem(sys.modules, "ragas.embeddings", MagicMock())
+        monkeypatch.setitem(sys.modules, "ragas.embeddings.base", mock_embeddings_base)
+        monkeypatch.setenv("VERTEXAI_PROJECT", "my-project")
+        monkeypatch.setenv("VERTEXAI_LOCATION", "europe-west1")
+
+        import importlib
+
+        import raki.metrics.ragas.llm_setup
+
+        importlib.reload(raki.metrics.ragas.llm_setup)
         from raki.metrics.ragas.llm_setup import create_ragas_embeddings
 
         create_ragas_embeddings()
-        # embedding_factory (which defaults to OpenAI) should NOT be called
-        mock_embedding_factory.assert_not_called()
+        mock_genai.Client.assert_called_once_with(
+            vertexai=True, project="my-project", location="europe-west1"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two bugs preventing LLM-backed metrics from working:

1. `llm_factory()` was called without `provider="anthropic"`, defaulting to
   `"openai"` which failed trying to use `instructor.from_openai()` on an
   Anthropic client.

2. Ragas 0.4 `InstructorModelArgs` has `top_p=0.1` as default. Combined with
   our `temperature=0.0`, Anthropic API rejects the request. Fix: pop `top_p`
   from model_args after creation.

3. Embeddings updated to use Ragas `embedding_factory("google", ...)` with a
   pre-configured `genai.Client(vertexai=True)` for Vertex AI compatibility.
   Added `google-genai` to the ragas extra.

Refs #104

## Testing

- `test_create_ragas_llm_returns_valid_object` — PASS (was FAIL)
- `test_faithfulness_returns_score_between_0_and_1` — PASS (was FAIL)
- `test_create_ragas_embeddings` — known issue (Ragas GoogleEmbeddings ignores
  pre-configured client, tracked separately)
- 572 non-slow tests pass

## Known Issue

`answer_relevancy` integration test still fails — Ragas 0.4's `GoogleEmbeddings`
class ignores the client we pass and tries to create its own via
`genai.Client()` without Vertex AI config. This is a Ragas bug, tracked as a
separate issue for v0.7.0.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko