### PR TITLE
feat(gates): per-metric thresholds and CI regression gate

### DIFF
--- a/changes/116.feature
+++ b/changes/116.feature
@@ -1,0 +1,1 @@
+Add per-metric quality gates (``--gate 'metric>value'``) and CI regression detection (``--fail-on-regression``). Distinct exit codes: 0=clear, 1=threshold, 3=regression, 4=both.

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -107,7 +107,21 @@ def main():
     "--no-llm", is_flag=True, help="[Deprecated] Skip LLM-backed metrics (now the default)"
 )
 @click.option("-q", "--quiet", is_flag=True, help="CI mode -- minimal output")
-@click.option("--threshold", type=float, default=None, help="Min score for exit code 0")
+@click.option(
+    "--threshold", type=float, default=None, help="[Deprecated] Min score for exit code 0"
+)
+@click.option(
+    "--gate",
+    "gate_thresholds",
+    multiple=True,
+    help="Quality gate: 'metric>value' (e.g. 'faithfulness>0.85')",
+)
+@click.option(
+    "--require-metric",
+    "required_metrics",
+    multiple=True,
+    help="Fail if metric is N/A instead of skipping threshold",
+)
 @click.option("--adapter", "adapter_format", default=None, help="Force adapter (default: auto)")
 @click.option(
     "--metrics",
@@ -150,6 +164,8 @@ def run(
     no_llm: bool,
     quiet: bool,
     threshold: float | None,
+    gate_thresholds: tuple[str, ...],
+    required_metrics: tuple[str, ...],
     adapter_format: str | None,
     metric_names: str | None,
     parallel_count: int,
@@ -368,6 +384,36 @@ def run(
             mean_retrieval = sum(retrieval_scores.values()) / len(retrieval_scores)
             if mean_retrieval < threshold:
                 raise SystemExit(1)
+
+    # Per-metric quality gates (--gate / manifest thresholds)
+    effective_thresholds = list(gate_thresholds)
+    if not effective_thresholds and manifest.thresholds:
+        effective_thresholds = list(manifest.thresholds)
+
+    if effective_thresholds:
+        from raki.gates.thresholds import (
+            evaluate_all,
+            format_threshold_results,
+            parse_threshold,
+        )
+
+        try:
+            parsed_thresholds = [parse_threshold(raw) for raw in effective_thresholds]
+        except ValueError as exc:
+            out.print(f"[red]Error: {exc}[/red]")
+            raise SystemExit(2) from exc
+
+        required_set = set(required_metrics) if required_metrics else None
+        gate_results = evaluate_all(
+            parsed_thresholds, report.aggregate_scores, required_metrics=required_set
+        )
+
+        if not quiet:
+            out.print(format_threshold_results(gate_results))
+
+        has_violation = any(not result.passed for result in gate_results)
+        if has_violation:
+            raise SystemExit(1)
 
 
 @main.command()
@@ -630,18 +676,25 @@ def metrics(json_output: bool) -> None:
     default=None,
     help="Output directory for diff report",
 )
+@click.option(
+    "--fail-on-regression",
+    is_flag=True,
+    default=False,
+    help="Exit non-zero on metric regression (use with --diff)",
+)
 def report(
     input_path: str | None,
     diff_paths: tuple[str, str] | None,
     html_path: str | None,
     output_dir: str | None,
+    fail_on_regression: bool,
 ) -> None:
     """Re-render CLI summary and HTML from a saved JSON report.
 
     Use --diff to compare two evaluation runs side by side.
     """
     if diff_paths is not None:
-        _handle_diff(diff_paths, html_path, output_dir)
+        _handle_diff(diff_paths, html_path, output_dir, fail_on_regression=fail_on_regression)
         return
 
     if input_path is None:
@@ -702,6 +755,8 @@ def _handle_diff(
     diff_paths: tuple[str, str],
     html_path: str | None,
     output_dir: str | None,
+    *,
+    fail_on_regression: bool = False,
 ) -> None:
     """Handle the --diff subflow of the report command."""
     from raki.report.json_report import load_json_report
@@ -756,6 +811,38 @@ def _handle_diff(
                 "[yellow]Note: jinja2 not installed — skipping HTML diff report. "
                 "Install with: uv pip install raki[html][/yellow]"
             )
+
+    # Regression detection gate (--fail-on-regression)
+    if fail_on_regression:
+        from raki.gates.regression import Direction, compute_exit_code, detect_regressions
+        from raki.report.diff import is_higher_is_better
+
+        metric_directions: dict[str, Direction] = {}
+        all_metric_names = set(baseline_report.aggregate_scores.keys()) | set(
+            compare_report.aggregate_scores.keys()
+        )
+        for metric_name in all_metric_names:
+            if is_higher_is_better(metric_name):
+                metric_directions[metric_name] = "higher_is_better"
+            else:
+                metric_directions[metric_name] = "lower_is_better"
+
+        regression_results = detect_regressions(
+            baseline_report.aggregate_scores,
+            compare_report.aggregate_scores,
+            metric_directions,
+        )
+
+        regressed_metrics = [result for result in regression_results if result.regressed]
+        if regressed_metrics:
+            console.print("\n[red]Regressions detected:[/red]")
+            for result in regressed_metrics:
+                console.print(
+                    f"  {result.metric}: {result.baseline:.4f} -> "
+                    f"{result.current:.4f} ({result.direction})"
+                )
+            exit_code = compute_exit_code(threshold_violated=False, regression_detected=True)
+            raise SystemExit(exit_code)
 
 
 if __name__ == "__main__":

--- a/src/raki/gates/__init__.py
+++ b/src/raki/gates/__init__.py
@@ -1,0 +1,11 @@
+from raki.gates.regression import (
+    RegressionResult as RegressionResult,
+    compute_exit_code as compute_exit_code,
+    detect_regressions as detect_regressions,
+)
+from raki.gates.thresholds import (
+    Threshold as Threshold,
+    ThresholdResult as ThresholdResult,
+    evaluate_all as evaluate_all,
+    parse_threshold as parse_threshold,
+)

--- a/src/raki/gates/regression.py
+++ b/src/raki/gates/regression.py
@@ -1,0 +1,91 @@
+"""Regression detection: compare baseline and current scores for metric regressions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+Direction = Literal["higher_is_better", "lower_is_better"]
+
+
+@dataclass(frozen=True)
+class RegressionResult:
+    """Result of checking one metric for regression between baseline and current."""
+
+    metric: str
+    baseline: float
+    current: float
+    direction: Direction
+    regressed: bool
+
+
+def detect_regressions(
+    baseline_scores: dict[str, float | None],
+    current_scores: dict[str, float | None],
+    metric_directions: dict[str, Direction],
+    noise_margin: float = 0.02,
+) -> list[RegressionResult]:
+    """Detect regressions between baseline and current scores.
+
+    For each metric present in both score dicts, check whether the score
+    moved in the wrong direction by more than the noise margin.
+
+    Args:
+        baseline_scores: Metric scores from the baseline run.
+        current_scores: Metric scores from the current run.
+        metric_directions: Map of metric names to direction
+            ("higher_is_better" or "lower_is_better").
+        noise_margin: Ignore regressions smaller than this absolute
+            difference (default 0.02 = 2%).
+
+    Returns:
+        List of RegressionResult instances for metrics present in both runs
+        with non-None scores.
+    """
+    common_metrics = set(baseline_scores.keys()) & set(current_scores.keys())
+    results: list[RegressionResult] = []
+
+    for metric_name in sorted(common_metrics):
+        baseline_value = baseline_scores[metric_name]
+        current_value = current_scores[metric_name]
+
+        if baseline_value is None or current_value is None:
+            continue
+
+        direction = metric_directions.get(metric_name, "higher_is_better")
+        delta = current_value - baseline_value
+
+        if direction == "higher_is_better":
+            regressed = delta < -noise_margin
+        else:
+            regressed = delta > noise_margin
+
+        results.append(
+            RegressionResult(
+                metric=metric_name,
+                baseline=baseline_value,
+                current=current_value,
+                direction=direction,
+                regressed=regressed,
+            )
+        )
+
+    return results
+
+
+def compute_exit_code(
+    threshold_violated: bool,
+    regression_detected: bool,
+) -> int:
+    """Compute the CLI exit code from threshold and regression results.
+
+    Returns:
+        0 = clear, 1 = threshold violation, 3 = regression, 4 = both.
+    """
+    if threshold_violated and regression_detected:
+        return 4
+    if threshold_violated:
+        return 1
+    if regression_detected:
+        return 3
+    return 0

--- a/src/raki/gates/thresholds.py
+++ b/src/raki/gates/thresholds.py
@@ -1,0 +1,170 @@
+"""Per-metric quality gates: threshold parsing, evaluation, and formatting."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+
+# Regex matches: metric_name, operator (>=, <=, >, <), numeric value (including negative)
+_THRESHOLD_PATTERN = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)(>=|<=|>|<)(-?[0-9]*\.?[0-9]+)$")
+
+_OPERATORS: dict[str, Callable[[float, float], bool]] = {
+    ">": lambda actual, target: actual > target,
+    "<": lambda actual, target: actual < target,
+    ">=": lambda actual, target: actual >= target,
+    "<=": lambda actual, target: actual <= target,
+}
+
+
+@dataclass(frozen=True)
+class Threshold:
+    """A single metric threshold: metric_name operator value."""
+
+    metric: str
+    operator: str
+    value: float
+
+
+@dataclass(frozen=True)
+class ThresholdResult:
+    """Result of evaluating a single threshold against an actual score."""
+
+    threshold: Threshold
+    actual: float | None
+    passed: bool
+    skipped: bool = False
+    reason: str = ""
+
+
+def parse_threshold(raw: str) -> Threshold:
+    """Parse a threshold string like 'metric_name>0.85' into a Threshold.
+
+    Supports operators: >, <, >=, <=.
+
+    Args:
+        raw: The raw threshold string (no whitespace allowed).
+
+    Returns:
+        A parsed Threshold instance.
+
+    Raises:
+        ValueError: If the string does not match the expected syntax.
+    """
+    match = _THRESHOLD_PATTERN.match(raw)
+    if match is None:
+        raise ValueError(
+            f"Invalid threshold syntax: '{raw}'. "
+            "Expected format: 'metric_name>0.85' (operators: >, <, >=, <=)"
+        )
+    metric_name = match.group(1)
+    operator = match.group(2)
+    value = float(match.group(3))
+    return Threshold(metric=metric_name, operator=operator, value=value)
+
+
+def evaluate_threshold(
+    threshold: Threshold,
+    scores: dict[str, float | None],
+    required_metrics: set[str] | None = None,
+) -> ThresholdResult:
+    """Evaluate a single threshold against the actual scores.
+
+    Args:
+        threshold: The threshold to evaluate.
+        scores: Map of metric names to their scores (None means N/A).
+        required_metrics: Set of metric names that must not be N/A.
+
+    Returns:
+        A ThresholdResult indicating pass/fail/skip.
+
+    Raises:
+        ValueError: If the metric name is not found in scores.
+    """
+    if threshold.metric not in scores:
+        raise ValueError(
+            f"Unknown metric '{threshold.metric}' in threshold. "
+            f"Available metrics: {', '.join(sorted(scores.keys()))}"
+        )
+
+    actual = scores[threshold.metric]
+
+    if actual is None:
+        required = required_metrics or set()
+        if threshold.metric in required:
+            return ThresholdResult(
+                threshold=threshold,
+                actual=None,
+                passed=False,
+                skipped=False,
+                reason=f"Metric '{threshold.metric}' is N/A but required by --require-metric",
+            )
+        return ThresholdResult(
+            threshold=threshold,
+            actual=None,
+            passed=True,
+            skipped=True,
+            reason=f"Metric '{threshold.metric}' is N/A — skipping threshold check",
+        )
+
+    comparison_fn = _OPERATORS[threshold.operator]
+    passed = comparison_fn(actual, threshold.value)
+    return ThresholdResult(
+        threshold=threshold,
+        actual=actual,
+        passed=passed,
+    )
+
+
+def evaluate_all(
+    thresholds: list[Threshold],
+    scores: dict[str, float | None],
+    required_metrics: set[str] | None = None,
+) -> list[ThresholdResult]:
+    """Evaluate multiple thresholds against scores.
+
+    Args:
+        thresholds: List of thresholds to evaluate.
+        scores: Map of metric names to their scores.
+        required_metrics: Set of metric names that must not be N/A.
+
+    Returns:
+        List of ThresholdResult instances, one per threshold.
+    """
+    return [
+        evaluate_threshold(threshold, scores, required_metrics=required_metrics)
+        for threshold in thresholds
+    ]
+
+
+def format_threshold_results(results: list[ThresholdResult]) -> str:
+    """Format threshold results as a human-readable string.
+
+    Args:
+        results: List of threshold evaluation results.
+
+    Returns:
+        Formatted multi-line string with PASS/FAIL/SKIP for each threshold.
+    """
+    lines: list[str] = []
+    lines.append("Quality Gates:")
+    for result in results:
+        threshold = result.threshold
+        threshold_str = f"{threshold.metric}{threshold.operator}{threshold.value}"
+
+        if result.skipped:
+            status = "SKIP"
+            detail = result.reason
+        elif result.passed:
+            status = "PASS"
+            detail = f"actual={result.actual}"
+        else:
+            status = "FAIL"
+            if result.actual is not None:
+                detail = f"actual={result.actual}"
+            else:
+                detail = result.reason
+
+        lines.append(f"  [{status}] {threshold_str} ({detail})")
+
+    return "\n".join(lines)

--- a/src/raki/ground_truth/manifest.py
+++ b/src/raki/ground_truth/manifest.py
@@ -61,6 +61,7 @@ class EvalManifest(BaseModel):
     sources: list[SourceDocument] = Field(default_factory=list)
     ground_truth: GroundTruthConfig = Field(default_factory=GroundTruthConfig)
     synthetic: SyntheticConfig = Field(default_factory=SyntheticConfig)
+    thresholds: list[str] = Field(default_factory=list)
 
 
 def _resolve_and_guard(

--- a/src/raki/report/diff.py
+++ b/src/raki/report/diff.py
@@ -56,7 +56,7 @@ class DiffReport:
 _VERDICT_RANK: dict[str, int] = {"fail": 0, "rework": 1, "pass": 2}
 
 
-def _is_higher_is_better(metric_name: str) -> bool:
+def is_higher_is_better(metric_name: str) -> bool:
     """Determine if a metric is higher_is_better from METRIC_METADATA.
 
     Defaults to True for unknown metrics.
@@ -114,7 +114,7 @@ def compute_deltas(
         if baseline_value is None or compare_value is None:
             continue
         delta = compare_value - baseline_value
-        higher_is_better = _is_higher_is_better(metric_name)
+        higher_is_better = is_higher_is_better(metric_name)
 
         if abs(delta) < 1e-9:
             direction: Literal["improved", "regressed", "flat"] = "flat"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1541,3 +1541,346 @@ class TestValidateDeep:
         assert result.exit_code == 0
         # Should contain a failure indicator
         assert "\u2717" in result.output or "fail" in result.output.lower()
+
+
+class TestGateThresholdCLI:
+    """Tests for --gate per-metric quality gates on the run command."""
+
+    def test_gate_pass(self, manifest_with_session, tmp_path):
+        """--gate with a passing threshold should exit 0."""
+        from unittest.mock import patch
+
+        from raki.model.report import EvalReport
+
+        fake_report = EvalReport(
+            run_id="fake",
+            aggregate_scores={"first_pass_verify_rate": 0.90},
+        )
+        manifest, _sessions = manifest_with_session
+        output_dir = tmp_path / "results"
+        with patch("raki.metrics.MetricsEngine.run", return_value=fake_report):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "run",
+                    "-m",
+                    str(manifest),
+                    "--gate",
+                    "first_pass_verify_rate>0.80",
+                    "-o",
+                    str(output_dir),
+                ],
+            )
+            assert result.exit_code == 0
+            assert "PASS" in result.output
+
+    def test_gate_violation_exits_1(self, manifest_with_session, tmp_path):
+        """--gate with a failing threshold should exit 1."""
+        from unittest.mock import patch
+
+        from raki.model.report import EvalReport
+
+        fake_report = EvalReport(
+            run_id="fake",
+            aggregate_scores={"first_pass_verify_rate": 0.70},
+        )
+        manifest, _sessions = manifest_with_session
+        output_dir = tmp_path / "results"
+        with patch("raki.metrics.MetricsEngine.run", return_value=fake_report):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "run",
+                    "-m",
+                    str(manifest),
+                    "--gate",
+                    "first_pass_verify_rate>0.80",
+                    "-o",
+                    str(output_dir),
+                ],
+            )
+            assert result.exit_code == 1
+            assert "FAIL" in result.output
+
+    def test_gate_na_skip(self, manifest_with_session, tmp_path):
+        """--gate with N/A metric should skip and exit 0."""
+        from unittest.mock import patch
+
+        from raki.model.report import EvalReport
+
+        fake_report = EvalReport(
+            run_id="fake",
+            aggregate_scores={"faithfulness": None},
+        )
+        manifest, _sessions = manifest_with_session
+        output_dir = tmp_path / "results"
+        with patch("raki.metrics.MetricsEngine.run", return_value=fake_report):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "run",
+                    "-m",
+                    str(manifest),
+                    "--gate",
+                    "faithfulness>0.80",
+                    "-o",
+                    str(output_dir),
+                ],
+            )
+            assert result.exit_code == 0
+            assert "SKIP" in result.output
+
+    def test_require_metric_fails_on_na(self, manifest_with_session, tmp_path):
+        """--require-metric with N/A metric should exit 1."""
+        from unittest.mock import patch
+
+        from raki.model.report import EvalReport
+
+        fake_report = EvalReport(
+            run_id="fake",
+            aggregate_scores={"faithfulness": None},
+        )
+        manifest, _sessions = manifest_with_session
+        output_dir = tmp_path / "results"
+        with patch("raki.metrics.MetricsEngine.run", return_value=fake_report):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "run",
+                    "-m",
+                    str(manifest),
+                    "--gate",
+                    "faithfulness>0.80",
+                    "--require-metric",
+                    "faithfulness",
+                    "-o",
+                    str(output_dir),
+                ],
+            )
+            assert result.exit_code == 1
+            assert "FAIL" in result.output
+
+    def test_manifest_thresholds_used_when_no_cli_gate(self, tmp_path):
+        """Manifest thresholds should be used when no --gate is specified."""
+        from unittest.mock import patch
+
+        from raki.model.report import EvalReport
+
+        # Create a manifest with thresholds
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest_path = tmp_path / "raki.yaml"
+        manifest_path.write_text(
+            f"sessions:\n  path: {sessions}\n  format: auto\n"
+            f"thresholds:\n  - first_pass_verify_rate>0.99\n"
+        )
+
+        fake_report = EvalReport(
+            run_id="fake",
+            aggregate_scores={"first_pass_verify_rate": 0.80},
+        )
+        output_dir = tmp_path / "results"
+        with patch("raki.metrics.MetricsEngine.run", return_value=fake_report):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "run",
+                    "-m",
+                    str(manifest_path),
+                    "-o",
+                    str(output_dir),
+                ],
+            )
+            assert result.exit_code == 1
+            assert "FAIL" in result.output
+
+    def test_cli_gate_overrides_manifest_thresholds(self, tmp_path):
+        """CLI --gate should override manifest thresholds."""
+        from unittest.mock import patch
+
+        from raki.model.report import EvalReport
+
+        # Manifest threshold is strict (>0.99), but CLI gate is lenient (>0.50)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest_path = tmp_path / "raki.yaml"
+        manifest_path.write_text(
+            f"sessions:\n  path: {sessions}\n  format: auto\n"
+            f"thresholds:\n  - first_pass_verify_rate>0.99\n"
+        )
+
+        fake_report = EvalReport(
+            run_id="fake",
+            aggregate_scores={"first_pass_verify_rate": 0.80},
+        )
+        output_dir = tmp_path / "results"
+        with patch("raki.metrics.MetricsEngine.run", return_value=fake_report):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "run",
+                    "-m",
+                    str(manifest_path),
+                    "--gate",
+                    "first_pass_verify_rate>0.50",
+                    "-o",
+                    str(output_dir),
+                ],
+            )
+            assert result.exit_code == 0
+            assert "PASS" in result.output
+
+    def test_gate_invalid_syntax_exits_2(self, manifest_with_session, tmp_path):
+        """--gate with invalid syntax should exit 2."""
+        from unittest.mock import patch
+
+        from raki.model.report import EvalReport
+
+        fake_report = EvalReport(
+            run_id="fake",
+            aggregate_scores={"first_pass_verify_rate": 0.90},
+        )
+        manifest, _sessions = manifest_with_session
+        output_dir = tmp_path / "results"
+        with patch("raki.metrics.MetricsEngine.run", return_value=fake_report):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "run",
+                    "-m",
+                    str(manifest),
+                    "--gate",
+                    "invalid threshold syntax",
+                    "-o",
+                    str(output_dir),
+                ],
+            )
+            assert result.exit_code == 2
+
+    def test_gate_quiet_suppresses_output(self, manifest_with_session, tmp_path):
+        """--gate with -q should suppress quality gates output."""
+        from unittest.mock import patch
+
+        from raki.model.report import EvalReport
+
+        fake_report = EvalReport(
+            run_id="fake",
+            aggregate_scores={"first_pass_verify_rate": 0.90},
+        )
+        manifest, _sessions = manifest_with_session
+        output_dir = tmp_path / "results"
+        with patch("raki.metrics.MetricsEngine.run", return_value=fake_report):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "run",
+                    "-m",
+                    str(manifest),
+                    "--gate",
+                    "first_pass_verify_rate>0.80",
+                    "-o",
+                    str(output_dir),
+                    "-q",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "Quality Gates" not in result.output
+
+
+class TestRegressionCLI:
+    """Tests for --fail-on-regression on the report --diff command."""
+
+    def test_fail_on_regression_detects_regression(self, tmp_path):
+        """--fail-on-regression should exit non-zero when a metric regresses."""
+        baseline = tmp_path / "baseline.json"
+        compare = tmp_path / "compare.json"
+        _write_diff_report_json(
+            baseline,
+            run_id="eval-baseline",
+            aggregate_scores={"first_pass_verify_rate": 0.90},
+        )
+        _write_diff_report_json(
+            compare,
+            run_id="eval-compare",
+            aggregate_scores={"first_pass_verify_rate": 0.70},
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "report",
+                "--diff",
+                str(baseline),
+                str(compare),
+                "--fail-on-regression",
+            ],
+        )
+        assert result.exit_code == 3
+        assert "Regressions detected" in result.output
+
+    def test_fail_on_regression_exits_0_when_no_regression(self, tmp_path):
+        """--fail-on-regression should exit 0 when no regression is detected."""
+        baseline = tmp_path / "baseline.json"
+        compare = tmp_path / "compare.json"
+        _write_diff_report_json(
+            baseline,
+            run_id="eval-baseline",
+            aggregate_scores={"first_pass_verify_rate": 0.80},
+        )
+        _write_diff_report_json(
+            compare,
+            run_id="eval-compare",
+            aggregate_scores={"first_pass_verify_rate": 0.90},
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "report",
+                "--diff",
+                str(baseline),
+                str(compare),
+                "--fail-on-regression",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_fail_on_regression_flag_accepted_without_diff(self, tmp_path):
+        """--fail-on-regression without --diff should not crash (it's ignored)."""
+        report_json = tmp_path / "report.json"
+        _write_report_json(report_json, include_sessions=True)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["report", str(report_json), "--fail-on-regression"],
+        )
+        assert result.exit_code == 0
+
+    def test_diff_without_fail_on_regression_exits_0(self, tmp_path):
+        """--diff without --fail-on-regression should exit 0 even with regression."""
+        baseline = tmp_path / "baseline.json"
+        compare = tmp_path / "compare.json"
+        _write_diff_report_json(
+            baseline,
+            run_id="eval-baseline",
+            aggregate_scores={"first_pass_verify_rate": 0.90},
+        )
+        _write_diff_report_json(
+            compare,
+            run_id="eval-compare",
+            aggregate_scores={"first_pass_verify_rate": 0.70},
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["report", "--diff", str(baseline), str(compare)],
+        )
+        assert result.exit_code == 0

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,0 +1,419 @@
+"""Tests for quality gates: threshold parsing/evaluation and regression detection."""
+
+import pytest
+
+from raki.gates.thresholds import (
+    Threshold,
+    ThresholdResult,
+    evaluate_all,
+    evaluate_threshold,
+    format_threshold_results,
+    parse_threshold,
+)
+from raki.gates.regression import (
+    compute_exit_code,
+    detect_regressions,
+)
+
+
+class TestThresholdParser:
+    """Tests for parse_threshold() — all operators, invalid syntax, edge cases."""
+
+    def test_parse_greater_than(self):
+        result = parse_threshold("faithfulness>0.85")
+        assert result == Threshold(metric="faithfulness", operator=">", value=0.85)
+
+    def test_parse_less_than(self):
+        result = parse_threshold("rework_cycles<2.0")
+        assert result == Threshold(metric="rework_cycles", operator="<", value=2.0)
+
+    def test_parse_greater_equal(self):
+        result = parse_threshold("context_precision>=0.90")
+        assert result == Threshold(metric="context_precision", operator=">=", value=0.90)
+
+    def test_parse_less_equal(self):
+        result = parse_threshold("cost_efficiency<=15.0")
+        assert result == Threshold(metric="cost_efficiency", operator="<=", value=15.0)
+
+    def test_parse_integer_value(self):
+        result = parse_threshold("rework_cycles<3")
+        assert result == Threshold(metric="rework_cycles", operator="<", value=3.0)
+
+    def test_parse_zero_value(self):
+        result = parse_threshold("rework_cycles>=0")
+        assert result == Threshold(metric="rework_cycles", operator=">=", value=0.0)
+
+    def test_parse_invalid_no_operator(self):
+        with pytest.raises(ValueError, match="Invalid threshold"):
+            parse_threshold("faithfulness0.85")
+
+    def test_parse_invalid_empty_string(self):
+        with pytest.raises(ValueError, match="Invalid threshold"):
+            parse_threshold("")
+
+    def test_parse_invalid_missing_value(self):
+        with pytest.raises(ValueError, match="Invalid threshold"):
+            parse_threshold("faithfulness>")
+
+    def test_parse_invalid_missing_metric(self):
+        with pytest.raises(ValueError, match="Invalid threshold"):
+            parse_threshold(">0.85")
+
+    def test_parse_invalid_non_numeric_value(self):
+        with pytest.raises(ValueError, match="Invalid threshold"):
+            parse_threshold("faithfulness>abc")
+
+    def test_parse_negative_value(self):
+        result = parse_threshold("some_metric>-0.5")
+        assert result == Threshold(metric="some_metric", operator=">", value=-0.5)
+
+    def test_parse_metric_with_underscores(self):
+        result = parse_threshold("first_pass_verify_rate>0.8")
+        assert result.metric == "first_pass_verify_rate"
+
+    def test_parse_whitespace_is_rejected(self):
+        with pytest.raises(ValueError, match="Invalid threshold"):
+            parse_threshold("faithfulness > 0.85")
+
+
+class TestThresholdEvaluator:
+    """Tests for evaluate_threshold() — pass, fail, N/A skip, N/A required, unknown metric."""
+
+    def test_pass_greater_than(self):
+        threshold = Threshold(metric="faithfulness", operator=">", value=0.80)
+        scores = {"faithfulness": 0.90}
+        result = evaluate_threshold(threshold, scores)
+        assert result.passed is True
+        assert result.skipped is False
+        assert result.actual == 0.90
+
+    def test_fail_greater_than(self):
+        threshold = Threshold(metric="faithfulness", operator=">", value=0.90)
+        scores = {"faithfulness": 0.85}
+        result = evaluate_threshold(threshold, scores)
+        assert result.passed is False
+        assert result.skipped is False
+
+    def test_pass_less_than(self):
+        threshold = Threshold(metric="rework_cycles", operator="<", value=2.0)
+        scores = {"rework_cycles": 1.0}
+        result = evaluate_threshold(threshold, scores)
+        assert result.passed is True
+
+    def test_fail_less_than(self):
+        threshold = Threshold(metric="rework_cycles", operator="<", value=1.0)
+        scores = {"rework_cycles": 2.0}
+        result = evaluate_threshold(threshold, scores)
+        assert result.passed is False
+
+    def test_pass_greater_equal_at_boundary(self):
+        threshold = Threshold(metric="faithfulness", operator=">=", value=0.85)
+        scores = {"faithfulness": 0.85}
+        result = evaluate_threshold(threshold, scores)
+        assert result.passed is True
+
+    def test_pass_less_equal_at_boundary(self):
+        threshold = Threshold(metric="rework_cycles", operator="<=", value=1.5)
+        scores = {"rework_cycles": 1.5}
+        result = evaluate_threshold(threshold, scores)
+        assert result.passed is True
+
+    def test_unknown_metric_raises(self):
+        threshold = Threshold(metric="nonexistent_metric", operator=">", value=0.5)
+        scores = {"faithfulness": 0.90}
+        with pytest.raises(ValueError, match="Unknown metric"):
+            evaluate_threshold(threshold, scores)
+
+    def test_none_score_skipped_by_default(self):
+        threshold = Threshold(metric="faithfulness", operator=">", value=0.80)
+        scores: dict[str, float | None] = {"faithfulness": None}
+        result = evaluate_threshold(threshold, scores)
+        assert result.skipped is True
+        assert result.passed is True  # skipped counts as passed (not a violation)
+        assert result.actual is None
+        assert "N/A" in result.reason
+
+    def test_none_score_fails_when_required(self):
+        threshold = Threshold(metric="faithfulness", operator=">", value=0.80)
+        scores: dict[str, float | None] = {"faithfulness": None}
+        result = evaluate_threshold(threshold, scores, required_metrics={"faithfulness"})
+        assert result.skipped is False
+        assert result.passed is False
+        assert "required" in result.reason.lower()
+
+    def test_none_score_skipped_when_not_in_required_set(self):
+        threshold = Threshold(metric="faithfulness", operator=">", value=0.80)
+        scores: dict[str, float | None] = {"faithfulness": None}
+        result = evaluate_threshold(threshold, scores, required_metrics={"context_precision"})
+        assert result.skipped is True
+        assert result.passed is True
+
+
+class TestEvaluateAll:
+    """Tests for evaluate_all() — multiple thresholds, mixed results."""
+
+    def test_all_pass(self):
+        thresholds = [
+            Threshold(metric="faithfulness", operator=">", value=0.80),
+            Threshold(metric="rework_cycles", operator="<", value=2.0),
+        ]
+        scores: dict[str, float | None] = {
+            "faithfulness": 0.95,
+            "rework_cycles": 1.0,
+        }
+        results = evaluate_all(thresholds, scores)
+        assert len(results) == 2
+        assert all(result.passed for result in results)
+
+    def test_mixed_pass_fail(self):
+        thresholds = [
+            Threshold(metric="faithfulness", operator=">", value=0.90),
+            Threshold(metric="rework_cycles", operator="<", value=1.0),
+        ]
+        scores: dict[str, float | None] = {
+            "faithfulness": 0.95,  # passes
+            "rework_cycles": 2.0,  # fails
+        }
+        results = evaluate_all(thresholds, scores)
+        assert results[0].passed is True
+        assert results[1].passed is False
+
+    def test_with_skipped(self):
+        thresholds = [
+            Threshold(metric="faithfulness", operator=">", value=0.80),
+            Threshold(metric="context_precision", operator=">=", value=0.70),
+        ]
+        scores: dict[str, float | None] = {
+            "faithfulness": 0.95,
+            "context_precision": None,
+        }
+        results = evaluate_all(thresholds, scores)
+        assert results[0].passed is True
+        assert results[1].skipped is True
+
+    def test_with_required_metrics(self):
+        thresholds = [
+            Threshold(metric="faithfulness", operator=">", value=0.80),
+        ]
+        scores: dict[str, float | None] = {
+            "faithfulness": None,
+        }
+        results = evaluate_all(thresholds, scores, required_metrics={"faithfulness"})
+        assert results[0].passed is False
+        assert results[0].skipped is False
+
+    def test_empty_thresholds(self):
+        results = evaluate_all([], {"faithfulness": 0.90})
+        assert results == []
+
+
+class TestFormatResults:
+    """Tests for format_threshold_results() — formatting output."""
+
+    def test_pass_format(self):
+        results = [
+            ThresholdResult(
+                threshold=Threshold(metric="faithfulness", operator=">", value=0.80),
+                actual=0.95,
+                passed=True,
+            ),
+        ]
+        output = format_threshold_results(results)
+        assert "PASS" in output
+        assert "faithfulness" in output
+
+    def test_fail_format(self):
+        results = [
+            ThresholdResult(
+                threshold=Threshold(metric="faithfulness", operator=">", value=0.90),
+                actual=0.85,
+                passed=False,
+            ),
+        ]
+        output = format_threshold_results(results)
+        assert "FAIL" in output
+        assert "faithfulness" in output
+
+    def test_skip_format(self):
+        results = [
+            ThresholdResult(
+                threshold=Threshold(metric="faithfulness", operator=">", value=0.80),
+                actual=None,
+                passed=True,
+                skipped=True,
+                reason="Metric is N/A",
+            ),
+        ]
+        output = format_threshold_results(results)
+        assert "SKIP" in output
+        assert "faithfulness" in output
+
+    def test_multiple_results_formatted(self):
+        results = [
+            ThresholdResult(
+                threshold=Threshold(metric="faithfulness", operator=">", value=0.80),
+                actual=0.95,
+                passed=True,
+            ),
+            ThresholdResult(
+                threshold=Threshold(metric="rework_cycles", operator="<", value=1.0),
+                actual=2.0,
+                passed=False,
+            ),
+        ]
+        output = format_threshold_results(results)
+        assert "PASS" in output
+        assert "FAIL" in output
+
+
+class TestLowerIsBetterThreshold:
+    """Tests for threshold evaluation with lower_is_better metrics."""
+
+    def test_lower_is_better_threshold_violation(self):
+        """Threshold 'knowledge_gap_rate<0.20' should fail when score is 0.30."""
+        threshold = parse_threshold("knowledge_gap_rate<0.20")
+        scores: dict[str, float | None] = {"knowledge_gap_rate": 0.30}
+        result = evaluate_threshold(threshold, scores)
+        assert result.passed is False
+
+    def test_lower_is_better_threshold_passes(self):
+        """Threshold 'knowledge_gap_rate<0.20' should pass when score is 0.10."""
+        threshold = parse_threshold("knowledge_gap_rate<0.20")
+        scores: dict[str, float | None] = {"knowledge_gap_rate": 0.10}
+        result = evaluate_threshold(threshold, scores)
+        assert result.passed is True
+
+
+class TestRegressionDetection:
+    """Tests for detect_regressions() — regression, improvement, noise margin, None scores."""
+
+    def test_regression_higher_is_better(self):
+        baseline = {"faithfulness": 0.90}
+        current = {"faithfulness": 0.80}
+        directions = {"faithfulness": "higher_is_better"}
+        results = detect_regressions(baseline, current, directions)
+        assert len(results) == 1
+        assert results[0].regressed is True
+
+    def test_improvement_higher_is_better(self):
+        baseline = {"faithfulness": 0.80}
+        current = {"faithfulness": 0.90}
+        directions = {"faithfulness": "higher_is_better"}
+        results = detect_regressions(baseline, current, directions)
+        assert len(results) == 1
+        assert results[0].regressed is False
+
+    def test_regression_lower_is_better(self):
+        baseline = {"rework_cycles": 1.0}
+        current = {"rework_cycles": 2.5}
+        directions = {"rework_cycles": "lower_is_better"}
+        results = detect_regressions(baseline, current, directions)
+        assert len(results) == 1
+        assert results[0].regressed is True
+
+    def test_improvement_lower_is_better(self):
+        baseline = {"rework_cycles": 2.5}
+        current = {"rework_cycles": 1.0}
+        directions = {"rework_cycles": "lower_is_better"}
+        results = detect_regressions(baseline, current, directions)
+        assert len(results) == 1
+        assert results[0].regressed is False
+
+    def test_noise_margin_suppresses_small_regression(self):
+        baseline = {"faithfulness": 0.90}
+        current = {"faithfulness": 0.89}  # delta of 0.01 < noise_margin of 0.02
+        directions = {"faithfulness": "higher_is_better"}
+        results = detect_regressions(baseline, current, directions, noise_margin=0.02)
+        assert len(results) == 1
+        assert results[0].regressed is False
+
+    def test_noise_margin_allows_real_regression(self):
+        baseline = {"faithfulness": 0.90}
+        current = {"faithfulness": 0.85}  # delta of 0.05 > noise_margin of 0.02
+        directions = {"faithfulness": "higher_is_better"}
+        results = detect_regressions(baseline, current, directions, noise_margin=0.02)
+        assert len(results) == 1
+        assert results[0].regressed is True
+
+    def test_none_baseline_skipped(self):
+        baseline: dict[str, float | None] = {"faithfulness": None}
+        current: dict[str, float | None] = {"faithfulness": 0.90}
+        directions = {"faithfulness": "higher_is_better"}
+        results = detect_regressions(baseline, current, directions)
+        assert len(results) == 0
+
+    def test_none_current_skipped(self):
+        baseline: dict[str, float | None] = {"faithfulness": 0.90}
+        current: dict[str, float | None] = {"faithfulness": None}
+        directions = {"faithfulness": "higher_is_better"}
+        results = detect_regressions(baseline, current, directions)
+        assert len(results) == 0
+
+    def test_metric_only_in_baseline_skipped(self):
+        baseline = {"faithfulness": 0.90}
+        current: dict[str, float | None] = {}
+        directions = {"faithfulness": "higher_is_better"}
+        results = detect_regressions(baseline, current, directions)
+        assert len(results) == 0
+
+    def test_metric_only_in_current_skipped(self):
+        baseline: dict[str, float | None] = {}
+        current = {"faithfulness": 0.90}
+        directions = {"faithfulness": "higher_is_better"}
+        results = detect_regressions(baseline, current, directions)
+        assert len(results) == 0
+
+    def test_multiple_metrics_mixed(self):
+        baseline = {"faithfulness": 0.90, "rework_cycles": 1.0}
+        current = {"faithfulness": 0.80, "rework_cycles": 0.5}
+        directions = {
+            "faithfulness": "higher_is_better",
+            "rework_cycles": "lower_is_better",
+        }
+        results = detect_regressions(baseline, current, directions)
+        assert len(results) == 2
+        faith_result = next(result for result in results if result.metric == "faithfulness")
+        rework_result = next(result for result in results if result.metric == "rework_cycles")
+        assert faith_result.regressed is True
+        assert rework_result.regressed is False
+
+    def test_custom_noise_margin(self):
+        baseline = {"faithfulness": 0.90}
+        current = {"faithfulness": 0.85}
+        directions = {"faithfulness": "higher_is_better"}
+        # With noise_margin=0.10, a 0.05 drop is within the margin
+        results = detect_regressions(baseline, current, directions, noise_margin=0.10)
+        assert results[0].regressed is False
+
+    def test_exact_same_score_no_regression(self):
+        baseline = {"faithfulness": 0.90}
+        current = {"faithfulness": 0.90}
+        directions = {"faithfulness": "higher_is_better"}
+        results = detect_regressions(baseline, current, directions)
+        assert len(results) == 1
+        assert results[0].regressed is False
+
+    def test_regression_lower_is_better_knowledge_gap(self):
+        """For lower_is_better metrics, an increase is a regression."""
+        baseline: dict[str, float | None] = {"knowledge_gap_rate": 0.10}
+        current: dict[str, float | None] = {"knowledge_gap_rate": 0.30}
+        directions: dict[str, str] = {"knowledge_gap_rate": "lower_is_better"}
+        regressions = detect_regressions(baseline, current, directions)
+        assert len(regressions) == 1
+        assert regressions[0].regressed is True
+
+
+class TestExitCodes:
+    """Tests for compute_exit_code() — all combinations."""
+
+    def test_clear(self):
+        assert compute_exit_code(threshold_violated=False, regression_detected=False) == 0
+
+    def test_threshold_violation_only(self):
+        assert compute_exit_code(threshold_violated=True, regression_detected=False) == 1
+
+    def test_regression_only(self):
+        assert compute_exit_code(threshold_violated=False, regression_detected=True) == 3
+
+    def test_both(self):
+        assert compute_exit_code(threshold_violated=True, regression_detected=True) == 4


### PR DESCRIPTION
## Summary

Add CI quality gates for automated enforcement:

- `--gate 'metric>value'` with `>`, `<`, `>=`, `<=` operators (multiple allowed)
- `--require-metric` forces N/A metrics to fail instead of skipping
- `--fail-on-regression` on `report --diff` detects wrong-direction moves with noise margin
- Manifest `thresholds:` config (CLI overrides)
- Distinct exit codes: 0=clear, 1=threshold, 3=regression, 4=both
- Supports lower_is_better metrics (knowledge_gap_rate, knowledge_miss_rate)

Refs #116

## Review
- Python Specialist: 3I fixed (public API, Literal types, __init__ re-exports)
- Security Specialist: clean (no exit code bypass, no injection vectors)
- RAG Specialist: 2I fixed (public API, lower_is_better test coverage)

## Test plan
- [x] `TestThresholdParser` (7 tests): all operators, invalid syntax
- [x] `TestThresholdEvaluator` (8 tests): pass, fail, N/A skip, N/A required, unknown metric
- [x] `TestLowerIsBetterThreshold` (2 tests): knowledge_gap_rate threshold
- [x] `TestRegressionDetection` (7 tests): regression, improvement, noise margin, lower_is_better
- [x] `TestExitCodes` (4 tests): all exit code combinations
- [x] `TestGateThresholdCLI` (8 tests): CLI integration
- [x] `TestRegressionCLI` (4 tests): --fail-on-regression integration
- [x] 704 total tests passing

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko