### PR TITLE
docs: three-tier documentation overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RAKI — Retrieval Assessment for Knowledge Impact
+# RAKI -- Retrieval Assessment for Knowledge Impact
 
 A CLI tool that evaluates agentic RAG quality from session transcripts.
 
@@ -6,63 +6,85 @@ A CLI tool that evaluates agentic RAG quality from session transcripts.
 
 ![RAKI HTML Report](docs/images/report-screenshot.png)
 
+## Three tiers of metrics
+
+| Tier | What you need | Metrics |
+|------|--------------|---------|
+| **Operational** | Nothing (zero config) | Verify rate, rework cycles, cost, severity, latency, tokens, self-correction |
+| **Knowledge** | `--docs-path` | Knowledge gap rate, knowledge miss rate |
+| **Analytical** | `--judge` | Faithfulness, answer relevancy, context precision, context recall |
+
 ## Features
 
-- **Operational metrics** — verify rate, rework cycles, severity distribution, cost analysis (no LLM required)
-- **Ragas retrieval metrics** — context precision/recall, faithfulness, answer relevancy
-- **HTML reports** — interactive reports with session-level detail and color-coded thresholds
-- **Pluggable adapters** — bring any session format; built-in support for session-schema and Alcove
-- **Ground truth matching** — curated YAML entries matched by domain for retrieval evaluation
+- **Operational metrics** -- verify rate, rework cycles, severity, cost, latency, tokens, self-correction (no LLM required)
+- **Knowledge metrics** -- gap rate and miss rate based on project documentation coverage
+- **Analytical metrics** -- Ragas-backed context precision/recall, faithfulness, answer relevancy (LLM judge)
+- **HTML reports** -- interactive reports with session-level detail and color-coded thresholds
+- **Quality gates** -- per-metric `--gate` thresholds and `--fail-on-regression` for CI
+- **Pluggable adapters** -- bring any session format; built-in support for session-schema and Alcove
 
 ## Quick Start
 
 ```bash
-uv pip install raki --extra html
-uv run raki validate --manifest raki.yaml
-uv run raki run --manifest raki.yaml --no-llm
-```
+# Install
+uv pip install raki[html]
 
-The `--no-llm` flag runs operational metrics only (no API keys needed).
-To include Ragas retrieval metrics, omit the flag and configure an LLM provider.
-Use `--judge-provider anthropic` for direct Anthropic API access, or
-`--judge-provider vertex-anthropic` (default) for Vertex AI.
+# Validate manifest
+uv run raki validate --manifest raki.yaml
+
+# Run operational metrics (default, no API keys needed)
+uv run raki run --manifest raki.yaml
+
+# Add knowledge metrics
+uv run raki run --manifest raki.yaml --docs-path ./docs
+
+# Add analytical metrics (requires LLM credentials)
+uv run raki run --manifest raki.yaml --judge --judge-provider anthropic
+```
 
 ## Usage
 
 ```bash
-# Run all metrics (requires LLM provider -- Vertex AI Anthropic by default)
-uv run raki run --manifest raki.yaml
+# Run all tiers (operational + knowledge + analytical)
+uv run raki run --manifest raki.yaml --docs-path ./docs --judge
 
-# Run all metrics with direct Anthropic API
-uv run raki run --manifest raki.yaml --judge-provider anthropic
-
-# Run operational metrics only
-uv run raki run --manifest raki.yaml --no-llm
+# Run with direct Anthropic API
+uv run raki run --manifest raki.yaml --judge --judge-provider anthropic
 
 # Run specific metrics only
-uv run raki run --manifest raki.yaml --no-llm --metrics cost_efficiency,rework_cycles
+uv run raki run --manifest raki.yaml --metrics cost_efficiency,rework_cycles
+
+# Quality gates for CI
+uv run raki run --manifest raki.yaml \
+  --gate 'first_pass_verify_rate>0.85' \
+  --gate 'rework_cycles<1.5' \
+  --quiet
+
+# List available metrics
+uv run raki metrics
 
 # Validate manifest and session data
-uv run raki validate --manifest raki.yaml
+uv run raki validate --manifest raki.yaml --deep
+
+# Compare two evaluation runs
+uv run raki report --diff results/baseline.json results/compare.json --fail-on-regression
 
 # List available adapters
 uv run raki adapters
-
-# List available metrics (name, display name, LLM requirement)
-uv run raki metrics
-
-# Machine-readable metric list
-uv run raki metrics --json
 ```
 
 ## Documentation
 
-- [Getting Started](docs/getting-started.md) — install, run, and understand your first report
-- [Interpretation Reference](docs/interpretation-reference.md) — what each metric means and when to act
-- [Ground Truth Curation Guide](docs/curation-guide.md) — write effective ground truth entries
-- [Adapter Guide](docs/adapter-guide.md) — integrate custom session formats
-- [Session Schema Reference](docs/session-schema.md) — field definitions for session-schema format
-- [CI Quality Gate Example](docs/examples/github-actions-quality-gate.yml) — GitHub Actions workflow for automated RAG evaluation
+- [Getting Started](docs/getting-started.md) -- install, run, and understand your first report
+- **Metric references:**
+  - [Operational Metrics](docs/metrics/operational.md) -- verify rate, rework, cost, severity, latency, tokens, self-correction
+  - [Knowledge Metrics](docs/metrics/knowledge.md) -- gap rate, miss rate, domain matching
+  - [Analytical Metrics](docs/metrics/analytical.md) -- faithfulness, relevancy, precision, recall
+- [CI Integration Guide](docs/ci-integration.md) -- quality gates, regression detection, GitHub Actions / GitLab CI
+- [Results Interpretation Reference](docs/interpretation-reference.md) -- zone tables and common patterns
+- [Ground Truth Curation Guide](docs/curation-guide.md) -- write effective ground truth entries
+- [Adapter Guide](docs/adapter-guide.md) -- integrate custom session formats
+- [Session Schema Reference](docs/session-schema.md) -- field definitions for session-schema format
 
 ## Development
 
@@ -78,4 +100,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution workflow.
 
 ## License
 
-Apache 2.0 — see [LICENSE](LICENSE) for details.
+Apache 2.0 -- see [LICENSE](LICENSE) for details.

--- a/changes/117.doc
+++ b/changes/117.doc
@@ -1,0 +1,1 @@
+Overhaul documentation with three-tier metric framework (Operational, Knowledge, Analytical) and CI integration guide.

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -1,0 +1,237 @@
+# CI Integration Guide
+
+RAKI provides quality gates, regression detection, and structured exit codes for CI pipelines.
+
+## Quality gates with --gate
+
+The `--gate` flag sets per-metric thresholds that control the exit code. If any gate fails, RAKI exits with code 1.
+
+### Syntax
+
+```
+--gate 'metric_name>value'
+--gate 'metric_name>=value'
+--gate 'metric_name<value'
+--gate 'metric_name<=value'
+```
+
+Supported operators: `>`, `<`, `>=`, `<=`.
+
+### Examples
+
+```bash
+# Require verify rate above 85%
+uv run raki run --manifest raki.yaml --gate 'first_pass_verify_rate>0.85'
+
+# Multiple gates
+uv run raki run --manifest raki.yaml \
+  --gate 'first_pass_verify_rate>0.85' \
+  --gate 'rework_cycles<1.5' \
+  --gate 'cost_efficiency<15.0'
+
+# With analytical metrics
+uv run raki run --manifest raki.yaml --judge \
+  --gate 'faithfulness>0.80' \
+  --gate 'context_precision>0.75'
+```
+
+### Manifest-based thresholds
+
+You can also define thresholds in your manifest file (`raki.yaml`). CLI `--gate` flags override manifest thresholds when both are present.
+
+```yaml
+thresholds:
+  - "first_pass_verify_rate>0.85"
+  - "rework_cycles<1.5"
+```
+
+## Requiring metrics with --require-metric
+
+By default, when a metric is N/A (no applicable data), its gate is skipped and treated as passing. Use `--require-metric` to fail instead:
+
+```bash
+uv run raki run --manifest raki.yaml \
+  --gate 'self_correction_rate>0.80' \
+  --require-metric self_correction_rate
+```
+
+If `self_correction_rate` is N/A (no rework findings exist), this fails the gate instead of silently skipping it.
+
+## Regression detection with --fail-on-regression
+
+Compare two evaluation runs and fail if any metric regressed beyond a noise margin (2%):
+
+```bash
+uv run raki report \
+  --diff results/baseline.json results/current.json \
+  --fail-on-regression
+```
+
+Regression direction respects each metric's `higher_is_better` setting. For example, an increase in `rework_cycles` (lower is better) is flagged as a regression.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All gates passed, no regressions |
+| 1 | Quality gate violation (`--gate` threshold failed) |
+| 2 | Configuration or input error (bad manifest, unknown metric, invalid syntax) |
+| 3 | Regression detected (`--fail-on-regression`) |
+| 4 | Both threshold violation and regression detected |
+
+## GitHub Actions example
+
+```yaml
+name: RAG Quality Gate
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+      - name: Install RAKI
+        run: uv sync --python 3.12 --all-extras
+      - name: Validate manifest
+        run: uv run raki validate --manifest raki.yaml
+
+  operational-gate:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+      - name: Install RAKI
+        run: uv sync --python 3.12 --all-extras
+      - name: Run operational metrics with gates
+        run: |
+          uv run raki run \
+            --manifest raki.yaml \
+            --gate 'first_pass_verify_rate>0.85' \
+            --gate 'rework_cycles<1.5' \
+            --output results/ \
+            --quiet
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: raki-operational-report
+          path: results/
+          retention-days: 30
+
+  nightly-judge-gate:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: validate
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+      - name: Install RAKI
+        run: uv sync --python 3.12 --all-extras
+      - name: Run full evaluation with judge
+        run: |
+          uv run raki run \
+            --manifest raki.yaml \
+            --judge \
+            --judge-provider anthropic \
+            --gate 'faithfulness>0.80' \
+            --gate 'first_pass_verify_rate>0.85' \
+            --include-sessions \
+            --output results/ \
+            --quiet
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: raki-full-report
+          path: results/
+          retention-days: 90
+```
+
+## GitLab CI example
+
+```yaml
+stages:
+  - validate
+  - gate
+
+variables:
+  UV_VERSION: "latest"
+
+.uv-setup: &uv-setup
+  before_script:
+    - curl -LsSf https://astral.sh/uv/install.sh | sh
+    - export PATH="$HOME/.local/bin:$PATH"
+    - uv sync --python 3.12 --all-extras
+
+validate:
+  stage: validate
+  <<: *uv-setup
+  script:
+    - uv run raki validate --manifest raki.yaml
+
+operational-gate:
+  stage: gate
+  <<: *uv-setup
+  needs: [validate]
+  script:
+    - |
+      uv run raki run \
+        --manifest raki.yaml \
+        --gate 'first_pass_verify_rate>0.85' \
+        --gate 'rework_cycles<1.5' \
+        --output results/ \
+        --quiet
+  artifacts:
+    paths:
+      - results/
+    expire_in: 30 days
+    when: always
+
+nightly-judge-gate:
+  stage: gate
+  <<: *uv-setup
+  needs: [validate]
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  variables:
+    ANTHROPIC_API_KEY: $ANTHROPIC_API_KEY
+  script:
+    - |
+      uv run raki run \
+        --manifest raki.yaml \
+        --judge \
+        --judge-provider anthropic \
+        --gate 'faithfulness>0.80' \
+        --include-sessions \
+        --output results/ \
+        --quiet
+  artifacts:
+    paths:
+      - results/
+    expire_in: 90 days
+    when: always
+```
+
+## Tips
+
+- **Start with operational gates only.** They run fast, need no API keys, and catch the most common issues. Add analytical gates after you have stable baselines.
+- **Use `--quiet` in CI.** Suppresses progress output and only prints errors and gate results.
+- **Use `--json` for machine parsing.** `uv run raki run --manifest raki.yaml --json` writes the full JSON report to stdout.
+- **Archive reports as artifacts.** JSON reports can be re-rendered later with `raki report` or compared with `raki report --diff`.
+- **Regression detection across PRs.** Store the baseline JSON from your main branch, then use `--fail-on-regression` to compare against it on each PR.

--- a/docs/examples/github-actions-quality-gate.yml
+++ b/docs/examples/github-actions-quality-gate.yml
@@ -1,10 +1,10 @@
-# RAKI CI Quality Gate — GitHub Actions Example
+# RAKI CI Quality Gate -- GitHub Actions Example
 #
 # This workflow shows how to integrate RAKI into your CI pipeline:
 #   1. Install RAKI
 #   2. Validate manifest and session data
-#   3. Run operational metrics (no LLM, every PR)
-#   4. Run full evaluation with Ragas metrics (nightly, with threshold)
+#   3. Run operational metrics with quality gates (every PR)
+#   4. Run full evaluation with --judge and gates (nightly)
 #   5. Upload report artifacts
 #
 # Copy this file into your repository as .github/workflows/raki-quality-gate.yml
@@ -16,12 +16,12 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # Nightly at 03:00 UTC — runs full LLM-backed evaluation
+    # Nightly at 03:00 UTC -- runs full LLM-backed evaluation
     - cron: "0 3 * * *"
   workflow_dispatch:
 
 jobs:
-  # ── Step 1: Validate manifest and session data ────────────────────────
+  # -- Step 1: Validate manifest and session data --
   validate:
     runs-on: ubuntu-latest
     steps:
@@ -37,7 +37,7 @@ jobs:
       - name: Validate manifest
         run: uv run raki validate --manifest raki.yaml
 
-  # ── Step 2: Operational gate (every PR, no LLM) ───────────────────────
+  # -- Step 2: Operational gate (every PR, no LLM) --
   operational-gate:
     needs: validate
     runs-on: ubuntu-latest
@@ -51,11 +51,12 @@ jobs:
       - name: Install RAKI
         run: uv sync --python 3.12 --all-extras
 
-      - name: Run operational metrics
+      - name: Run operational metrics with gates
         run: |
           uv run raki run \
             --manifest raki.yaml \
-            --no-llm \
+            --gate 'first_pass_verify_rate>0.85' \
+            --gate 'rework_cycles<1.5' \
             --output results/ \
             --quiet
 
@@ -67,8 +68,8 @@ jobs:
           path: results/
           retention-days: 30
 
-  # ── Step 3: Full evaluation with LLM metrics (nightly only) ───────────
-  nightly-llm-gate:
+  # -- Step 3: Full evaluation with judge metrics (nightly only) --
+  nightly-judge-gate:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: validate
     runs-on: ubuntu-latest
@@ -88,12 +89,14 @@ jobs:
       - name: Install RAKI
         run: uv sync --python 3.12 --all-extras
 
-      - name: Run full evaluation with threshold
+      - name: Run full evaluation with judge and gates
         run: |
           uv run raki run \
             --manifest raki.yaml \
+            --judge \
             --judge-provider anthropic \
-            --threshold 0.7 \
+            --gate 'faithfulness>0.80' \
+            --gate 'first_pass_verify_rate>0.85' \
             --include-sessions \
             --output results/ \
             --quiet

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,19 +10,24 @@ Evaluate your agentic RAG sessions in under 10 minutes.
 ## Install
 
 ```bash
-git clone https://github.com/decko/raki.git
-cd raki
-uv sync --python 3.12 --extra html
+uv pip install raki
 ```
 
-> **LLM-backed metrics**: if you plan to use Ragas retrieval metrics, install
-> with `uv sync --python 3.12 --all-extras` instead. This pulls in
-> `scikit-network`, which requires a C++ compiler.
->
-> By default, RAKI uses **Vertex AI Anthropic** (`--judge-provider vertex-anthropic`)
-> for LLM judge calls. If you have a direct Anthropic API key instead, use
-> `--judge-provider anthropic`. Set the `ANTHROPIC_API_KEY` environment variable
-> for direct API access, or configure Google Cloud credentials for Vertex AI.
+For HTML reports, install the `html` extra:
+
+```bash
+uv pip install raki[html]
+```
+
+For development or analytical metrics (Ragas), install all extras:
+
+```bash
+git clone https://github.com/decko/raki.git
+cd raki
+uv sync --python 3.12 --all-extras
+```
+
+> **Note:** The `ragas` extra pulls `scikit-network`, which requires a C++ compiler (`g++`).
 
 Verify the install:
 
@@ -30,136 +35,159 @@ Verify the install:
 uv run raki --help
 ```
 
-## Quick Start
+## Three tiers of metrics
 
-RAKI ships with example session data so you can try it immediately.
+RAKI organizes metrics into three tiers, each adding more depth:
 
-Validate the example manifest:
+| Tier | What you need | What you get |
+|------|--------------|--------------|
+| **Operational** | Nothing (zero config) | Verify rate, rework cycles, cost, severity, latency, tokens, self-correction |
+| **Knowledge** | `--docs-path ./docs` | Knowledge gap rate, knowledge miss rate |
+| **Analytical** | `--judge` + LLM credentials | Faithfulness, answer relevancy, context precision, context recall |
 
-```bash
-uv run raki validate --manifest examples/raki-minimal.yaml
-```
+Start with operational metrics and add tiers as needed.
 
-For a deeper smoke test that checks adapter loading, ground truth wiring, and
-operational metrics against a single sample (no LLM calls, no full run):
+## Step 1: Operational metrics (zero config)
 
-```bash
-uv run raki validate --manifest examples/raki-minimal.yaml --deep
-```
-
-Run an evaluation using only operational metrics (no LLM required):
+Run operational metrics immediately -- no API keys, no docs, no ground truth:
 
 ```bash
-uv run raki run --manifest examples/raki-minimal.yaml --no-llm
+uv run raki run --manifest raki.yaml
 ```
 
-### Discovering Available Metrics
+This is the default mode. It computes all seven operational metrics from session transcript data alone:
 
-List all metrics RAKI can compute, including which ones require an LLM provider:
+- **Verify rate** -- % sessions passing verification on first try
+- **Rework cycles** -- mean review-fix iterations per session
+- **Severity score** -- weighted severity of review findings
+- **Cost / session** -- mean USD cost per session
+- **Self-correction rate** -- ratio of rework findings resolved
+- **Phase execution time** -- mean phase time in seconds
+- **Tokens / phase** -- mean tokens per phase
+
+### Discovering metrics
 
 ```bash
-uv run raki metrics
+uv run raki metrics          # table of all metrics
+uv run raki metrics --json   # machine-readable
 ```
 
-Use `--json` for machine-readable output:
+### Running specific metrics
 
 ```bash
-uv run raki metrics --json
+uv run raki run --manifest raki.yaml --metrics cost_efficiency,rework_cycles
 ```
 
-Run only specific metrics by name (use the internal name from `raki metrics`):
+## Step 2: Add docs for knowledge metrics
+
+Point RAKI at your project documentation to activate knowledge metrics:
 
 ```bash
-uv run raki run --manifest examples/raki-minimal.yaml --no-llm --metrics cost_efficiency,rework_cycles
+uv run raki run --manifest raki.yaml --docs-path ./docs
 ```
 
-## Prepare Your Data
+Or configure it in your manifest:
 
-RAKI evaluates session transcripts produced by agentic coding tools. Each session is a directory containing phase files (`triage.json`, `implement.json`, `verify.json`, `review.json`) and an `events.jsonl` log. See `examples/sessions/` for working examples.
+```yaml
+docs:
+  path: ./docs
+  extensions: [".md", ".rst", ".txt"]
+```
 
-If your tool produces a different format, you can write a custom adapter. See the [Adapter Authoring Guide](adapter-guide.md) for details.
+This adds two metrics:
 
-## Understanding the Output
+- **Knowledge gap rate** -- how often rework happens in domains not covered by your docs
+- **Knowledge miss rate** -- how often the agent fails despite having relevant docs
 
-The Quick Start command above produces output like this:
+See [Knowledge Metrics Reference](metrics/knowledge.md) for details.
+
+## Step 3: Add a judge for analytical metrics
+
+Enable LLM-judged retrieval quality metrics with `--judge`:
+
+```bash
+# Vertex AI Anthropic (default)
+uv run raki run --manifest raki.yaml --judge
+
+# Direct Anthropic API
+uv run raki run --manifest raki.yaml --judge --judge-provider anthropic
+
+# Google AI
+uv run raki run --manifest raki.yaml --judge --judge-provider google
+```
+
+This adds four Ragas-backed metrics:
+
+- **Faithfulness** -- is the output grounded in retrieved context?
+- **Answer relevancy** -- does the output address the question?
+- **Context precision** -- is the retrieved context relevant? (requires ground truth)
+- **Context recall** -- was all needed context retrieved? (requires ground truth)
+
+Set `ANTHROPIC_API_KEY` for direct Anthropic API, or configure Google Cloud credentials for Vertex AI.
+
+See [Analytical Metrics Reference](metrics/analytical.md) for details.
+
+## Validate before running
+
+Check your manifest and session data without running metrics:
+
+```bash
+uv run raki validate --manifest raki.yaml
+```
+
+For a deeper smoke test (adapter loading, ground truth wiring, metric computation against one sample):
+
+```bash
+uv run raki validate --manifest raki.yaml --deep
+```
+
+## Understanding the output
+
+A typical operational run produces:
 
 ```
-Loading sessions from examples/sessions...
-Loaded 6 sessions (0 skipped, 0 errors)
-
 Operational Health
-  Verify rate                         0.75  (% sessions passing verify on first try)
-  Rework cycles                       0.2  (Mean review-rework iterations per session)
-  Severity score                      0.39  (Weighted severity of review findings (1.0 = no findings))
-  Cost / session                      $10.93  (Mean USD cost per session)
-  Knowledge miss rate                 1.00  (Ratio of rework findings caused by missing knowledge retrieval)
-  ⚠ Small sample size (n=6) — scores are directional, not definitive
+  Verify rate                         0.75
+  Rework cycles                       0.2
+  Severity score                      0.39
+  Cost / session                      $10.93
+  Self-correction rate                N/A (no rework findings)
+  Phase execution time                142.3s
+  Tokens / phase                      3,241
 ```
 
-Key metrics to watch:
-
-- **Verify rate** (0.75) -- 75% of sessions passed verification on the first attempt. Higher is better; values below 0.5 suggest systemic quality issues in the implement phase.
-- **Rework cycles** (0.2) -- sessions needed an average of 0.2 review-rework iterations. Lower is better; values above 1.0 mean most sessions require at least one rework round.
-- **Severity score** (0.39) -- weighted severity of review findings, where 1.0 means no findings at all. Higher is better; low values indicate reviewers are catching serious issues.
-
-## Re-rendering Reports
-
-RAKI saves evaluation results as JSON. You can re-render the CLI summary or generate an HTML report from a saved JSON file at any time:
+Reports are saved as JSON (always) and HTML (when jinja2 is installed). Re-render anytime:
 
 ```bash
-# Re-render CLI summary from a saved report
 uv run raki report results/raki-report-20260410T120000.json
-
-# Generate an HTML report from the same JSON
-uv run raki report results/raki-report-20260410T120000.json --html results/report.html
+uv run raki report results/raki-report-20260410T120000.json --html report.html
 ```
 
-If the JSON report was generated without `--include-sessions`, RAKI will show aggregate scores only and warn that per-session drill-down is unavailable.
-
-## Comparing Runs
-
-Compare two evaluation runs side by side to see what improved and what regressed:
+Compare two runs:
 
 ```bash
-# Compare a baseline and a new run
 uv run raki report --diff results/baseline.json results/compare.json
-
-# Generate an HTML diff report
-uv run raki report --diff results/baseline.json results/compare.json --html results/diff.html
-
-# Write HTML to a specific output directory
-uv run raki report --diff results/baseline.json results/compare.json -o results/
 ```
 
-The diff output shows:
+## CI integration
 
-- **Coverage line** -- how many sessions matched between runs, plus counts of new and dropped sessions.
-- **Aggregate deltas** -- metric-by-metric comparison with direction indicators (green for improvements, red for regressions).
-- **Session transitions** -- which sessions changed verdict (e.g., REWORK to PASS), grouped by transition type with regressions listed first.
-
-For per-session transition analysis, both reports must have been generated with `--include-sessions`. Without session data, only aggregate deltas are shown.
-
-## CI Integration
-
-RAKI works well as a CI quality gate. A typical setup has two layers:
-
-1. **Operational gate (every PR)** -- runs `raki run --no-llm` to check verify rate, rework cycles, and cost without needing API keys. Fast and free.
-2. **Nightly LLM gate (scheduled)** -- runs the full evaluation including Ragas retrieval metrics with `--threshold` to catch regressions overnight.
+Use `--gate` for per-metric quality gates:
 
 ```bash
-# Operational gate (no LLM, suitable for every PR)
-uv run raki run --manifest raki.yaml --no-llm --output results/ --quiet
-
-# Nightly gate (full evaluation with threshold)
-uv run raki run --manifest raki.yaml --threshold 0.7 --output results/ --quiet
+uv run raki run --manifest raki.yaml \
+  --gate 'first_pass_verify_rate>0.85' \
+  --gate 'rework_cycles<1.5' \
+  --quiet
 ```
 
-Note that `--threshold` sets a minimum score for a zero exit code -- use it in the nightly job to fail the build on regressions, but not with `--no-llm` where the limited metric set makes a single threshold less meaningful.
+See [CI Integration Guide](ci-integration.md) for `--gate` syntax, `--fail-on-regression`, exit codes, and full GitHub Actions / GitLab CI examples.
 
-See [docs/examples/github-actions-quality-gate.yml](examples/github-actions-quality-gate.yml) for a complete GitHub Actions workflow with validation, operational gating, nightly LLM runs, and artifact upload.
+## Next steps
 
-## Next Steps
-
-- [Results Interpretation Reference](interpretation-reference.md) -- thresholds, patterns, and what to do about low scores
-- [Ground Truth Curation Guide](curation-guide.md) -- writing effective ground truth for Ragas retrieval metrics
-- [Adapter Authoring Guide](adapter-guide.md) -- integrating session formats beyond the built-in adapters
+- [Operational Metrics Reference](metrics/operational.md) -- all seven operational metrics in detail
+- [Knowledge Metrics Reference](metrics/knowledge.md) -- knowledge gap and miss rates
+- [Analytical Metrics Reference](metrics/analytical.md) -- Ragas-backed retrieval quality metrics
+- [CI Integration Guide](ci-integration.md) -- quality gates, regression detection, CI examples
+- [Results Interpretation Reference](interpretation-reference.md) -- zone tables and common patterns
+- [Ground Truth Curation Guide](curation-guide.md) -- writing ground truth for context precision/recall
+- [Adapter Guide](adapter-guide.md) -- integrating custom session formats

--- a/docs/interpretation-reference.md
+++ b/docs/interpretation-reference.md
@@ -3,6 +3,11 @@
 How to read RAKI metrics and what to do when they signal problems.
 See [Getting Started](getting-started.md) for running your first evaluation.
 
+For detailed metric documentation, see the per-tier references:
+- [Operational Metrics](metrics/operational.md)
+- [Knowledge Metrics](metrics/knowledge.md)
+- [Analytical Metrics](metrics/analytical.md)
+
 ## Operational Health Metrics
 
 These metrics require no LLM -- they are computed directly from session data.
@@ -55,17 +60,17 @@ Mean USD cost per session (lower is better). Acceptable ranges depend on your co
 
 **Red zone action:** Check token counts and rework cycles. High cost usually stems from excessive rework or overly large context windows. Reducing retrieved context or improving first-pass quality brings cost down.
 
-### knowledge_retrieval_miss_rate -- Knowledge miss rate
+### self_correction_rate -- Self-correction rate
 
-Fraction of rework-triggering findings where the relevant knowledge was not in the retrieved context (lower is better).
+Ratio of rework findings (critical/major) resolved by the agent (higher is better). Returns N/A when no rework findings exist.
 
 | Zone | Range | Meaning |
 |------|-------|---------|
-| Green | < 0.15 | Knowledge base covers most failure cases |
-| Yellow | 0.15 -- 0.40 | Notable gaps in knowledge coverage |
-| Red | > 0.40 | Knowledge base is missing content for many failure modes |
+| Green | >= 0.80 | Agent fixes most issues after feedback |
+| Yellow | 0.50 -- 0.79 | Some issues persist after rework |
+| Red | < 0.50 | Agent fails to resolve most issues |
 
-**Red zone action:** Extract the topics from missed findings and add them to your knowledge base. This is the single most direct way to improve agent quality.
+**Red zone action:** Investigate whether review criteria are clear and whether the agent's fix-apply loop is working. Low self-correction with high rework cycles means the agent is churning without converging.
 
 ### phase_execution_time -- Phase execution time
 
@@ -91,7 +96,35 @@ Average tokens (input + output) consumed per phase (lower is better). Measures h
 
 **Red zone action:** Check whether phases are receiving overly large context windows or generating verbose output. Reducing retrieved context size and tightening prompts are the most effective levers. High token counts combined with high cost_per_session confirm that token volume is driving spend.
 
-## Retrieval Quality Metrics
+## Knowledge Metrics
+
+These metrics require `--docs-path` or `docs.path` in the manifest. They measure how well your documentation covers the domains where the agent makes mistakes.
+
+### knowledge_gap_rate -- Knowledge gap rate
+
+Ratio of rework findings in domains NOT covered by the knowledge base (lower is better).
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | < 0.20 | KB covers most failure domains |
+| Yellow | 0.20 -- 0.40 | Notable gaps in knowledge coverage |
+| Red | > 0.40 | KB is missing content for many failure modes |
+
+**Red zone action:** Extract the topics from uncovered findings and add them to your knowledge base. This is the single most direct way to improve agent quality.
+
+### knowledge_miss_rate -- Knowledge miss rate
+
+Ratio of rework findings in domains covered by the KB but the agent still got wrong (lower is better).
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | < 0.10 | Agent uses KB content effectively |
+| Yellow | 0.10 -- 0.30 | Agent sometimes ignores available knowledge |
+| Red | > 0.30 | Agent frequently fails despite having KB coverage |
+
+**Red zone action:** Review the KB content for affected domains. The information exists but is not preventing mistakes -- it may need restructuring or clearer language.
+
+## Analytical Metrics
 
 These metrics use LLM-backed evaluation via Ragas and require ground truth data.
 

--- a/docs/interpreting-results.md
+++ b/docs/interpreting-results.md
@@ -2,8 +2,12 @@
 
 How to read the RAKI HTML report and understand what the metrics mean.
 
-For the full metric reference with zone tables and red-zone actions, see
-[interpretation-reference.md](interpretation-reference.md).
+RAKI organizes metrics into three tiers. For full metric details, see the dedicated references:
+- [Operational Metrics](metrics/operational.md) -- zero config, computed from session data
+- [Knowledge Metrics](metrics/knowledge.md) -- requires `--docs-path`
+- [Analytical Metrics](metrics/analytical.md) -- requires `--judge`
+
+For zone tables and red-zone actions, see [interpretation-reference.md](interpretation-reference.md).
 
 ## Operational Health
 
@@ -57,21 +61,41 @@ The **weighted severity** formula is:
 This weights critical findings three times more than minor ones. A "Severe"
 label means a disproportionate number of findings are critical or major.
 
-### Knowledge Miss Rate
+### Self-Correction Rate
 
-**What it measures:** How often rework happened because the agent lacked the
-right reference material in its retrieved context.
+**What it measures:** Ratio of rework findings (critical/major) resolved by
+the agent after review feedback.
+
+- **Target:** >80%
+- **Direction:** Higher is better
+- Shows N/A when no rework findings exist.
+
+## Knowledge Metrics
+
+These metrics appear when `--docs-path` is provided (or `docs.path` is set in the manifest).
+
+### Knowledge Gap Rate
+
+**What it measures:** Ratio of rework findings in domains NOT covered by
+the knowledge base.
 
 - **Target:** <0.20
 - **Direction:** Lower is better
-- This metric is **hidden** when no sessions have `knowledge_context` data.
-  A footnote explains: "Knowledge Miss Rate omitted -- no retrieval context
-  available in sessions."
+- Shows N/A when no rework findings exist or no docs are loaded.
 
-## Retrieval Quality
+### Knowledge Miss Rate
 
-These metrics require LLM-backed evaluation (they are hidden in `--no-llm`
-mode, with a footnote explaining why).
+**What it measures:** Ratio of rework findings in domains covered by the KB
+but the agent still got wrong.
+
+- **Target:** <0.10
+- **Direction:** Lower is better
+- Shows N/A when no rework findings exist or no docs are loaded.
+
+## Analytical Quality
+
+These metrics require `--judge` to enable LLM-backed evaluation. Without
+`--judge`, this section shows a footnote explaining why it is hidden.
 
 ### Context Precision
 
@@ -80,6 +104,7 @@ relevant to the question.
 
 - **Target:** >0.80
 - **Direction:** Higher is better
+- Requires ground truth.
 
 ### Context Recall
 
@@ -88,11 +113,19 @@ successfully found.
 
 - **Target:** >0.80
 - **Direction:** Higher is better
+- Requires ground truth.
 
 ### Faithfulness
 
 **What it measures:** How closely the agent's output sticks to the facts in
 its source material.
+
+- **Direction:** Higher is better
+- This metric is **experimental** for agentic sessions.
+
+### Answer Relevancy
+
+**What it measures:** How relevant the agent's output is to the user query.
 
 - **Direction:** Higher is better
 - This metric is **experimental** for agentic sessions.
@@ -139,5 +172,5 @@ is unavailable.
   that changes improved metrics without introducing regressions.
 - **Across evaluation batches**: compare runs on different session sets to
   spot trends in retrieval quality or operational health.
-- **CI pipelines**: use diff to gate merges -- if regressions appear, the
-  diff output shows exactly which sessions regressed and by how much.
+- **CI pipelines**: use `--fail-on-regression` to gate merges -- if regressions
+  appear, the diff output shows exactly which sessions regressed and by how much.

--- a/docs/metrics/analytical.md
+++ b/docs/metrics/analytical.md
@@ -1,0 +1,134 @@
+# Analytical Metrics Reference
+
+Analytical metrics use an LLM judge (via Ragas) to evaluate retrieval quality. They require the `--judge` flag and LLM provider credentials.
+
+## Prerequisites
+
+Enable analytical metrics with `--judge`:
+
+```bash
+# Using Vertex AI Anthropic (default provider)
+uv run raki run --manifest raki.yaml --judge
+
+# Using direct Anthropic API
+uv run raki run --manifest raki.yaml --judge --judge-provider anthropic
+
+# Using Google AI
+uv run raki run --manifest raki.yaml --judge --judge-provider google
+```
+
+Provider options for `--judge-provider`:
+- `vertex-anthropic` (default) -- Claude via Vertex AI
+- `anthropic` -- direct Anthropic API (requires `ANTHROPIC_API_KEY`)
+- `google` -- Google AI
+
+The default judge model is `claude-sonnet-4-6`. Override with `--judge-model`.
+
+Install with all extras to get Ragas dependencies:
+
+```bash
+uv sync --python 3.12 --all-extras
+```
+
+> **Note:** The `ragas` extra pulls `scikit-network`, which requires a C++ compiler (`g++`).
+
+## Context synthesis
+
+RAKI synthesizes context for Ragas evaluation from session phase data. The agent's tool calls, retrieved documents, and phase outputs are assembled into `retrieved_contexts` and `response` fields that Ragas evaluates.
+
+When the context source is inferred from phase data rather than explicit retrieval logs, metric names may appear with an `(inferred)` suffix in the report to indicate that context was reconstructed rather than directly captured.
+
+## faithfulness -- Faithfulness (experimental)
+
+**What it measures:** Whether the agent's output is grounded in the retrieved context -- i.e., the agent is not hallucinating beyond what the sources provide.
+
+**What it tells you:** How closely the agent sticks to facts in its source material.
+
+**What action it drives:** Inspect low-scoring sessions manually. Distinguish between genuine hallucination and legitimate multi-step reasoning before taking action.
+
+**How it's computed:** Ragas Faithfulness metric. Uses LLM-as-judge to check each claim in the response against retrieved contexts.
+
+**N/A conditions:** Returns `score=None` when no sessions have retrieval context.
+
+**Experimental caveat:** This metric was designed for natural language answers, not code. Scores may be noisy for agentic code-generation sessions where the agent synthesizes across tool calls.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | >= 0.80 | Output is well-grounded in context |
+| Yellow | 0.50--0.79 | Some claims lack context support |
+| Red | < 0.50 | Output frequently diverges from context |
+
+---
+
+## answer_relevancy -- Answer relevancy (experimental)
+
+**What it measures:** How relevant the agent's output is to the original user query.
+
+**What it tells you:** Whether the agent is addressing the actual question or going off-track.
+
+**What action it drives:** Low relevancy often indicates a prompt or routing issue rather than a retrieval problem. Check whether the agent is interpreting the task correctly.
+
+**How it's computed:** Ragas AnswerRelevancy metric. Uses LLM + embeddings to measure semantic similarity between the response and the question.
+
+**N/A conditions:** Returns `score=None` when no sessions have retrieval context.
+
+**Experimental caveat:** Multi-step agent workflows may address the question indirectly, lowering scores without indicating a real problem.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | >= 0.80 | Output directly addresses the question |
+| Yellow | 0.50--0.79 | Output partially addresses the question |
+| Red | < 0.50 | Output does not address the question |
+
+---
+
+## context_precision -- Context precision (requires ground truth)
+
+**What it measures:** Precision of retrieved contexts relative to ground truth -- how much of what the retriever pulled in was actually relevant.
+
+**What it tells you:** Whether the retriever is surfacing relevant content or flooding the context window with noise.
+
+**What action it drives:** Low precision means the agent wastes tokens on irrelevant context. Review your retrieval pipeline's chunking and ranking.
+
+**How it's computed:** Ragas ContextPrecisionWithReference metric. Requires ground truth entries matched to sessions via `ground_truth.path` in the manifest.
+
+**N/A conditions:** Scores 0.0 with `details.skipped: "no ground truth"` when no sessions have matched ground truth entries. Run `raki validate` to check your ground truth match rate.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | >= 0.80 | Retrieved context is mostly relevant |
+| Yellow | 0.50--0.79 | Significant irrelevant context |
+| Red | < 0.50 | More noise than signal |
+
+---
+
+## context_recall -- Context recall (requires ground truth)
+
+**What it measures:** Recall of retrieved contexts relative to ground truth -- how much of the needed information the retriever successfully found.
+
+**What it tells you:** Whether the retriever is finding all the relevant knowledge.
+
+**What action it drives:** Low recall means the agent cannot find what it needs. Check that your knowledge base contains the expected content and that search is surfacing it.
+
+**How it's computed:** Ragas ContextRecallWithReference metric. Requires ground truth entries matched to sessions.
+
+**N/A conditions:** Same as context_precision -- requires matched ground truth.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | >= 0.80 | Most relevant knowledge is retrieved |
+| Yellow | 0.50--0.79 | Important context is being missed |
+| Red | < 0.50 | Retrieval fails to surface relevant knowledge |
+
+## Ground truth requirements
+
+Context precision and context recall require ground truth data configured in your manifest:
+
+```yaml
+ground_truth:
+  path: ./ground-truth/
+```
+
+Ground truth entries are matched to sessions by `code_area` domain-token overlap from triage phases. Sessions without a triage phase will not match. Run `raki validate` to check your match rate.
+
+See [Ground Truth Curation Guide](../curation-guide.md) for writing effective ground truth entries.

--- a/docs/metrics/knowledge.md
+++ b/docs/metrics/knowledge.md
@@ -1,0 +1,79 @@
+# Knowledge Metrics Reference
+
+Knowledge metrics measure how well your project's documentation covers the domains where the agent makes mistakes. They require a docs path (via `--docs-path` or the `docs.path` manifest field) and activate automatically when docs are loaded.
+
+## Prerequisites
+
+Provide project documentation so RAKI can build a knowledge context:
+
+```bash
+uv run raki run --manifest raki.yaml --docs-path ./docs
+```
+
+Or configure it in your manifest:
+
+```yaml
+docs:
+  path: ./docs
+  extensions: [".md", ".rst", ".txt"]
+```
+
+## How domain matching works
+
+RAKI loads doc files from the docs path, chunks them, and derives **domains** from the directory structure (e.g., `docs/api/auth.md` maps to the `api` domain). Each chunk carries its domain tag.
+
+When computing knowledge metrics, RAKI compares the words in each review finding's `issue` text against the words in the knowledge context. A finding is considered **covered** if its issue words overlap with the knowledge context, and **uncovered** if they do not.
+
+- **Covered domains:** The knowledge base has content relevant to the finding's topic.
+- **Uncovered domains:** No knowledge base content matches the finding's topic.
+
+## knowledge_gap_rate -- Knowledge gap rate
+
+**What it measures:** Ratio of rework-triggering findings (critical/major) in domains NOT covered by the knowledge base.
+
+**What it tells you:** Where your documentation is missing. High values mean agents are making mistakes in areas where no reference material exists.
+
+**What action it drives:** Extract the topics from uncovered findings and add them to your knowledge base. This is the single most direct way to improve agent quality.
+
+**How it's computed:** For sessions with `rework_cycles > 0` and knowledge context: count findings whose issue words do NOT overlap with the knowledge context. Score = `uncovered_findings / total_rework_findings`. Lower is better.
+
+**N/A conditions:** Returns `score=None` when:
+- No sessions have rework findings, OR
+- No sessions have knowledge context (docs not loaded)
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | < 0.20 | KB covers most failure domains |
+| Yellow | 0.20--0.40 | Notable gaps in knowledge coverage |
+| Red | > 0.40 | KB is missing content for many failure modes |
+
+---
+
+## knowledge_miss_rate -- Knowledge miss rate
+
+**What it measures:** Ratio of rework-triggering findings (critical/major) in domains that ARE covered by the knowledge base but the agent still got wrong.
+
+**What it tells you:** How often the agent fails despite having the right reference material. High values may indicate the KB content is unclear, outdated, or the agent is not using it effectively.
+
+**What action it drives:** Review the KB content for the affected domains. The information exists but is not preventing mistakes -- it may need to be restructured, made more explicit, or moved closer to the agent's context window.
+
+**How it's computed:** For sessions with `rework_cycles > 0` and knowledge context: count findings whose issue words overlap with the knowledge context. Score = `covered_findings / total_rework_findings`. Lower is better.
+
+**N/A conditions:** Returns `score=None` when:
+- No sessions have rework findings, OR
+- No sessions have knowledge context (docs not loaded)
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | < 0.10 | Agent uses KB content effectively |
+| Yellow | 0.10--0.30 | Agent sometimes ignores available knowledge |
+| Red | > 0.30 | Agent frequently fails despite having KB coverage |
+
+## Relationship between gap rate and miss rate
+
+These two metrics are complementary:
+
+- `knowledge_gap_rate + knowledge_miss_rate` may not sum to 1.0 because minor findings are excluded and sessions without knowledge context are skipped entirely.
+- **High gap rate, low miss rate:** Your KB works well where it exists -- expand its coverage.
+- **Low gap rate, high miss rate:** Your KB covers the right domains but the content is not effective -- improve quality.
+- **Both high:** Both coverage and quality need work.

--- a/docs/metrics/operational.md
+++ b/docs/metrics/operational.md
@@ -1,0 +1,140 @@
+# Operational Metrics Reference
+
+Operational metrics run with zero configuration -- no LLM, no API keys, no docs path. They are computed directly from session transcript data.
+
+## first_pass_verify_rate -- Verify rate
+
+**What it measures:** Fraction of sessions where the agent's work passed all verification checks on the first attempt.
+
+**What it tells you:** Whether the agent consistently delivers correct work without needing rework. A proxy for implementation quality.
+
+**What action it drives:** Low values mean the implement phase is producing defective output. Investigate common failure patterns in failing sessions and improve prompts or knowledge coverage for those domains.
+
+**How it's computed:** Count sessions with a `verify` phase at `generation=1` and `status=completed`, divided by total sessions with at least one verify phase. Returns a ratio (0.0--1.0).
+
+**N/A conditions:** Never N/A -- returns 0.0 when no sessions have verify phases.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | >= 0.85 | Most sessions pass on first try |
+| Yellow | 0.60--0.84 | Noticeable first-attempt failures |
+| Red | < 0.60 | Majority of sessions need rework |
+
+---
+
+## rework_cycles -- Rework cycles
+
+**What it measures:** Mean number of review-fix iterations per session.
+
+**What it tells you:** How much back-and-forth happens between the agent and reviewers. High values mean inefficient iteration.
+
+**What action it drives:** Audit review findings across sessions. Repeated rework on the same issue category means the agent lacks the knowledge to get it right the first time. Add that knowledge to the KB or improve prompts.
+
+**How it's computed:** Sum `session.rework_cycles` across all sessions, divide by session count. Returns a raw count (not 0--1 normalized).
+
+**N/A conditions:** Never N/A -- returns 0.0 when there are no sessions.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | < 1.5 | Minor or no rework needed |
+| Yellow | 1.5--3.0 | Sessions routinely need multiple iterations |
+| Red | > 3.0 | Excessive iteration |
+
+---
+
+## review_severity_distribution -- Severity score
+
+**What it measures:** Weighted severity of review findings across all sessions, where 1.0 means no findings.
+
+**What it tells you:** Whether review findings are trending toward critical or staying minor.
+
+**What action it drives:** Categorize findings by severity and domain. Critical findings in a specific domain point to knowledge gaps in that area.
+
+**How it's computed:**
+```
+weighted = (3 * critical + 2 * major + 1 * minor) / (3 * total)
+score = 1.0 - weighted
+```
+Returns 1.0 when there are zero findings.
+
+**N/A conditions:** Never N/A -- returns 1.0 when no findings exist.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | >= 0.85 | Few or no significant findings |
+| Yellow | 0.60--0.84 | Moderate findings present |
+| Red | < 0.60 | Critical or major findings are common |
+
+---
+
+## cost_efficiency -- Cost / session
+
+**What it measures:** Mean LLM API cost per session in USD.
+
+**What it tells you:** How much each agent task costs. Useful for budgeting and spotting cost spikes.
+
+**What action it drives:** High cost usually stems from excessive rework or large context windows. Reducing retrieved context size or improving first-pass quality brings cost down.
+
+**How it's computed:** Average `session.total_cost_usd` across sessions that have cost data. Returns raw USD value.
+
+**N/A conditions:** Returns 0.0 when no sessions have `total_cost_usd`. The report shows "N/A" when `details.sessions_with_cost` is 0.
+
+---
+
+## self_correction_rate -- Self-correction rate
+
+**What it measures:** Ratio of rework findings (critical/major) that were resolved by the agent.
+
+**What it tells you:** Whether the agent can fix its own mistakes after review feedback.
+
+**What action it drives:** Low self-correction with high rework cycles means the agent is churning without converging. Investigate whether review criteria are clear and whether the agent's fix-apply loop is working.
+
+**How it's computed:** For sessions with `rework_cycles > 0` and critical/major findings: if the final verify phase has `status=completed`, all findings in that session count as resolved. Score = `resolved_findings / total_rework_findings`.
+
+**N/A conditions:** Returns `score=None` (displayed as N/A) when no sessions have rework findings. This is normal for high-quality runs.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | >= 0.80 | Agent fixes most issues after feedback |
+| Yellow | 0.50--0.79 | Some issues persist after rework |
+| Red | < 0.50 | Agent fails to resolve most issues |
+
+---
+
+## phase_execution_time -- Phase execution time
+
+**What it measures:** Mean total phase execution time per session in seconds.
+
+**What it tells you:** How long the agent spends on each session. Sums `duration_ms` across all phases and converts to seconds. Does not capture inter-phase gaps or human-in-the-loop pauses.
+
+**What action it drives:** Long execution times usually come from expensive tool calls, large context processing, or retry loops within a single phase. Check which phases are slowest.
+
+**How it's computed:** For each session with duration data, sum `phase.duration_ms` across phases, convert to seconds. Average across sessions.
+
+**N/A conditions:** Returns 0.0 when no sessions have `duration_ms` data. The report shows "N/A" when `details.sessions_with_duration` is 0.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | < 60s | Phases complete quickly |
+| Yellow | 60s--300s | Noticeable execution time |
+| Red | > 300s | Phases take a long time |
+
+---
+
+## token_efficiency -- Tokens / phase
+
+**What it measures:** Average tokens (input + output) consumed per phase.
+
+**What it tells you:** How efficiently each phase uses context. High token counts drive both cost and latency.
+
+**What action it drives:** Reduce retrieved context size and tighten prompts. High token counts combined with high cost confirm that token volume is driving spend.
+
+**How it's computed:** For each session, compute the mean of `(tokens_in + tokens_out)` across phases with token data. Then average across sessions.
+
+**N/A conditions:** Returns 0.0 when no phases have token data. The report shows "N/A" when `details.sessions_with_tokens` is 0.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | < 2,000 | Lean and efficient |
+| Yellow | 2,000--8,000 | Moderate token usage |
+| Red | > 8,000 | Excessive tokens per phase |


### PR DESCRIPTION
## Summary

Overhaul all documentation around the Operational / Knowledge / Analytical metric framework:

- **Metric reference guides** (`docs/metrics/`): per-metric docs with what it measures, tells you, and drives
- **Progressive getting-started**: zero-config Operational -> `--docs-path` Knowledge -> `--judge` Analytical
- **CI integration guide**: `--gate`, `--fail-on-regression`, `--require-metric`, exit codes, GitHub Actions + GitLab CI examples
- **README updated**: three-tier summary table, correct CLI flags
- **All `--no-llm` references replaced** with `--judge` across all user-facing docs

Refs #117

## Review
- Doc Specialist: 2C + 1I fixed (tier naming, metric placement, threshold reconciliation)

## Test plan
- [x] All cross-references verified (no broken links)
- [x] CLI flags match actual code (`--judge`, `--gate`, `--docs-path`, `--fail-on-regression`)
- [x] No `--no-llm` in user-facing docs

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko