### PR TITLE
fix(metrics): wire doc chunks as reference_contexts for precision/recall

### DIFF
--- a/src/raki/metrics/ragas/adapter.py
+++ b/src/raki/metrics/ragas/adapter.py
@@ -4,10 +4,16 @@ Maps EvalSample fields to Ragas 0.4 collections API ascore() keyword arg
 names without importing ragas -- this module has no ragas dependency.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from raki.model import EvalDataset, EvalSample
 from raki.model.phases import PhaseResult
+
+if TYPE_CHECKING:
+    from raki.docs.chunker import DocChunk
 
 
 @dataclass
@@ -21,11 +27,23 @@ class RagasRow:
     reference: str | None  # maps to ascore() kwarg reference (was ground_truths in v0.3)
 
 
-def to_ragas_rows(dataset: EvalDataset) -> list[RagasRow]:
+def to_ragas_rows(
+    dataset: EvalDataset,
+    doc_chunks: list[DocChunk] | None = None,
+) -> list[RagasRow]:
     """Extract RagasRow objects from an EvalDataset.
 
     Skips samples that have no implement/session phase or no knowledge_context.
+
+    When *doc_chunks* are provided and a sample has no ground-truth
+    ``reference_answer``, the doc-chunk texts are joined and used as the
+    ``reference`` field so that precision/recall metrics can compute real
+    scores instead of returning N/A.
     """
+    doc_reference: str | None = None
+    if doc_chunks:
+        doc_reference = "\n\n".join(chunk.text for chunk in doc_chunks)
+
     rows: list[RagasRow] = []
     for sample in dataset.samples:
         implement = _find_phase(sample, "implement") or _find_phase(sample, "session")
@@ -41,6 +59,8 @@ def to_ragas_rows(dataset: EvalDataset) -> list[RagasRow]:
         reference = None
         if sample.ground_truth and sample.ground_truth.reference_answer:
             reference = sample.ground_truth.reference_answer
+        elif doc_reference:
+            reference = doc_reference
         rows.append(
             RagasRow(
                 session_id=sample.session.session_id,

--- a/src/raki/metrics/ragas/precision.py
+++ b/src/raki/metrics/ragas/precision.py
@@ -34,7 +34,7 @@ class ContextPrecisionMetric:
         dataset: EvalDataset,
         config: MetricConfig,
     ) -> MetricResult:
-        rows = to_ragas_rows(dataset)
+        rows = to_ragas_rows(dataset, doc_chunks=config.doc_chunks or None)
         rows_with_ref = [row for row in rows if row.reference is not None]
         if not rows_with_ref:
             return MetricResult(name=self.name, score=None, details={"skipped": "no ground truth"})

--- a/src/raki/metrics/ragas/recall.py
+++ b/src/raki/metrics/ragas/recall.py
@@ -34,7 +34,7 @@ class ContextRecallMetric:
         dataset: EvalDataset,
         config: MetricConfig,
     ) -> MetricResult:
-        rows = to_ragas_rows(dataset)
+        rows = to_ragas_rows(dataset, doc_chunks=config.doc_chunks or None)
         rows_with_ref = [row for row in rows if row.reference is not None]
         if not rows_with_ref:
             return MetricResult(name=self.name, score=None, details={"skipped": "no ground truth"})

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -19,6 +19,7 @@ from raki.model import (
 )
 from raki.model.ground_truth import GroundTruth
 from raki.metrics.protocol import MetricConfig
+from raki.docs.chunker import DocChunk
 from raki.metrics.ragas.adapter import RagasRow, to_ragas_rows
 from raki.metrics.ragas.llm_setup import JudgeLogger
 
@@ -204,6 +205,155 @@ class TestToRagasRows:
         assert len(rows) == 1
         assert rows[0].response == "session output"
         assert rows[0].retrieved_contexts == ["session knowledge"]
+
+
+# ---------------------------------------------------------------------------
+# Doc-chunk reference tests — doc chunks as reference for precision/recall
+# ---------------------------------------------------------------------------
+
+
+class TestToRagasRowsWithDocChunks:
+    """When doc_chunks are provided, they should serve as reference for rows without ground truth."""
+
+    def test_doc_chunks_used_as_reference_when_no_ground_truth(self):
+        """Rows without ground_truth should get reference from doc_chunks."""
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        doc_chunks = [
+            DocChunk(text="Auth requires JWT tokens", source_file="auth.md", domain="auth"),
+            DocChunk(text="Validate with pydantic", source_file="validation.md", domain="general"),
+        ]
+        rows = to_ragas_rows(EvalDataset(samples=[sample]), doc_chunks=doc_chunks)
+        assert len(rows) == 1
+        assert rows[0].reference is not None
+        assert "Auth requires JWT tokens" in rows[0].reference
+        assert "Validate with pydantic" in rows[0].reference
+
+    def test_ground_truth_takes_precedence_over_doc_chunks(self):
+        """When ground_truth has reference_answer, it should be used instead of doc_chunks."""
+        ground_truth = GroundTruth(
+            question="How to validate?",
+            reference_answer="Use pydantic",
+            domains=["validation"],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        doc_chunks = [
+            DocChunk(text="Some doc text", source_file="doc.md", domain="general"),
+        ]
+        rows = to_ragas_rows(EvalDataset(samples=[sample]), doc_chunks=doc_chunks)
+        assert len(rows) == 1
+        assert rows[0].reference == "Use pydantic"
+
+    def test_no_doc_chunks_no_ground_truth_reference_is_none(self):
+        """Without doc_chunks or ground_truth, reference should remain None."""
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 1
+        assert rows[0].reference is None
+
+    def test_empty_doc_chunks_no_reference(self):
+        """Empty doc_chunks list should not set reference."""
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        rows = to_ragas_rows(EvalDataset(samples=[sample]), doc_chunks=[])
+        assert len(rows) == 1
+        assert rows[0].reference is None
+
+
+class TestPrecisionWithDocChunks:
+    """Context precision should compute real scores when doc_chunks provide reference."""
+
+    def test_computes_with_doc_chunks_no_ground_truth(self, monkeypatch: pytest.MonkeyPatch):
+        """Precision should score samples using doc_chunks as reference."""
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.80
+        mock_result.reason = "Precise with doc chunks"
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_precision_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_precision_class, "ContextPrecisionWithReference")
+
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        dataset = EvalDataset(samples=[sample])
+
+        doc_chunks = [
+            DocChunk(text="Reference doc content", source_file="ref.md", domain="general"),
+        ]
+        config = MetricConfig(doc_chunks=doc_chunks)
+
+        with patch(
+            "raki.metrics.ragas.precision.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextPrecisionMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.80)
+        assert result.details["samples_scored"] == 1
+        assert "skipped" not in result.details
+
+    def test_still_skips_without_doc_chunks_or_ground_truth(self):
+        """Without doc_chunks or ground_truth, precision should still return N/A."""
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+
+        metric = ContextPrecisionMetric()
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+        result = metric.compute(dataset, config)
+        assert result.score == 0.0
+        assert result.details.get("skipped") == "no ground truth"
+
+
+class TestRecallWithDocChunks:
+    """Context recall should compute real scores when doc_chunks provide reference."""
+
+    def test_computes_with_doc_chunks_no_ground_truth(self, monkeypatch: pytest.MonkeyPatch):
+        """Recall should score samples using doc_chunks as reference."""
+        from raki.metrics.ragas.recall import ContextRecallMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.75
+        mock_result.reason = "Good recall with doc chunks"
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_recall_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_recall_class, "ContextRecall")
+
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        dataset = EvalDataset(samples=[sample])
+
+        doc_chunks = [
+            DocChunk(text="Reference doc content", source_file="ref.md", domain="general"),
+        ]
+        config = MetricConfig(doc_chunks=doc_chunks)
+
+        with patch(
+            "raki.metrics.ragas.recall.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextRecallMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.75)
+        assert result.details["samples_scored"] == 1
+        assert "skipped" not in result.details
+
+    def test_still_skips_without_doc_chunks_or_ground_truth(self):
+        """Without doc_chunks or ground_truth, recall should still return N/A."""
+        from raki.metrics.ragas.recall import ContextRecallMetric
+
+        metric = ContextRecallMetric()
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+        result = metric.compute(dataset, config)
+        assert result.score == 0.0
+        assert result.details.get("skipped") == "no ground truth"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -303,7 +303,7 @@ class TestPrecisionWithDocChunks:
         dataset = EvalDataset(samples=[sample])
         config = MetricConfig()
         result = metric.compute(dataset, config)
-        assert result.score == 0.0
+        assert result.score is None
         assert result.details.get("skipped") == "no ground truth"
 
 
@@ -352,7 +352,7 @@ class TestRecallWithDocChunks:
         dataset = EvalDataset(samples=[sample])
         config = MetricConfig()
         result = metric.compute(dataset, config)
-        assert result.score == 0.0
+        assert result.score is None
         assert result.details.get("skipped") == "no ground truth"
 
 


### PR DESCRIPTION
## Summary

Context precision/recall returned "N/A (no ground truth)" even when
\`--docs-path\` provided doc chunks. The Ragas adapter now uses doc chunk
texts as the \`reference\` field when ground truth is absent, enabling
Tier 2 precision/recall computation.

Fixes #129

## Changes

- \`src/raki/metrics/ragas/adapter.py\`: Extended \`to_ragas_rows()\` with \`doc_chunks\` parameter
- \`src/raki/metrics/ragas/precision.py\`: Passes \`config.doc_chunks\` to adapter
- \`src/raki/metrics/ragas/recall.py\`: Same as precision
- \`src/raki/metrics/protocol.py\`: Added \`doc_chunks\` field to MetricConfig
- \`src/raki/cli.py\`: Wires doc_chunks to MetricConfig
- \`tests/test_metrics_ragas.py\`: 8 new tests

## Note

Both this PR and #145 add \`doc_chunks\` to MetricConfig. Whichever merges
second will need trivial conflict resolution.

## Review

- Python/RAG Specialist: 2 IMPORTANT (list[Any] typing, scalability for large doc sets) — not correctness issues
- Security Specialist: not applicable

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko