### PR TITLE
fix(gates): handle missing metrics in --require-metric gracefully

### DIFF
--- a/src/raki/gates/thresholds.py
+++ b/src/raki/gates/thresholds.py
@@ -70,6 +70,11 @@ def evaluate_threshold(
 ) -> ThresholdResult:
     """Evaluate a single threshold against the actual scores.
 
+    If a metric is absent from scores (not computed) or is None (N/A), behavior
+    depends on whether it appears in required_metrics:
+    - Required: returns a FAIL result with an explanatory reason.
+    - Not required: returns a SKIP result (treated as passing).
+
     Args:
         threshold: The threshold to evaluate.
         scores: Map of metric names to their scores (None means N/A).
@@ -77,34 +82,38 @@ def evaluate_threshold(
 
     Returns:
         A ThresholdResult indicating pass/fail/skip.
-
-    Raises:
-        ValueError: If the metric name is not found in scores.
     """
-    if threshold.metric not in scores:
-        raise ValueError(
-            f"Unknown metric '{threshold.metric}' in threshold. "
-            f"Available metrics: {', '.join(sorted(scores.keys()))}"
-        )
+    actual = scores.get(threshold.metric)
+    metric_missing = threshold.metric not in scores
 
-    actual = scores[threshold.metric]
-
-    if actual is None:
+    if metric_missing or actual is None:
         required = required_metrics or set()
         if threshold.metric in required:
+            if metric_missing:
+                reason = (
+                    f"Metric '{threshold.metric}' was not computed "
+                    f"(did you forget --judge?). "
+                    f"Available metrics: {', '.join(sorted(scores.keys()))}"
+                )
+            else:
+                reason = f"Metric '{threshold.metric}' is N/A but required by --require-metric"
             return ThresholdResult(
                 threshold=threshold,
                 actual=None,
                 passed=False,
                 skipped=False,
-                reason=f"Metric '{threshold.metric}' is N/A but required by --require-metric",
+                reason=reason,
             )
+        if metric_missing:
+            reason = f"Metric '{threshold.metric}' was not computed — skipping threshold check"
+        else:
+            reason = f"Metric '{threshold.metric}' is N/A — skipping threshold check"
         return ThresholdResult(
             threshold=threshold,
             actual=None,
             passed=True,
             skipped=True,
-            reason=f"Metric '{threshold.metric}' is N/A — skipping threshold check",
+            reason=reason,
         )
 
     comparison_fn = _OPERATORS[threshold.operator]

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -118,11 +118,15 @@ class TestThresholdEvaluator:
         result = evaluate_threshold(threshold, scores)
         assert result.passed is True
 
-    def test_unknown_metric_raises(self):
+    def test_unknown_metric_skipped_not_raised(self):
+        """Unknown metric (not in scores, not required) is skipped gracefully."""
         threshold = Threshold(metric="nonexistent_metric", operator=">", value=0.5)
-        scores = {"faithfulness": 0.90}
-        with pytest.raises(ValueError, match="Unknown metric"):
-            evaluate_threshold(threshold, scores)
+        scores: dict[str, float | None] = {"faithfulness": 0.90}
+        result = evaluate_threshold(threshold, scores)
+        assert result.skipped is True
+        assert result.passed is True
+        assert result.actual is None
+        assert "not computed" in result.reason.lower()
 
     def test_none_score_skipped_by_default(self):
         threshold = Threshold(metric="faithfulness", operator=">", value=0.80)
@@ -144,6 +148,34 @@ class TestThresholdEvaluator:
     def test_none_score_skipped_when_not_in_required_set(self):
         threshold = Threshold(metric="faithfulness", operator=">", value=0.80)
         scores: dict[str, float | None] = {"faithfulness": None}
+        result = evaluate_threshold(threshold, scores, required_metrics={"context_precision"})
+        assert result.skipped is True
+        assert result.passed is True
+
+    def test_missing_metric_fails_when_required(self):
+        """Bug #137: --require-metric with a metric not in scores should fail gracefully."""
+        threshold = Threshold(metric="faithfulness", operator=">", value=0.80)
+        scores: dict[str, float | None] = {"rework_cycles": 1.5}
+        result = evaluate_threshold(threshold, scores, required_metrics={"faithfulness"})
+        assert result.passed is False
+        assert result.skipped is False
+        assert result.actual is None
+        assert "not computed" in result.reason.lower()
+
+    def test_missing_metric_skipped_when_not_required(self):
+        """Bug #137: metric absent from scores and not required should skip, not crash."""
+        threshold = Threshold(metric="faithfulness", operator=">", value=0.80)
+        scores: dict[str, float | None] = {"rework_cycles": 1.5}
+        result = evaluate_threshold(threshold, scores)
+        assert result.skipped is True
+        assert result.passed is True
+        assert result.actual is None
+        assert "not computed" in result.reason.lower()
+
+    def test_missing_metric_skipped_when_required_set_does_not_include_it(self):
+        """Bug #137: metric absent from scores but not in required set should skip."""
+        threshold = Threshold(metric="faithfulness", operator=">", value=0.80)
+        scores: dict[str, float | None] = {"rework_cycles": 1.5}
         result = evaluate_threshold(threshold, scores, required_metrics={"context_precision"})
         assert result.skipped is True
         assert result.passed is True
@@ -205,6 +237,18 @@ class TestEvaluateAll:
     def test_empty_thresholds(self):
         results = evaluate_all([], {"faithfulness": 0.90})
         assert results == []
+
+    def test_missing_metric_required_no_traceback(self):
+        """Bug #137: evaluate_all should not raise when required metric is absent from scores."""
+        thresholds = [
+            Threshold(metric="faithfulness", operator=">", value=0.80),
+        ]
+        scores: dict[str, float | None] = {"rework_cycles": 1.5}
+        results = evaluate_all(thresholds, scores, required_metrics={"faithfulness"})
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert results[0].skipped is False
+        assert "not computed" in results[0].reason.lower()
 
 
 class TestFormatResults:


### PR DESCRIPTION
## Summary

`--require-metric` with a metric not in the scores dict (e.g., `faithfulness`
without `--judge`) raised a `ValueError` traceback. Now `evaluate_threshold()`
returns FAIL with a clear message for required metrics or SKIP for optional ones.

Fixes #137

## Review

- Python Specialist: CLEAN (1 MINOR noted — format test coverage)
- Security Specialist: not applicable
- RAG Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko