### PR TITLE
chore: set up towncrier for changelog generation

### DIFF
--- a/changes/+report-positional.breaking
+++ b/changes/+report-positional.breaking
@@ -1,0 +1,1 @@
+``raki report`` now takes the input file as a positional argument: ``raki report file.json`` replaces ``raki report --input file.json``.

--- a/changes/+threshold-warning.fix
+++ b/changes/+threshold-warning.fix
@@ -1,0 +1,1 @@
+Update ``--threshold`` + ``--no-llm`` warning to accurately state that threshold applies only to LLM-backed retrieval metrics.

--- a/changes/101.fix
+++ b/changes/101.fix
@@ -1,0 +1,1 @@
+Show "N/A (no data)" instead of misleading 0.0 for metrics when session data lacks the required fields (e.g., token counts).

--- a/changes/104.fix
+++ b/changes/104.fix
@@ -1,0 +1,1 @@
+Pass ``provider="anthropic"`` to Ragas ``llm_factory()`` and remove ``top_p`` from model args to fix Anthropic API compatibility.

--- a/changes/77.fix
+++ b/changes/77.fix
@@ -1,0 +1,1 @@
+Wire ground truth matching into CLI ``run`` and ``validate`` commands. Previously ``load_ground_truth()`` and ``match_ground_truth()`` were never called, causing Ragas metrics to silently produce 0.0 scores.

--- a/changes/78.misc
+++ b/changes/78.misc
@@ -1,0 +1,1 @@
+Extract adapter registry to ``default_registry()`` in ``adapters/__init__.py``, preparing for plugin discovery in v0.7.0.

--- a/changes/79.feature
+++ b/changes/79.feature
@@ -1,0 +1,1 @@
+Implement ``--adapter`` filtering to force a specific session adapter instead of auto-detection.

--- a/changes/80.feature
+++ b/changes/80.feature
@@ -1,0 +1,1 @@
+Implement ``--metrics`` filtering (comma-separated) and ``raki metrics`` subcommand for listing available metrics with ``--json`` support.

--- a/changes/81.breaking
+++ b/changes/81.breaking
@@ -1,0 +1,1 @@
+The ``--tenant`` CLI option has been removed. It wrote a field nothing consumed.

--- a/changes/82.misc
+++ b/changes/82.misc
@@ -1,0 +1,1 @@
+Extract report re-rendering helpers (``MetricStub``, ``is_session_data_stripped``, ``metric_stubs_from_metadata``) to ``raki/report/rerender.py``.

--- a/changes/83.feature
+++ b/changes/83.feature
@@ -1,0 +1,1 @@
+Add phase execution time metric (``phase_execution_time``) — sums ``duration_ms`` per session with p50/p95/min/max in details.

--- a/changes/84.feature
+++ b/changes/84.feature
@@ -1,0 +1,1 @@
+Add token efficiency metric (``token_efficiency``) — average tokens (in + out) per phase.

--- a/changes/85.feature
+++ b/changes/85.feature
@@ -1,0 +1,1 @@
+Lower Python floor from ``>=3.14`` to ``>=3.12``. CI matrix now tests both 3.12 and 3.14.

--- a/changes/86.feature
+++ b/changes/86.feature
@@ -1,0 +1,1 @@
+Add ``--judge-provider`` option for LLM provider selection (``vertex-anthropic`` or ``anthropic``).

--- a/changes/87.doc
+++ b/changes/87.doc
@@ -1,0 +1,1 @@
+Add CI quality gate example workflow (``docs/examples/github-actions-quality-gate.yml``).

--- a/changes/88.feature
+++ b/changes/88.feature
@@ -1,0 +1,1 @@
+Add ``raki validate --deep`` for smoke-testing adapters and operational metrics without LLM calls.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "ruff>=0.8",
+    "towncrier>=24.8",
     "ty",
 ]
 all = ["raki[ragas,html,dev]"]
@@ -43,6 +44,38 @@ line-length = 100
 
 [tool.ty.environment]
 python-version = "3.12"
+
+[tool.towncrier]
+package = "raki"
+directory = "changes"
+filename = "CHANGELOG.md"
+title_format = "## [{version}] — {project_date}"
+underlines = ["", "", ""]
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fix"
+name = "Bug Fixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Internal Changes"
+showcontent = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Set up towncrier for automated changelog generation. Includes:

- towncrier config in pyproject.toml (5 fragment types: breaking, feature, fix, doc, misc)
- `changes/` directory with news fragments for all v0.6.0 changes
- towncrier added to dev dependencies

Future workflow: each PR drops a fragment in `changes/<issue>.<type>`, and `towncrier build --version X.Y.Z` generates the changelog entry at release time. The orchestrator pipeline can create fragments automatically per issue.

## Usage

```bash
# Preview changelog
uv run towncrier build --draft --version 0.6.0

# Build changelog (writes to CHANGELOG.md, removes fragments)
uv run towncrier build --version 0.6.0
```

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko