### PR TITLE
feat(metrics): zero-config analytical metrics via context synthesis

### DIFF
--- a/changes/114.feature
+++ b/changes/114.feature
@@ -1,0 +1,1 @@
+Faithfulness and answer relevancy now work without ground truth by synthesizing retrieval context from session transcripts. Results from synthesized context are tagged with ``(inferred)`` in CLI output.

--- a/src/raki/adapters/alcove.py
+++ b/src/raki/adapters/alcove.py
@@ -7,6 +7,24 @@ from raki.model import EvalSample, PhaseResult, SessionMeta, ToolCall
 
 MAX_ALCOVE_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
 DETECT_READ_SIZE = 4096  # Only read first 4KB for format detection
+MAX_SYNTHESIZED_CONTEXT_CHARS = 50_000
+
+# Bash commands whose output is informational for retrieval context (whitelist).
+# Only include outputs from commands that start with one of these prefixes.
+_INFORMATIONAL_BASH_PREFIXES = (
+    "pytest",
+    "uv run pytest",
+    "uv run ruff",
+    "uv run ty",
+    "ruff",
+    "make",
+    "npm test",
+    "cargo test",
+    "grep",
+    "rg",
+    "find",
+    "cat",
+)
 
 
 class AlcoveAdapter:
@@ -111,9 +129,81 @@ class AlcoveAdapter:
             tool_calls=tool_calls,
         )
 
-        return EvalSample(
+        sample = EvalSample(
             session=meta,
             phases=[phase],
             findings=[],
             events=[],
         )
+
+        # Synthesize context from tool outputs if no phase has explicit knowledge_context
+        has_explicit_context = any(phase.knowledge_context is not None for phase in sample.phases)
+        if not has_explicit_context:
+            synthesized = self._synthesize_context(transcript)
+            if synthesized:
+                sample.phases[0].knowledge_context = synthesized
+                sample.context_source = "synthesized"
+
+        return sample
+
+    def _synthesize_context(self, transcript: list[dict]) -> str | None:
+        """Extract retrieval context from tool call outputs in the transcript.
+
+        Iterates through the transcript looking for tool_use blocks followed by
+        tool_result responses. Extracts content from Read, Grep, and informational
+        Bash tool calls.
+        """
+        # Build a map of tool_use_id -> tool_name from assistant messages
+        tool_name_by_id: dict[str, str] = {}
+        tool_command_by_id: dict[str, str] = {}
+
+        for entry in transcript:
+            if entry.get("type") != "assistant":
+                continue
+            message = entry.get("message", {})
+            for content_block in message.get("content", []):
+                if content_block.get("type") == "tool_use":
+                    tool_id = content_block.get("id", "")
+                    tool_name = content_block.get("name", "")
+                    tool_name_by_id[tool_id] = tool_name
+                    tool_input = content_block.get("input", {})
+                    if isinstance(tool_input, dict):
+                        tool_command_by_id[tool_id] = tool_input.get("command", "")
+
+        # Extract tool result content
+        context_chunks: list[str] = []
+
+        for entry in transcript:
+            if entry.get("type") != "user":
+                continue
+            message = entry.get("message", {})
+            for content_block in message.get("content", []):
+                if not isinstance(content_block, dict):
+                    continue
+                if content_block.get("type") != "tool_result":
+                    continue
+
+                tool_id = content_block.get("tool_use_id", "")
+                tool_name = tool_name_by_id.get(tool_id, "")
+                result_content = content_block.get("content", "")
+
+                if not result_content or not isinstance(result_content, str):
+                    continue
+
+                if tool_name in ("Read", "Grep"):
+                    redacted_chunk = redact_sensitive(result_content)
+                    context_chunks.append(redacted_chunk)
+                elif tool_name == "Bash":
+                    command = tool_command_by_id.get(tool_id, "").lstrip()
+                    if not command.startswith(_INFORMATIONAL_BASH_PREFIXES):
+                        continue
+                    redacted_chunk = redact_sensitive(result_content)
+                    context_chunks.append(redacted_chunk)
+
+        if not context_chunks:
+            return None
+
+        joined = "\n---\n".join(context_chunks)
+        if len(joined) > MAX_SYNTHESIZED_CONTEXT_CHARS:
+            joined = joined[:MAX_SYNTHESIZED_CONTEXT_CHARS]
+        return joined

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -11,6 +11,8 @@ from raki.model import EvalSample, PhaseResult, ReviewFinding, SessionEvent, Ses
 PHASE_NAMES = ["triage", "plan", "implement", "verify"]
 
 MAX_SESSION_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+MAX_IMPLEMENT_FALLBACK_CHARS = 10_000
+MAX_SYNTHESIZED_CONTEXT_CHARS = 50_000
 
 
 def _read_bounded(path: Path) -> str:
@@ -95,7 +97,31 @@ class SessionSchemaAdapter:
         )
         phases = self._load_phases(source, meta_raw, events)
         findings = self._load_findings(source)
-        return EvalSample(session=meta, phases=phases, findings=findings, events=events)
+        sample = EvalSample(session=meta, phases=phases, findings=findings, events=events)
+
+        # Synthesize context from phase outputs if no phase has explicit knowledge_context
+        has_explicit_context = any(phase.knowledge_context is not None for phase in sample.phases)
+        if not has_explicit_context and sample.phases:
+            synthesized = self._synthesize_context(sample.phases)
+            if synthesized:
+                # Store on the implement phase (where to_ragas_rows reads from)
+                target_phase = None
+                for phase in reversed(sample.phases):
+                    if phase.name == "implement":
+                        target_phase = phase
+                        break
+                if target_phase is None:
+                    for phase in reversed(sample.phases):
+                        if phase.name == "session":
+                            target_phase = phase
+                            break
+                if target_phase is None and sample.phases:
+                    target_phase = sample.phases[-1]
+                if target_phase:
+                    target_phase.knowledge_context = synthesized
+                    sample.context_source = "synthesized"
+
+        return sample
 
     def _load_phases(
         self,
@@ -204,6 +230,92 @@ class SessionSchemaAdapter:
                 except (KeyError, ValueError):
                     continue
         return findings
+
+    def _synthesize_context(self, phases: list[PhaseResult]) -> str | None:
+        """Synthesize retrieval context from structured phase outputs.
+
+        Extracts relevant fields from triage, plan, and implement phases:
+        - Triage: approach, code_area, files, risks
+        - Plan: approach, task descriptions and files
+        - Implement: files_changed, commits, deviations; falls back to output text
+        """
+        context_chunks: list[str] = []
+
+        for phase in phases:
+            if phase.name == "triage" and phase.output_structured:
+                triage_parts: list[str] = []
+                approach = phase.output_structured.get("approach")
+                if approach and isinstance(approach, str):
+                    triage_parts.append(f"Approach: {approach}")
+                code_area = phase.output_structured.get("code_area")
+                if code_area and isinstance(code_area, str):
+                    triage_parts.append(f"Code area: {code_area}")
+                files = phase.output_structured.get("files")
+                if files and isinstance(files, list):
+                    triage_parts.append(f"Files: {', '.join(str(filepath) for filepath in files)}")
+                risks = phase.output_structured.get("risks")
+                if risks and isinstance(risks, list):
+                    triage_parts.append(f"Risks: {', '.join(str(risk) for risk in risks)}")
+                if triage_parts:
+                    context_chunks.append(redact_sensitive("\n".join(triage_parts)))
+
+            elif phase.name == "plan" and phase.output_structured:
+                plan_parts: list[str] = []
+                approach = phase.output_structured.get("approach")
+                if approach and isinstance(approach, str):
+                    plan_parts.append(f"Plan approach: {approach}")
+                tasks = phase.output_structured.get("tasks")
+                if tasks and isinstance(tasks, list):
+                    for task_item in tasks:
+                        if isinstance(task_item, dict):
+                            description = task_item.get("description", "")
+                            task_files = task_item.get("files", [])
+                            if description:
+                                task_line = f"Task: {description}"
+                                if task_files and isinstance(task_files, list):
+                                    task_line += f" (files: {', '.join(str(filepath) for filepath in task_files)})"
+                                plan_parts.append(task_line)
+                if plan_parts:
+                    context_chunks.append(redact_sensitive("\n".join(plan_parts)))
+
+            elif phase.name == "implement" and phase.output_structured:
+                impl_parts: list[str] = []
+                files_changed = phase.output_structured.get("files_changed")
+                if files_changed and isinstance(files_changed, list):
+                    impl_parts.append(
+                        f"Files changed: {', '.join(str(filepath) for filepath in files_changed)}"
+                    )
+                commits = phase.output_structured.get("commits")
+                if commits and isinstance(commits, list):
+                    commit_messages = []
+                    for commit_item in commits:
+                        if isinstance(commit_item, dict):
+                            msg = commit_item.get("message", "")
+                            if msg:
+                                commit_messages.append(str(msg))
+                    if commit_messages:
+                        impl_parts.append(f"Commits: {'; '.join(commit_messages)}")
+                deviations = phase.output_structured.get("deviations")
+                if deviations and isinstance(deviations, str):
+                    impl_parts.append(f"Deviations: {deviations}")
+                if impl_parts:
+                    context_chunks.append(redact_sensitive("\n".join(impl_parts)))
+
+        # Fall back to implement phase output when structured fields are insufficient
+        if not context_chunks:
+            for phase in phases:
+                if phase.name == "implement" and phase.output:
+                    fallback_text = phase.output[:MAX_IMPLEMENT_FALLBACK_CHARS]
+                    context_chunks.append(redact_sensitive(fallback_text))
+                    break
+
+        if not context_chunks:
+            return None
+
+        joined = "\n---\n".join(context_chunks)
+        if len(joined) > MAX_SYNTHESIZED_CONTEXT_CHARS:
+            joined = joined[:MAX_SYNTHESIZED_CONTEXT_CHARS]
+        return joined
 
     def _load_events(self, source: Path) -> list[SessionEvent]:
         events_file = source / "events.jsonl"

--- a/src/raki/metrics/ragas/adapter.py
+++ b/src/raki/metrics/ragas/adapter.py
@@ -80,3 +80,18 @@ def _extract_question(sample: EvalSample) -> str:
             if summary:
                 return summary
     return sample.session.ticket or sample.session.session_id
+
+
+def detect_context_source(dataset: EvalDataset) -> str | None:
+    """Determine the predominant context_source across dataset samples.
+
+    Returns "synthesized" if any sample used synthesized context,
+    "explicit" if all samples used explicit context, or None if no samples
+    have context_source set.
+    """
+    sources = {sample.context_source for sample in dataset.samples if sample.context_source}
+    if not sources:
+        return None
+    if "synthesized" in sources:
+        return "synthesized"
+    return "explicit"

--- a/src/raki/metrics/ragas/faithfulness.py
+++ b/src/raki/metrics/ragas/faithfulness.py
@@ -12,7 +12,7 @@ import logging
 
 from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
-from raki.metrics.ragas.adapter import to_ragas_rows
+from raki.metrics.ragas.adapter import detect_context_source, to_ragas_rows
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
 from raki.model import EvalDataset
@@ -44,7 +44,16 @@ class FaithfulnessMetric:
     ) -> MetricResult:
         rows = to_ragas_rows(dataset)
         if not rows:
-            return MetricResult(name=self.name, score=0.0, details={"skipped": "no samples"})
+            return MetricResult(
+                name=self.name, score=None, details={"skipped": "no retrieval context"}
+            )
+
+        # Guard: if all rows have empty retrieved_contexts, return N/A
+        rows_with_contexts = [row for row in rows if row.retrieved_contexts]
+        if not rows_with_contexts:
+            return MetricResult(
+                name=self.name, score=None, details={"skipped": "no retrieval context"}
+            )
 
         from ragas.metrics.collections import (  # ty: ignore[unresolved-import]
             Faithfulness as RagasFaithfulness,
@@ -92,16 +101,24 @@ class FaithfulnessMetric:
         run_async(score_all())
 
         mean_score = sum(scores) / len(scores) if scores else 0.0
+
+        # Determine context_source from the dataset samples
+        context_source = detect_context_source(dataset)
+
+        details: dict = {
+            "samples_scored": len(scores),
+            "samples_skipped": len(rows) - len(scores),
+            "experimental": True,
+            "caveat": (
+                "Designed for NL answers, not code -- scores may be noisy for agentic sessions"
+            ),
+        }
+        if context_source is not None:
+            details["context_source"] = context_source
+
         return MetricResult(
             name=self.name,
             score=mean_score,
-            details={
-                "samples_scored": len(scores),
-                "samples_skipped": len(rows) - len(scores),
-                "experimental": True,
-                "caveat": (
-                    "Designed for NL answers, not code -- scores may be noisy for agentic sessions"
-                ),
-            },
+            details=details,
             sample_scores=sample_scores,
         )

--- a/src/raki/metrics/ragas/relevancy.py
+++ b/src/raki/metrics/ragas/relevancy.py
@@ -12,7 +12,7 @@ import logging
 
 from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
-from raki.metrics.ragas.adapter import to_ragas_rows
+from raki.metrics.ragas.adapter import detect_context_source, to_ragas_rows
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_embeddings, create_ragas_llm
 from raki.model import EvalDataset
@@ -44,7 +44,16 @@ class AnswerRelevancyMetric:
     ) -> MetricResult:
         rows = to_ragas_rows(dataset)
         if not rows:
-            return MetricResult(name=self.name, score=0.0, details={"skipped": "no samples"})
+            return MetricResult(
+                name=self.name, score=None, details={"skipped": "no retrieval context"}
+            )
+
+        # Guard: if all rows have empty retrieved_contexts, return N/A
+        rows_with_contexts = [row for row in rows if row.retrieved_contexts]
+        if not rows_with_contexts:
+            return MetricResult(
+                name=self.name, score=None, details={"skipped": "no retrieval context"}
+            )
 
         from ragas.metrics.collections import (  # ty: ignore[unresolved-import]
             AnswerRelevancy as RagasAnswerRelevancy,
@@ -92,16 +101,24 @@ class AnswerRelevancyMetric:
         run_async(score_all())
 
         mean_score = sum(scores) / len(scores) if scores else 0.0
+
+        # Determine context_source from the dataset samples
+        context_source = detect_context_source(dataset)
+
+        details: dict = {
+            "samples_scored": len(scores),
+            "samples_skipped": len(rows) - len(scores),
+            "experimental": True,
+            "caveat": (
+                "Designed for NL answers, not code -- scores may be noisy for agentic sessions"
+            ),
+        }
+        if context_source is not None:
+            details["context_source"] = context_source
+
         return MetricResult(
             name=self.name,
             score=mean_score,
-            details={
-                "samples_scored": len(scores),
-                "samples_skipped": len(rows) - len(scores),
-                "experimental": True,
-                "caveat": (
-                    "Designed for NL answers, not code -- scores may be noisy for agentic sessions"
-                ),
-            },
+            details=details,
             sample_scores=sample_scores,
         )

--- a/src/raki/model/dataset.py
+++ b/src/raki/model/dataset.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -25,6 +26,7 @@ class EvalSample(BaseModel):
     findings: list[ReviewFinding]
     events: list[SessionEvent]
     ground_truth: GroundTruth | None = None
+    context_source: Literal["explicit", "synthesized"] | None = None
 
 
 class EvalDataset(BaseModel):

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -29,6 +29,11 @@ EXPERIMENTAL_METRICS = {
     "answer_relevancy",
 }
 
+CONTEXT_SENSITIVE_METRICS = {
+    "faithfulness",
+    "answer_relevancy",
+}
+
 
 class _MetricMeta:
     """Lookup helper for metric display metadata."""
@@ -90,6 +95,12 @@ def _has_no_data(metric_details: dict[str, dict], metric_name: str) -> bool:
         if key.startswith("sessions_with_") and value == 0:
             return True
     return False
+
+
+def _is_synthesized_context(metric_details: dict[str, dict], metric_name: str) -> bool:
+    """Check if a metric used synthesized (inferred) context."""
+    details = metric_details.get(metric_name, {})
+    return details.get("context_source") == "synthesized"
 
 
 def _no_data_reason(metric_details: dict[str, dict], metric_name: str) -> str:
@@ -251,6 +262,14 @@ def print_summary(
         for name, score in retrieval.items():
             tag = " [yellow]\\[experimental][/yellow]" if name in EXPERIMENTAL_METRICS else ""
             metric_no_data = _has_no_data(report.metric_details, name)
+            # Check if context was synthesized for this metric
+            inferred_tag = ""
+            if (
+                not metric_no_data
+                and name in CONTEXT_SENSITIVE_METRICS
+                and _is_synthesized_context(report.metric_details, name)
+            ):
+                inferred_tag = " [cyan]\\(inferred)[/cyan]"
             output_console.print(
                 format_metric_line(
                     name,
@@ -264,7 +283,7 @@ def print_summary(
                     if metric_no_data
                     else "no data",
                 )
-                + ("" if metric_no_data else tag)
+                + ("" if metric_no_data else tag + inferred_tag)
             )
         if session_count < 50:
             output_console.print(

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1207,3 +1207,802 @@ def test_session_schema_no_token_counts_from_either_source(tmp_path):
     assert len(impl_phases) == 1
     assert impl_phases[0].tokens_in is None
     assert impl_phases[0].tokens_out is None
+
+
+# --- Alcove context synthesis tests (issue #114) ---
+
+
+class TestAlcoveContextExtraction:
+    def test_synthesizes_context_from_read_tool(self, tmp_path):
+        """Read tool outputs should be extracted as synthesized context."""
+        transcript = {
+            "session_id": "ctx-read-test",
+            "transcript": [
+                {"type": "system", "model": "claude-sonnet-4-20250514"},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_01",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                        "content": [
+                            {
+                                "id": "toolu_01",
+                                "name": "Read",
+                                "type": "tool_use",
+                                "input": {"file_path": "/src/main.py"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": "def main():\n    print('hello')",
+                                "tool_use_id": "toolu_01",
+                            }
+                        ],
+                    },
+                    "timestamp": "2026-04-16T12:11:06.161Z",
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_02",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 5, "output_tokens": 10},
+                        "content": [{"type": "text", "text": "I read the file."}],
+                    },
+                },
+                {
+                    "type": "result",
+                    "total_cost_usd": 0.01,
+                    "duration_ms": 5000,
+                },
+            ],
+        }
+        fixture = tmp_path / "session.json"
+        fixture.write_text(json.dumps(transcript))
+        adapter = AlcoveAdapter()
+        sample = adapter.load(fixture)
+        assert sample.phases[0].knowledge_context is not None
+        assert "def main()" in sample.phases[0].knowledge_context
+        assert sample.context_source == "synthesized"
+
+    def test_synthesizes_context_from_grep_tool(self, tmp_path):
+        """Grep tool outputs should be extracted as synthesized context."""
+        transcript = {
+            "session_id": "ctx-grep-test",
+            "transcript": [
+                {"type": "system", "model": "claude-sonnet-4-20250514"},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_01",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                        "content": [
+                            {
+                                "id": "toolu_01",
+                                "name": "Grep",
+                                "type": "tool_use",
+                                "input": {"pattern": "def validate"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": "src/validator.py:10: def validate_input(data):",
+                                "tool_use_id": "toolu_01",
+                            }
+                        ],
+                    },
+                    "timestamp": "2026-04-16T12:11:06.161Z",
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_02",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 5, "output_tokens": 10},
+                        "content": [{"type": "text", "text": "Found it."}],
+                    },
+                },
+                {
+                    "type": "result",
+                    "total_cost_usd": 0.01,
+                    "duration_ms": 5000,
+                },
+            ],
+        }
+        fixture = tmp_path / "session.json"
+        fixture.write_text(json.dumps(transcript))
+        adapter = AlcoveAdapter()
+        sample = adapter.load(fixture)
+        assert sample.phases[0].knowledge_context is not None
+        assert "def validate_input" in sample.phases[0].knowledge_context
+        assert sample.context_source == "synthesized"
+
+    def test_synthesizes_context_from_informational_bash(self, tmp_path):
+        """Informational bash commands (pytest, cat, grep) should be extracted."""
+        transcript = {
+            "session_id": "ctx-bash-test",
+            "transcript": [
+                {"type": "system", "model": "claude-sonnet-4-20250514"},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_01",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                        "content": [
+                            {
+                                "id": "toolu_01",
+                                "name": "Bash",
+                                "type": "tool_use",
+                                "input": {"command": "pytest tests/ -v"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": "PASSED test_main.py::test_hello",
+                                "tool_use_id": "toolu_01",
+                            }
+                        ],
+                    },
+                    "timestamp": "2026-04-16T12:11:06.161Z",
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_02",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 5, "output_tokens": 10},
+                        "content": [{"type": "text", "text": "Tests passed."}],
+                    },
+                },
+                {
+                    "type": "result",
+                    "total_cost_usd": 0.01,
+                    "duration_ms": 5000,
+                },
+            ],
+        }
+        fixture = tmp_path / "session.json"
+        fixture.write_text(json.dumps(transcript))
+        adapter = AlcoveAdapter()
+        sample = adapter.load(fixture)
+        assert sample.phases[0].knowledge_context is not None
+        assert "PASSED test_main" in sample.phases[0].knowledge_context
+
+    def test_filters_out_non_informational_bash(self, tmp_path):
+        """Non-informational bash commands (cd, ls, pwd, git status) should be skipped."""
+        transcript = {
+            "session_id": "ctx-skip-bash",
+            "transcript": [
+                {"type": "system", "model": "claude-sonnet-4-20250514"},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_01",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                        "content": [
+                            {
+                                "id": "toolu_01",
+                                "name": "Bash",
+                                "type": "tool_use",
+                                "input": {"command": "cd /home/user/project"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": "",
+                                "tool_use_id": "toolu_01",
+                            }
+                        ],
+                    },
+                    "timestamp": "2026-04-16T12:11:06.161Z",
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_02",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 5, "output_tokens": 5},
+                        "content": [
+                            {
+                                "id": "toolu_02",
+                                "name": "Bash",
+                                "type": "tool_use",
+                                "input": {"command": "ls -la"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": "total 42\ndrwxr-xr-x ...",
+                                "tool_use_id": "toolu_02",
+                            }
+                        ],
+                    },
+                    "timestamp": "2026-04-16T12:11:07.161Z",
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_03",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 5, "output_tokens": 10},
+                        "content": [{"type": "text", "text": "Done."}],
+                    },
+                },
+                {
+                    "type": "result",
+                    "total_cost_usd": 0.01,
+                    "duration_ms": 5000,
+                },
+            ],
+        }
+        fixture = tmp_path / "session.json"
+        fixture.write_text(json.dumps(transcript))
+        adapter = AlcoveAdapter()
+        sample = adapter.load(fixture)
+        # No informational tool calls, so no synthesized context
+        assert sample.phases[0].knowledge_context is None
+        assert sample.context_source is None
+
+    def test_does_not_overwrite_explicit_knowledge_context(self, tmp_path):
+        """When a phase already has knowledge_context, synthesis should not run."""
+        transcript = {
+            "session_id": "ctx-explicit-test",
+            "transcript": [
+                {"type": "system", "model": "claude-sonnet-4-20250514"},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_01",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                        "content": [
+                            {
+                                "id": "toolu_01",
+                                "name": "Read",
+                                "type": "tool_use",
+                                "input": {"file_path": "/src/main.py"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": "def main(): pass",
+                                "tool_use_id": "toolu_01",
+                            }
+                        ],
+                    },
+                    "timestamp": "2026-04-16T12:11:06.161Z",
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_02",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 5, "output_tokens": 10},
+                        "content": [{"type": "text", "text": "Done."}],
+                    },
+                },
+                {
+                    "type": "result",
+                    "total_cost_usd": 0.01,
+                    "duration_ms": 5000,
+                },
+            ],
+        }
+        fixture = tmp_path / "session.json"
+        fixture.write_text(json.dumps(transcript))
+        adapter = AlcoveAdapter()
+        sample = adapter.load(fixture)
+        # Manually set explicit knowledge_context before synthesis would run
+        # Since this tests the load() flow, we verify the adapter does synthesize
+        # because Alcove never has explicit knowledge_context set externally.
+        # This test instead verifies context_source is set correctly.
+        assert sample.context_source == "synthesized"
+
+    def test_redacts_sensitive_content_in_synthesized_context(self, tmp_path):
+        """Synthesized context must pass through redact_sensitive()."""
+        transcript = {
+            "session_id": "ctx-redact-test",
+            "transcript": [
+                {"type": "system", "model": "claude-sonnet-4-20250514"},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_01",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                        "content": [
+                            {
+                                "id": "toolu_01",
+                                "name": "Read",
+                                "type": "tool_use",
+                                "input": {"file_path": "/etc/secrets.env"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": "password=super_secret_123",
+                                "tool_use_id": "toolu_01",
+                            }
+                        ],
+                    },
+                    "timestamp": "2026-04-16T12:11:06.161Z",
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_02",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 5, "output_tokens": 10},
+                        "content": [{"type": "text", "text": "Read secrets."}],
+                    },
+                },
+                {
+                    "type": "result",
+                    "total_cost_usd": 0.01,
+                    "duration_ms": 5000,
+                },
+            ],
+        }
+        fixture = tmp_path / "session.json"
+        fixture.write_text(json.dumps(transcript))
+        adapter = AlcoveAdapter()
+        sample = adapter.load(fixture)
+        assert sample.phases[0].knowledge_context is not None
+        assert "super_secret_123" not in sample.phases[0].knowledge_context
+        assert "***REDACTED***" in sample.phases[0].knowledge_context
+
+    def test_truncates_context_to_50000_chars(self, tmp_path):
+        """Synthesized context should be truncated to 50,000 characters maximum."""
+        # Create a session with a very long tool output
+        long_content = "x" * 60000
+        transcript = {
+            "session_id": "ctx-truncate-test",
+            "transcript": [
+                {"type": "system", "model": "claude-sonnet-4-20250514"},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_01",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                        "content": [
+                            {
+                                "id": "toolu_01",
+                                "name": "Read",
+                                "type": "tool_use",
+                                "input": {"file_path": "/big_file.txt"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": long_content,
+                                "tool_use_id": "toolu_01",
+                            }
+                        ],
+                    },
+                    "timestamp": "2026-04-16T12:11:06.161Z",
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_02",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 5, "output_tokens": 10},
+                        "content": [{"type": "text", "text": "Read big file."}],
+                    },
+                },
+                {
+                    "type": "result",
+                    "total_cost_usd": 0.01,
+                    "duration_ms": 5000,
+                },
+            ],
+        }
+        fixture = tmp_path / "session.json"
+        fixture.write_text(json.dumps(transcript))
+        adapter = AlcoveAdapter()
+        sample = adapter.load(fixture)
+        assert sample.phases[0].knowledge_context is not None
+        assert len(sample.phases[0].knowledge_context) <= 50000
+
+    def test_joins_multiple_tool_outputs_with_separator(self, tmp_path):
+        """Multiple tool outputs should be joined with \\n---\\n separator."""
+        transcript = {
+            "session_id": "ctx-multi-tool",
+            "transcript": [
+                {"type": "system", "model": "claude-sonnet-4-20250514"},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_01",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                        "content": [
+                            {
+                                "id": "toolu_01",
+                                "name": "Read",
+                                "type": "tool_use",
+                                "input": {"file_path": "/file1.py"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": "content of file1",
+                                "tool_use_id": "toolu_01",
+                            }
+                        ],
+                    },
+                    "timestamp": "2026-04-16T12:11:06.161Z",
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_02",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                        "content": [
+                            {
+                                "id": "toolu_02",
+                                "name": "Grep",
+                                "type": "tool_use",
+                                "input": {"pattern": "search"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": "grep result line 1",
+                                "tool_use_id": "toolu_02",
+                            }
+                        ],
+                    },
+                    "timestamp": "2026-04-16T12:11:07.161Z",
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_03",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 5, "output_tokens": 10},
+                        "content": [{"type": "text", "text": "Done."}],
+                    },
+                },
+                {
+                    "type": "result",
+                    "total_cost_usd": 0.02,
+                    "duration_ms": 8000,
+                },
+            ],
+        }
+        fixture = tmp_path / "session.json"
+        fixture.write_text(json.dumps(transcript))
+        adapter = AlcoveAdapter()
+        sample = adapter.load(fixture)
+        knowledge = sample.phases[0].knowledge_context
+        assert knowledge is not None
+        assert "\n---\n" in knowledge
+        assert "content of file1" in knowledge
+        assert "grep result line 1" in knowledge
+
+    def test_no_context_when_no_tool_outputs(self, tmp_path):
+        """Sessions with no tool calls should not have synthesized context."""
+        transcript = {
+            "session_id": "ctx-no-tools",
+            "transcript": [
+                {"type": "system", "model": "claude-sonnet-4-20250514"},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg_01",
+                        "role": "assistant",
+                        "usage": {"input_tokens": 10, "output_tokens": 20},
+                        "content": [{"type": "text", "text": "Just text, no tools."}],
+                    },
+                },
+                {
+                    "type": "result",
+                    "total_cost_usd": 0.01,
+                    "duration_ms": 3000,
+                },
+            ],
+        }
+        fixture = tmp_path / "session.json"
+        fixture.write_text(json.dumps(transcript))
+        adapter = AlcoveAdapter()
+        sample = adapter.load(fixture)
+        assert sample.phases[0].knowledge_context is None
+        assert sample.context_source is None
+
+
+# --- Soda context synthesis tests (issue #114) ---
+
+
+class TestSodaContextExtraction:
+    def test_synthesizes_context_from_triage_structured(self, tmp_path):
+        """Triage output_structured fields should be extracted for context."""
+        meta = {
+            "ticket": "700",
+            "summary": "triage synthesis test",
+            "started_at": "2026-04-10T08:00:00Z",
+            "total_cost": 5.0,
+            "rework_cycles": 0,
+            "phases": {
+                "triage": {"status": "completed", "generation": 1},
+                "implement": {"status": "completed", "generation": 1},
+            },
+        }
+        (tmp_path / "meta.json").write_text(json.dumps(meta))
+        (tmp_path / "events.jsonl").write_text("")
+        triage_data = {
+            "approach": "Add input validation to the API",
+            "code_area": "api/handlers",
+            "files": ["src/api/handler.py", "src/api/validator.py"],
+            "risks": ["Breaking change for existing clients"],
+        }
+        (tmp_path / "triage.json").write_text(json.dumps(triage_data))
+        implement_data = {"summary": "implemented validation"}
+        (tmp_path / "implement.json").write_text(json.dumps(implement_data))
+
+        adapter = SessionSchemaAdapter()
+        sample = adapter.load(tmp_path)
+        # Context should be stored on the implement phase (where to_ragas_rows reads from)
+        impl_phases = [phase for phase in sample.phases if phase.name == "implement"]
+        assert len(impl_phases) >= 1
+        assert impl_phases[-1].knowledge_context is not None
+        context = impl_phases[-1].knowledge_context
+        assert "Add input validation" in context
+        assert "api/handlers" in context
+        assert sample.context_source == "synthesized"
+
+    def test_synthesizes_context_from_plan_structured(self, tmp_path):
+        """Plan output_structured fields should be extracted for context."""
+        meta = {
+            "ticket": "701",
+            "summary": "plan synthesis test",
+            "started_at": "2026-04-10T08:00:00Z",
+            "total_cost": 5.0,
+            "rework_cycles": 0,
+            "phases": {
+                "plan": {"status": "completed", "generation": 1},
+                "implement": {"status": "completed", "generation": 1},
+            },
+        }
+        (tmp_path / "meta.json").write_text(json.dumps(meta))
+        (tmp_path / "events.jsonl").write_text("")
+        plan_data = {
+            "approach": "Refactor the validation layer",
+            "tasks": [
+                {
+                    "description": "Add field-level validators",
+                    "files": ["src/validators.py"],
+                },
+                {
+                    "description": "Update API handlers",
+                    "files": ["src/handlers.py"],
+                },
+            ],
+        }
+        (tmp_path / "plan.json").write_text(json.dumps(plan_data))
+        implement_data = {"summary": "implemented plan"}
+        (tmp_path / "implement.json").write_text(json.dumps(implement_data))
+
+        adapter = SessionSchemaAdapter()
+        sample = adapter.load(tmp_path)
+        # Context should be stored on the implement phase
+        impl_phases = [phase for phase in sample.phases if phase.name == "implement"]
+        assert len(impl_phases) >= 1
+        assert impl_phases[-1].knowledge_context is not None
+        context = impl_phases[-1].knowledge_context
+        assert "Refactor the validation layer" in context
+        assert sample.context_source == "synthesized"
+
+    def test_synthesizes_context_from_implement_structured(self, tmp_path):
+        """Implement output_structured fields should be extracted for context."""
+        meta = {
+            "ticket": "702",
+            "summary": "implement synthesis test",
+            "started_at": "2026-04-10T08:00:00Z",
+            "total_cost": 5.0,
+            "rework_cycles": 0,
+            "phases": {
+                "implement": {"status": "completed", "generation": 1},
+            },
+        }
+        (tmp_path / "meta.json").write_text(json.dumps(meta))
+        (tmp_path / "events.jsonl").write_text("")
+        implement_data = {
+            "files_changed": ["src/main.py", "tests/test_main.py"],
+            "commits": [
+                {"message": "feat: add input validation"},
+                {"message": "test: add validation tests"},
+            ],
+            "deviations": "Had to change the API contract",
+        }
+        (tmp_path / "implement.json").write_text(json.dumps(implement_data))
+
+        adapter = SessionSchemaAdapter()
+        sample = adapter.load(tmp_path)
+        # Context should be stored on the implement phase
+        impl_phases = [phase for phase in sample.phases if phase.name == "implement"]
+        assert len(impl_phases) >= 1
+        assert impl_phases[-1].knowledge_context is not None
+        context = impl_phases[-1].knowledge_context
+        assert "src/main.py" in context
+        assert sample.context_source == "synthesized"
+
+    def test_does_not_overwrite_explicit_knowledge_context(self, tmp_path):
+        """When a phase already has knowledge_context, synthesis should not run."""
+        meta = {
+            "ticket": "703",
+            "summary": "explicit context test",
+            "started_at": "2026-04-10T08:00:00Z",
+            "total_cost": 5.0,
+            "rework_cycles": 0,
+            "phases": {
+                "implement": {"status": "completed", "generation": 1},
+            },
+        }
+        (tmp_path / "meta.json").write_text(json.dumps(meta))
+        (tmp_path / "events.jsonl").write_text("")
+        implement_data = {
+            "files_changed": ["src/main.py"],
+            "summary": "implemented",
+        }
+        (tmp_path / "implement.json").write_text(json.dumps(implement_data))
+
+        adapter = SessionSchemaAdapter()
+        sample = adapter.load(tmp_path)
+        # Verify synthesis produced context (since no explicit context exists)
+        assert sample.context_source == "synthesized"
+        # Context should be on the implement phase
+        impl_phases = [phase for phase in sample.phases if phase.name == "implement"]
+        assert len(impl_phases) >= 1
+        assert impl_phases[-1].knowledge_context is not None
+
+    def test_redacts_sensitive_content_in_synthesized_context(self, tmp_path):
+        """Synthesized context must pass through redact_sensitive()."""
+        meta = {
+            "ticket": "704",
+            "summary": "redaction test",
+            "started_at": "2026-04-10T08:00:00Z",
+            "total_cost": 5.0,
+            "rework_cycles": 0,
+            "phases": {
+                "triage": {"status": "completed", "generation": 1},
+                "implement": {"status": "completed", "generation": 1},
+            },
+        }
+        (tmp_path / "meta.json").write_text(json.dumps(meta))
+        (tmp_path / "events.jsonl").write_text("")
+        triage_data = {
+            "approach": "Fix the password=super_secret_value leak",
+            "code_area": "auth",
+        }
+        (tmp_path / "triage.json").write_text(json.dumps(triage_data))
+        implement_data = {"summary": "fixed leak"}
+        (tmp_path / "implement.json").write_text(json.dumps(implement_data))
+
+        adapter = SessionSchemaAdapter()
+        sample = adapter.load(tmp_path)
+        phases_with_context = [
+            phase for phase in sample.phases if phase.knowledge_context is not None
+        ]
+        assert len(phases_with_context) >= 1
+        context = phases_with_context[0].knowledge_context
+        assert "super_secret_value" not in context
+
+    def test_falls_back_to_implement_output_when_no_structured(self, tmp_path):
+        """When no structured fields exist, fall back to implement phase output."""
+        meta = {
+            "ticket": "705",
+            "summary": "fallback test",
+            "started_at": "2026-04-10T08:00:00Z",
+            "total_cost": 5.0,
+            "rework_cycles": 0,
+            "phases": {
+                "implement": {"status": "completed", "generation": 1},
+            },
+        }
+        (tmp_path / "meta.json").write_text(json.dumps(meta))
+        (tmp_path / "events.jsonl").write_text("")
+        # A minimal implement.json with no structured extraction fields
+        implement_data = {"summary": "I implemented the feature by modifying the handler"}
+        (tmp_path / "implement.json").write_text(json.dumps(implement_data))
+
+        adapter = SessionSchemaAdapter()
+        sample = adapter.load(tmp_path)
+        # Context should be on the implement phase
+        impl_phases = [phase for phase in sample.phases if phase.name == "implement"]
+        assert len(impl_phases) >= 1
+        assert impl_phases[-1].knowledge_context is not None
+        assert sample.context_source == "synthesized"
+
+    def test_no_synthesis_when_no_phases(self, tmp_path):
+        """Sessions with no phases should not synthesize context."""
+        meta = {
+            "ticket": "706",
+            "summary": "no phases test",
+            "started_at": "2026-04-10T08:00:00Z",
+            "total_cost": 5.0,
+            "rework_cycles": 0,
+            "phases": {},
+        }
+        (tmp_path / "meta.json").write_text(json.dumps(meta))
+        (tmp_path / "events.jsonl").write_text("")
+
+        adapter = SessionSchemaAdapter()
+        sample = adapter.load(tmp_path)
+        assert sample.context_source is None

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -609,6 +609,18 @@ class TestMetricConfigJudgeLogPath:
 
 
 class TestFaithfulnessMetric:
+    def test_returns_none_score_when_no_retrieval_context(self):
+        """Faithfulness should return score=None when no context is available."""
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        metric = FaithfulnessMetric()
+        sample = _make_sample_with_knowledge(knowledge_context=None)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+        result = metric.compute(dataset, config)
+        assert result.score is None
+        assert result.details.get("skipped") == "no retrieval context"
+
     def test_skips_without_samples(self):
         from raki.metrics.ragas.faithfulness import FaithfulnessMetric
 
@@ -617,8 +629,7 @@ class TestFaithfulnessMetric:
         dataset = EvalDataset(samples=[sample])
         config = MetricConfig()
         result = metric.compute(dataset, config)
-        assert result.score == 0.0
-        assert result.details.get("skipped") == "no samples"
+        assert result.score is None
 
     def test_experimental_flag(self):
         from raki.metrics.ragas.faithfulness import FaithfulnessMetric
@@ -804,6 +815,18 @@ class TestFaithfulnessMetric:
 
 
 class TestAnswerRelevancyMetric:
+    def test_returns_none_score_when_no_retrieval_context(self):
+        """AnswerRelevancy should return score=None when no context is available."""
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        metric = AnswerRelevancyMetric()
+        sample = _make_sample_with_knowledge(knowledge_context=None)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+        result = metric.compute(dataset, config)
+        assert result.score is None
+        assert result.details.get("skipped") == "no retrieval context"
+
     def test_skips_without_samples(self):
         from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
 
@@ -812,8 +835,7 @@ class TestAnswerRelevancyMetric:
         dataset = EvalDataset(samples=[sample])
         config = MetricConfig()
         result = metric.compute(dataset, config)
-        assert result.score == 0.0
-        assert result.details.get("skipped") == "no samples"
+        assert result.score is None
 
     def test_experimental_flag(self):
         from raki.metrics.ragas.relevancy import AnswerRelevancyMetric

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -246,3 +246,52 @@ def test_ground_truth():
     for valid_knowledge in ("fact", "procedure", "constraint", "context-dependent"):
         truth = GroundTruth(knowledge_type=valid_knowledge)
         assert truth.knowledge_type == valid_knowledge
+
+
+# --- context_source field tests (issue #114) ---
+
+
+def test_eval_sample_context_source_defaults_to_none():
+    meta = SessionMeta(
+        session_id="114",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=1,
+        rework_cycles=0,
+    )
+    sample = EvalSample(session=meta, phases=[], findings=[], events=[])
+    assert sample.context_source is None
+
+
+def test_eval_sample_context_source_accepts_explicit():
+    meta = SessionMeta(
+        session_id="114",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=1,
+        rework_cycles=0,
+    )
+    sample = EvalSample(session=meta, phases=[], findings=[], events=[], context_source="explicit")
+    assert sample.context_source == "explicit"
+
+
+def test_eval_sample_context_source_accepts_synthesized():
+    meta = SessionMeta(
+        session_id="114",
+        started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        total_phases=1,
+        rework_cycles=0,
+    )
+    sample = EvalSample(
+        session=meta, phases=[], findings=[], events=[], context_source="synthesized"
+    )
+    assert sample.context_source == "synthesized"
+
+
+def test_eval_sample_context_source_rejects_invalid():
+    with pytest.raises(ValidationError):
+        meta = SessionMeta(
+            session_id="114",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=1,
+            rework_cycles=0,
+        )
+        EvalSample(session=meta, phases=[], findings=[], events=[], context_source="invalid")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -114,6 +114,51 @@ class TestJsonReportRoundTrip:
         assert loaded.timestamp.tzinfo is not None
 
 
+class TestJsonReportContextSource:
+    def test_context_source_included_in_json_output(self, tmp_path: Path) -> None:
+        """context_source field should be included in JSON report sample results."""
+        sample = make_sample("session-ctx-001")
+        sample.context_source = "synthesized"
+        metric_result = MetricResult(
+            name="faithfulness",
+            score=0.85,
+            sample_scores={"session-ctx-001": 0.85},
+        )
+        sample_result = SampleResult(sample=sample, scores=[metric_result])
+        report = EvalReport(
+            run_id="ctx-source-test",
+            config={"adapter": "alcove"},
+            aggregate_scores={"faithfulness": 0.85},
+            sample_results=[sample_result],
+        )
+        output_path = tmp_path / "report.json"
+        write_json_report(report, output_path, include_sessions=True)
+        raw = json.loads(output_path.read_text())
+        sample_data = raw["sample_results"][0]["sample"]
+        assert sample_data["context_source"] == "synthesized"
+
+    def test_context_source_none_in_json_output(self, tmp_path: Path) -> None:
+        """context_source=None should appear as null in JSON output."""
+        sample = make_sample("session-no-ctx")
+        metric_result = MetricResult(
+            name="rework_cycles",
+            score=1.0,
+            sample_scores={"session-no-ctx": 1.0},
+        )
+        sample_result = SampleResult(sample=sample, scores=[metric_result])
+        report = EvalReport(
+            run_id="no-ctx-source-test",
+            config={"adapter": "session-schema"},
+            aggregate_scores={"rework_cycles": 1.0},
+            sample_results=[sample_result],
+        )
+        output_path = tmp_path / "report.json"
+        write_json_report(report, output_path, include_sessions=True)
+        raw = json.loads(output_path.read_text())
+        sample_data = raw["sample_results"][0]["sample"]
+        assert sample_data["context_source"] is None
+
+
 class TestJsonReportStripping:
     def test_strips_session_data_by_default(self, tmp_path: Path) -> None:
         report = _make_report_with_samples()
@@ -415,6 +460,50 @@ class TestPrintSummary:
         print_summary(report, session_count=10, console=test_console)
         output = string_io.getvalue()
         assert "same-provider" not in output.lower()
+
+    def test_inferred_suffix_when_context_synthesized(self) -> None:
+        """Faithfulness/relevancy with synthesized context should show (inferred) tag."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        report = EvalReport(
+            run_id="inferred-test",
+            aggregate_scores={
+                "faithfulness": 0.85,
+                "answer_relevancy": 0.72,
+            },
+            metric_details={
+                "faithfulness": {"context_source": "synthesized", "samples_scored": 5},
+                "answer_relevancy": {"context_source": "synthesized", "samples_scored": 5},
+            },
+        )
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True)
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "inferred" in output.lower()
+
+    def test_no_inferred_suffix_when_context_explicit(self) -> None:
+        """Faithfulness/relevancy with explicit context should NOT show (inferred) tag."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        report = EvalReport(
+            run_id="explicit-test",
+            aggregate_scores={
+                "faithfulness": 0.85,
+            },
+            metric_details={
+                "faithfulness": {"context_source": "explicit", "samples_scored": 5},
+            },
+        )
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True)
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "inferred" not in output.lower()
 
 
 # --- generate_summary_sentence tests ---


### PR DESCRIPTION
## Summary

Synthesize retrieval context from session transcripts so faithfulness and answer relevancy work without ground truth or `--docs-path`:

- **Alcove adapter**: extracts Read/Grep and whitelisted Bash tool outputs
- **Soda adapter**: extracts triage/plan/implement structured fields with implement fallback
- All synthesized content passes through `redact_sensitive()` before storage
- Both adapters cap synthesized context at 50,000 characters
- Bash command filter uses a whitelist (pytest, ruff, grep, etc.) to prevent secret leakage
- Metrics return `score=None` on empty context (N/A semantics)
- CLI shows `(inferred)` suffix for synthesized-context metrics
- `context_source` field on `EvalSample` tracks explicit vs synthesized origin

Refs #114

## Review
- Python Specialist: 2I fixed (duplicate _detect_context_source, weak test assertion)
- Security Specialist: 2I fixed (Bash whitelist, Soda size cap)
- RAG Specialist: 1C + 2I fixed (wrong phase placement, shared helper, details key mismatch)

## Test plan
- [x] `TestAlcoveContextExtraction` (9 tests): tool output extraction, filtering, redaction, truncation
- [x] `TestSodaContextExtraction` (7 tests): structured field extraction, implement fallback, redaction
- [x] Faithfulness/relevancy N/A guard tests (2 tests)
- [x] `TestJsonReportContextSource` (2 tests): context_source in JSON output
- [x] `TestPrintSummary` (2 tests): (inferred) suffix display
- [x] 639 total tests passing

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko