### PR TITLE
feat(metrics): add Google judge provider for Gemini-as-judge

### DIFF
--- a/changes/110.feature
+++ b/changes/110.feature
@@ -1,0 +1,1 @@
+Add ``google`` as a third LLM judge provider, enabling Gemini models via Vertex AI (``--judge-provider google``).

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -129,7 +129,7 @@ def main():
 @click.option(
     "--judge-provider",
     "judge_provider",
-    type=click.Choice(["vertex-anthropic", "anthropic"]),
+    type=click.Choice(["vertex-anthropic", "anthropic", "google"]),
     default="vertex-anthropic",
     help="LLM provider for judge metrics (default: vertex-anthropic)",
 )

--- a/src/raki/metrics/protocol.py
+++ b/src/raki/metrics/protocol.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from raki.model import EvalDataset
 from raki.model.report import MetricResult
 
-LLMProvider = Literal["vertex-anthropic", "anthropic"]
+LLMProvider = Literal["vertex-anthropic", "anthropic", "google"]
 
 
 class MetricConfig(BaseModel):

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -1,8 +1,9 @@
 """LLM setup and judge logging for Ragas metrics.
 
-Uses Ragas 0.4 llm_factory with configurable Anthropic client:
+Uses Ragas 0.4 llm_factory with configurable LLM client:
 - vertex-anthropic (default): AsyncAnthropicVertex for Vertex AI
 - anthropic: AsyncAnthropic for direct Anthropic API
+- google: Google GenAI client via Vertex AI
 """
 
 import json
@@ -25,8 +26,9 @@ def create_ragas_llm(config: MetricConfig):
 
     - ``vertex-anthropic`` (default) -- uses ``AsyncAnthropicVertex``
     - ``anthropic`` -- uses ``AsyncAnthropic`` (direct Anthropic API)
+    - ``google`` -- uses ``google.genai.Client`` via Vertex AI
 
-    Defers ragas and anthropic imports so this module can be imported
+    Defers ragas and anthropic/google imports so this module can be imported
     without those packages installed.
 
     Raises:
@@ -40,6 +42,28 @@ def create_ragas_llm(config: MetricConfig):
         from anthropic import AsyncAnthropic  # ty: ignore[unresolved-import]
 
         client = AsyncAnthropic()
+    elif config.llm_provider == "google":
+        import os
+
+        from google import genai
+
+        project = os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("VERTEXAI_PROJECT")
+        if not project:
+            raise ValueError(
+                "Google provider requires GOOGLE_CLOUD_PROJECT or VERTEXAI_PROJECT environment variable"
+            )
+        location = os.environ.get("VERTEXAI_LOCATION", "us-central1")
+        client = genai.Client(vertexai=True, project=project, location=location)
+
+        from ragas.llms import llm_factory
+
+        llm = llm_factory(
+            config.llm_model,
+            provider="google",
+            client=client,
+            temperature=config.temperature,
+        )
+        return llm
     else:
         supported_list = ", ".join(SUPPORTED_PROVIDERS)
         raise ValueError(

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -45,7 +45,7 @@ def create_ragas_llm(config: MetricConfig):
     elif config.llm_provider == "google":
         import os
 
-        from google import genai
+        from google import genai  # ty: ignore[unresolved-import]
 
         project = os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("VERTEXAI_PROJECT")
         if not project:
@@ -55,7 +55,7 @@ def create_ragas_llm(config: MetricConfig):
         location = os.environ.get("VERTEXAI_LOCATION", "us-central1")
         client = genai.Client(vertexai=True, project=project, location=location)
 
-        from ragas.llms import llm_factory
+        from ragas.llms import llm_factory  # ty: ignore[unresolved-import]
 
         llm = llm_factory(
             config.llm_model,

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -1204,6 +1204,168 @@ class TestCreateRagasEmbeddings:
 
 
 # ---------------------------------------------------------------------------
+# Google provider tests — verify create_ragas_llm dispatches to Google
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleProvider:
+    def test_google_provider_creates_llm(self, monkeypatch):
+        """Google provider dispatches to llm_factory with provider='google'."""
+        import sys
+
+        mock_client = MagicMock()
+        mock_genai = MagicMock()
+        mock_genai.Client.return_value = mock_client
+        monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
+        monkeypatch.setattr("google.genai", mock_genai, raising=False)
+
+        mock_llm = MagicMock()
+        mock_factory = MagicMock(return_value=mock_llm)
+        monkeypatch.setitem(sys.modules, "ragas.llms", MagicMock(llm_factory=mock_factory))
+
+        from importlib import reload
+
+        from raki.metrics.ragas import llm_setup
+
+        reload(llm_setup)
+
+        config = MetricConfig(llm_provider="google", llm_model="gemini-2.5-pro")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+        monkeypatch.setenv("VERTEXAI_LOCATION", "us-central1")
+
+        result = llm_setup.create_ragas_llm(config)
+
+        mock_genai.Client.assert_called_once_with(
+            vertexai=True, project="test-project", location="us-central1"
+        )
+        mock_factory.assert_called_once()
+        call_kwargs = mock_factory.call_args
+        assert call_kwargs[0][0] == "gemini-2.5-pro"
+        assert call_kwargs[1]["provider"] == "google"
+        assert call_kwargs[1]["client"] == mock_client
+        assert result is mock_llm
+
+    def test_google_in_supported_providers(self):
+        """google is listed in SUPPORTED_PROVIDERS."""
+        from raki.metrics.ragas.llm_setup import SUPPORTED_PROVIDERS
+
+        assert "google" in SUPPORTED_PROVIDERS
+
+    def test_google_provider_missing_project_raises(self, monkeypatch):
+        """When neither GOOGLE_CLOUD_PROJECT nor VERTEXAI_PROJECT is set, raise ValueError."""
+        import sys
+
+        mock_genai = MagicMock()
+        monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
+        monkeypatch.setattr("google.genai", mock_genai, raising=False)
+
+        mock_factory = MagicMock(return_value=MagicMock())
+        monkeypatch.setitem(sys.modules, "ragas.llms", MagicMock(llm_factory=mock_factory))
+
+        from importlib import reload
+
+        from raki.metrics.ragas import llm_setup
+
+        reload(llm_setup)
+
+        config = MetricConfig(llm_provider="google", llm_model="gemini-2.5-pro")
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("VERTEXAI_PROJECT", raising=False)
+
+        with pytest.raises(ValueError, match="GOOGLE_CLOUD_PROJECT or VERTEXAI_PROJECT"):
+            llm_setup.create_ragas_llm(config)
+
+    def test_google_provider_vertexai_project_fallback(self, monkeypatch):
+        """VERTEXAI_PROJECT is used when GOOGLE_CLOUD_PROJECT is not set."""
+        import sys
+
+        mock_client = MagicMock()
+        mock_genai = MagicMock()
+        mock_genai.Client.return_value = mock_client
+        monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
+        monkeypatch.setattr("google.genai", mock_genai, raising=False)
+
+        mock_llm = MagicMock()
+        mock_factory = MagicMock(return_value=mock_llm)
+        monkeypatch.setitem(sys.modules, "ragas.llms", MagicMock(llm_factory=mock_factory))
+
+        from importlib import reload
+
+        from raki.metrics.ragas import llm_setup
+
+        reload(llm_setup)
+
+        config = MetricConfig(llm_provider="google", llm_model="gemini-2.5-pro")
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.setenv("VERTEXAI_PROJECT", "fallback-project")
+        monkeypatch.setenv("VERTEXAI_LOCATION", "us-central1")
+
+        llm_setup.create_ragas_llm(config)
+
+        mock_genai.Client.assert_called_once_with(
+            vertexai=True, project="fallback-project", location="us-central1"
+        )
+
+    def test_google_provider_forwards_temperature(self, monkeypatch):
+        """Temperature from MetricConfig is passed to llm_factory."""
+        import sys
+
+        mock_client = MagicMock()
+        mock_genai = MagicMock()
+        mock_genai.Client.return_value = mock_client
+        monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
+        monkeypatch.setattr("google.genai", mock_genai, raising=False)
+
+        mock_llm = MagicMock()
+        mock_factory = MagicMock(return_value=mock_llm)
+        monkeypatch.setitem(sys.modules, "ragas.llms", MagicMock(llm_factory=mock_factory))
+
+        from importlib import reload
+
+        from raki.metrics.ragas import llm_setup
+
+        reload(llm_setup)
+
+        config = MetricConfig(llm_provider="google", llm_model="gemini-2.5-pro", temperature=0.5)
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+
+        llm_setup.create_ragas_llm(config)
+
+        call_kwargs = mock_factory.call_args
+        assert call_kwargs[1]["temperature"] == 0.5
+
+    def test_google_provider_default_location(self, monkeypatch):
+        """When VERTEXAI_LOCATION is not set, 'us-central1' is used as default."""
+        import sys
+
+        mock_client = MagicMock()
+        mock_genai = MagicMock()
+        mock_genai.Client.return_value = mock_client
+        monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
+        monkeypatch.setattr("google.genai", mock_genai, raising=False)
+
+        mock_llm = MagicMock()
+        mock_factory = MagicMock(return_value=mock_llm)
+        monkeypatch.setitem(sys.modules, "ragas.llms", MagicMock(llm_factory=mock_factory))
+
+        from importlib import reload
+
+        from raki.metrics.ragas import llm_setup
+
+        reload(llm_setup)
+
+        config = MetricConfig(llm_provider="google", llm_model="gemini-2.5-pro")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+        monkeypatch.delenv("VERTEXAI_LOCATION", raising=False)
+
+        llm_setup.create_ragas_llm(config)
+
+        mock_genai.Client.assert_called_once_with(
+            vertexai=True, project="test-project", location="us-central1"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Integration tests (slow, requires LLM) — marked for selective running
 # ---------------------------------------------------------------------------
 

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -1216,8 +1216,10 @@ class TestGoogleProvider:
         mock_client = MagicMock()
         mock_genai = MagicMock()
         mock_genai.Client.return_value = mock_client
+        mock_google_module = MagicMock()
+        mock_google_module.genai = mock_genai
+        monkeypatch.setitem(sys.modules, "google", mock_google_module)
         monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
-        monkeypatch.setattr("google.genai", mock_genai, raising=False)
 
         mock_llm = MagicMock()
         mock_factory = MagicMock(return_value=mock_llm)
@@ -1256,8 +1258,10 @@ class TestGoogleProvider:
         import sys
 
         mock_genai = MagicMock()
+        mock_google_module = MagicMock()
+        mock_google_module.genai = mock_genai
+        monkeypatch.setitem(sys.modules, "google", mock_google_module)
         monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
-        monkeypatch.setattr("google.genai", mock_genai, raising=False)
 
         mock_factory = MagicMock(return_value=MagicMock())
         monkeypatch.setitem(sys.modules, "ragas.llms", MagicMock(llm_factory=mock_factory))
@@ -1282,8 +1286,10 @@ class TestGoogleProvider:
         mock_client = MagicMock()
         mock_genai = MagicMock()
         mock_genai.Client.return_value = mock_client
+        mock_google_module = MagicMock()
+        mock_google_module.genai = mock_genai
+        monkeypatch.setitem(sys.modules, "google", mock_google_module)
         monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
-        monkeypatch.setattr("google.genai", mock_genai, raising=False)
 
         mock_llm = MagicMock()
         mock_factory = MagicMock(return_value=mock_llm)
@@ -1313,8 +1319,10 @@ class TestGoogleProvider:
         mock_client = MagicMock()
         mock_genai = MagicMock()
         mock_genai.Client.return_value = mock_client
+        mock_google_module = MagicMock()
+        mock_google_module.genai = mock_genai
+        monkeypatch.setitem(sys.modules, "google", mock_google_module)
         monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
-        monkeypatch.setattr("google.genai", mock_genai, raising=False)
 
         mock_llm = MagicMock()
         mock_factory = MagicMock(return_value=mock_llm)
@@ -1341,8 +1349,10 @@ class TestGoogleProvider:
         mock_client = MagicMock()
         mock_genai = MagicMock()
         mock_genai.Client.return_value = mock_client
+        mock_google_module = MagicMock()
+        mock_google_module.genai = mock_genai
+        monkeypatch.setitem(sys.modules, "google", mock_google_module)
         monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
-        monkeypatch.setattr("google.genai", mock_genai, raising=False)
 
         mock_llm = MagicMock()
         mock_factory = MagicMock(return_value=mock_llm)


### PR DESCRIPTION
## Summary

Enable Gemini models as LLM judge for Ragas metrics via native Google provider support:

- Add `"google"` as a third option for `--judge-provider`, using `google.genai.Client` with Vertex AI ADC
- Validate that `GOOGLE_CLOUD_PROJECT` or `VERTEXAI_PROJECT` is set, raising a clear error otherwise
- Early return in the Google branch avoids the Anthropic-specific `top_p` workaround

Refs #110

## Review
- Python Specialist: 1 CRITICAL + 4 IMPORTANT fixed (CLI choice, project validation, towncrier, edge-case tests)
- Security Specialist: 1 IMPORTANT fixed (project validation), clean otherwise
- RAG Specialist: clean (correct llm_factory usage, proper early return)

## Test plan
- [x] `TestGoogleProvider` (6 tests): happy path, SUPPORTED_PROVIDERS membership, missing project env var, VERTEXAI_PROJECT fallback, temperature forwarding, default location
- [ ] Manual: `raki run --manifest <manifest> --judge --judge-provider google --judge-model gemini-2.5-pro` (requires Vertex AI credentials)

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko