### PR TITLE
fix(ragas): truncate synthesized contexts and handle max_tokens errors

### DIFF
--- a/src/raki/metrics/ragas/adapter.py
+++ b/src/raki/metrics/ragas/adapter.py
@@ -15,6 +15,38 @@ from raki.model.phases import PhaseResult
 if TYPE_CHECKING:
     from raki.docs.chunker import DocChunk
 
+# Maximum characters for each retrieved context chunk sent to Ragas.
+# Synthesized contexts from session transcripts can be 100k+ chars;
+# truncating prevents max_tokens errors during Ragas scoring.
+MAX_CONTEXT_CHARS: int = 10_000
+
+# Maximum characters for the response field sent to Ragas.
+# Implement phase output can contain thousands of lines of raw code/JSON;
+# Ragas faithfulness decomposes this into individual statements, which explodes.
+MAX_RESPONSE_CHARS: int = 10_000
+
+_TRUNCATION_MARKER = " [truncated]"
+
+
+def truncate_for_ragas(text: str, max_chars: int = MAX_CONTEXT_CHARS) -> str:
+    """Truncate text to *max_chars*, cutting at a word boundary.
+
+    When truncation occurs a ``[truncated]`` marker is appended so
+    downstream consumers know content was removed.  The marker is *not*
+    counted against the limit -- total length may be up to
+    ``max_chars + len(" [truncated]")``.
+    """
+    if len(text) <= max_chars:
+        return text
+
+    # Cut at max_chars then find the last space to avoid splitting a word.
+    truncated = text[:max_chars]
+    last_space = truncated.rfind(" ")
+    if last_space > 0:
+        truncated = truncated[:last_space]
+
+    return truncated + _TRUNCATION_MARKER
+
 
 @dataclass
 class RagasRow:
@@ -50,12 +82,14 @@ def to_ragas_rows(
         if implement is None or implement.knowledge_context is None:
             continue
         contexts = [
-            chunk.strip() for chunk in implement.knowledge_context.split("\n---\n") if chunk.strip()
+            truncate_for_ragas(chunk.strip(), max_chars=MAX_CONTEXT_CHARS)
+            for chunk in implement.knowledge_context.split("\n---\n")
+            if chunk.strip()
         ]
         if not contexts:
             continue
         user_input = _extract_question(sample)
-        response = implement.output
+        response = truncate_for_ragas(implement.output, max_chars=MAX_RESPONSE_CHARS)
         reference = None
         if sample.ground_truth and sample.ground_truth.reference_answer:
             reference = sample.ground_truth.reference_answer
@@ -100,6 +134,17 @@ def _extract_question(sample: EvalSample) -> str:
             if summary:
                 return summary
     return sample.session.ticket or sample.session.session_id
+
+
+def is_max_tokens_error(exc: Exception) -> bool:
+    """Check whether *exc* indicates the LLM hit its output token limit.
+
+    Anthropic and OpenAI surface this as ``max_tokens`` in the error
+    message or stop reason.  We do a case-insensitive substring check
+    so we catch variants across providers.
+    """
+    message = str(exc).lower()
+    return "max_tokens" in message
 
 
 def detect_context_source(dataset: EvalDataset) -> str | None:

--- a/src/raki/metrics/ragas/faithfulness.py
+++ b/src/raki/metrics/ragas/faithfulness.py
@@ -12,7 +12,7 @@ import logging
 
 from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
-from raki.metrics.ragas.adapter import detect_context_source, to_ragas_rows
+from raki.metrics.ragas.adapter import detect_context_source, is_max_tokens_error, to_ragas_rows
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
 from raki.model import EvalDataset
@@ -68,6 +68,7 @@ class FaithfulnessMetric:
 
         sample_scores: dict[str, float] = {}
         scores: list[float] = []
+        max_tokens_failures: list[str] = []
 
         async def score_all():
             semaphore = asyncio.Semaphore(config.batch_size)
@@ -88,6 +89,8 @@ class FaithfulnessMetric:
                             judge_logger.log(self.name, row.user_input, score, reason)
                     except Exception as exc:
                         safe_error = redact_sensitive(f"ERROR: {exc}")
+                        if is_max_tokens_error(exc):
+                            max_tokens_failures.append(row.session_id)
                         logger.warning(
                             "faithfulness scoring failed for session %s: %s",
                             row.session_id,
@@ -99,6 +102,17 @@ class FaithfulnessMetric:
             await asyncio.gather(*(score_one(row) for row in rows))
 
         run_async(score_all())
+
+        # If all failures were max_tokens errors, return score=None
+        if not scores and max_tokens_failures:
+            return MetricResult(
+                name=self.name,
+                score=None,
+                details={
+                    "skipped": "max_tokens: all sessions exceeded output token limit",
+                    "max_tokens_sessions": len(max_tokens_failures),
+                },
+            )
 
         mean_score = sum(scores) / len(scores) if scores else 0.0
 

--- a/src/raki/metrics/ragas/precision.py
+++ b/src/raki/metrics/ragas/precision.py
@@ -9,7 +9,7 @@ import logging
 
 from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
-from raki.metrics.ragas.adapter import to_ragas_rows
+from raki.metrics.ragas.adapter import is_max_tokens_error, to_ragas_rows
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
 from raki.model import EvalDataset
@@ -52,6 +52,7 @@ class ContextPrecisionMetric:
 
         sample_scores: dict[str, float] = {}
         scores: list[float] = []
+        max_tokens_failures: list[str] = []
 
         async def score_all():
             semaphore = asyncio.Semaphore(config.batch_size)
@@ -72,6 +73,8 @@ class ContextPrecisionMetric:
                             judge_logger.log(self.name, row.user_input, score, reason)
                     except Exception as exc:
                         safe_error = redact_sensitive(f"ERROR: {exc}")
+                        if is_max_tokens_error(exc):
+                            max_tokens_failures.append(row.session_id)
                         logger.warning(
                             "context_precision scoring failed for session %s: %s",
                             row.session_id,
@@ -83,6 +86,17 @@ class ContextPrecisionMetric:
             await asyncio.gather(*(score_one(row) for row in rows_with_ref))
 
         run_async(score_all())
+
+        # If all failures were max_tokens errors, return score=None
+        if not scores and max_tokens_failures:
+            return MetricResult(
+                name=self.name,
+                score=None,
+                details={
+                    "skipped": "max_tokens: all sessions exceeded output token limit",
+                    "max_tokens_sessions": len(max_tokens_failures),
+                },
+            )
 
         mean_score = sum(scores) / len(scores) if scores else 0.0
         return MetricResult(

--- a/src/raki/metrics/ragas/recall.py
+++ b/src/raki/metrics/ragas/recall.py
@@ -9,7 +9,7 @@ import logging
 
 from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
-from raki.metrics.ragas.adapter import to_ragas_rows
+from raki.metrics.ragas.adapter import is_max_tokens_error, to_ragas_rows
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
 from raki.model import EvalDataset
@@ -52,6 +52,7 @@ class ContextRecallMetric:
 
         sample_scores: dict[str, float] = {}
         scores: list[float] = []
+        max_tokens_failures: list[str] = []
 
         async def score_all():
             semaphore = asyncio.Semaphore(config.batch_size)
@@ -72,6 +73,8 @@ class ContextRecallMetric:
                             judge_logger.log(self.name, row.user_input, score, reason)
                     except Exception as exc:
                         safe_error = redact_sensitive(f"ERROR: {exc}")
+                        if is_max_tokens_error(exc):
+                            max_tokens_failures.append(row.session_id)
                         logger.warning(
                             "context_recall scoring failed for session %s: %s",
                             row.session_id,
@@ -83,6 +86,17 @@ class ContextRecallMetric:
             await asyncio.gather(*(score_one(row) for row in rows_with_ref))
 
         run_async(score_all())
+
+        # If all failures were max_tokens errors, return score=None
+        if not scores and max_tokens_failures:
+            return MetricResult(
+                name=self.name,
+                score=None,
+                details={
+                    "skipped": "max_tokens: all sessions exceeded output token limit",
+                    "max_tokens_sessions": len(max_tokens_failures),
+                },
+            )
 
         mean_score = sum(scores) / len(scores) if scores else 0.0
         return MetricResult(

--- a/src/raki/metrics/ragas/relevancy.py
+++ b/src/raki/metrics/ragas/relevancy.py
@@ -12,7 +12,7 @@ import logging
 
 from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
-from raki.metrics.ragas.adapter import detect_context_source, to_ragas_rows
+from raki.metrics.ragas.adapter import detect_context_source, is_max_tokens_error, to_ragas_rows
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_embeddings, create_ragas_llm
 from raki.model import EvalDataset
@@ -69,6 +69,7 @@ class AnswerRelevancyMetric:
 
         sample_scores: dict[str, float] = {}
         scores: list[float] = []
+        max_tokens_failures: list[str] = []
 
         async def score_all():
             semaphore = asyncio.Semaphore(config.batch_size)
@@ -88,6 +89,8 @@ class AnswerRelevancyMetric:
                             judge_logger.log(self.name, row.user_input, score, reason)
                     except Exception as exc:
                         safe_error = redact_sensitive(f"ERROR: {exc}")
+                        if is_max_tokens_error(exc):
+                            max_tokens_failures.append(row.session_id)
                         logger.warning(
                             "answer_relevancy scoring failed for session %s: %s",
                             row.session_id,
@@ -99,6 +102,17 @@ class AnswerRelevancyMetric:
             await asyncio.gather(*(score_one(row) for row in rows))
 
         run_async(score_all())
+
+        # If all failures were max_tokens errors, return score=None
+        if not scores and max_tokens_failures:
+            return MetricResult(
+                name=self.name,
+                score=None,
+                details={
+                    "skipped": "max_tokens: all sessions exceeded output token limit",
+                    "max_tokens_sessions": len(max_tokens_failures),
+                },
+            )
 
         mean_score = sum(scores) / len(scores) if scores else 0.0
 

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -20,7 +20,13 @@ from raki.model import (
 from raki.model.ground_truth import GroundTruth
 from raki.metrics.protocol import MetricConfig
 from raki.docs.chunker import DocChunk
-from raki.metrics.ragas.adapter import RagasRow, to_ragas_rows
+from raki.metrics.ragas.adapter import (
+    MAX_CONTEXT_CHARS,
+    MAX_RESPONSE_CHARS,
+    RagasRow,
+    to_ragas_rows,
+    truncate_for_ragas,
+)
 from raki.metrics.ragas.llm_setup import JudgeLogger
 
 
@@ -1657,3 +1663,284 @@ class TestAnswerRelevancyIntegration:
 
         assert 0.0 <= result.score <= 1.0
         assert result.details["samples_scored"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Truncation tests — truncate_for_ragas and to_ragas_rows truncation
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateForRagas:
+    """Tests for the truncate_for_ragas helper function."""
+
+    def test_short_text_unchanged(self):
+        """Text shorter than the limit should be returned as-is."""
+        short = "This is short text."
+        assert truncate_for_ragas(short, max_chars=100) == short
+
+    def test_text_at_limit_unchanged(self):
+        """Text exactly at the limit should be returned as-is."""
+        text = "a" * 100
+        assert truncate_for_ragas(text, max_chars=100) == text
+
+    def test_long_text_truncated_with_marker(self):
+        """Text exceeding the limit should be truncated with [truncated] marker."""
+        long_text = "word " * 5000  # ~25000 chars
+        result = truncate_for_ragas(long_text, max_chars=100)
+        assert len(result) <= 100 + len(" [truncated]")
+        assert result.endswith("[truncated]")
+
+    def test_truncation_at_word_boundary(self):
+        """Truncation should happen at a word boundary, not mid-word."""
+        # Create text with distinct words
+        text = "alpha bravo charlie delta echo foxtrot golf hotel india juliet"
+        result = truncate_for_ragas(text, max_chars=30)
+        assert result.endswith("[truncated]")
+        # The text before [truncated] should not end with a partial word
+        content_part = result.replace(" [truncated]", "")
+        assert not content_part.endswith("cha")  # should not cut mid-word
+
+    def test_truncation_uses_default_max_context_chars(self):
+        """Default max_chars should be MAX_CONTEXT_CHARS (10_000)."""
+        assert MAX_CONTEXT_CHARS == 10_000
+
+    def test_max_response_chars_constant(self):
+        """MAX_RESPONSE_CHARS should be defined for response truncation."""
+        assert MAX_RESPONSE_CHARS == 10_000
+
+    def test_empty_string_unchanged(self):
+        """Empty string should be returned as-is."""
+        assert truncate_for_ragas("", max_chars=100) == ""
+
+    def test_truncation_marker_present_only_when_truncated(self):
+        """[truncated] marker should not appear when text fits."""
+        text = "fits fine"
+        result = truncate_for_ragas(text, max_chars=100)
+        assert "[truncated]" not in result
+
+
+class TestToRagasRowsTruncation:
+    """Tests that to_ragas_rows truncates contexts and response."""
+
+    def test_truncates_large_knowledge_context(self):
+        """Each context chunk should be truncated to MAX_CONTEXT_CHARS."""
+        huge_context = "knowledge " * 5000  # ~50000 chars per chunk
+        sample = _make_sample_with_knowledge(
+            knowledge_context=huge_context,
+            output="short response",
+        )
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 1
+        for context in rows[0].retrieved_contexts:
+            assert len(context) <= MAX_CONTEXT_CHARS + len(" [truncated]")
+
+    def test_truncates_large_response(self):
+        """The response field should be truncated to MAX_RESPONSE_CHARS."""
+        huge_output = "code_line(); " * 5000  # ~65000 chars
+        sample = _make_sample_with_knowledge(
+            knowledge_context="normal context",
+            output=huge_output,
+        )
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 1
+        assert len(rows[0].response) <= MAX_RESPONSE_CHARS + len(" [truncated]")
+
+    def test_short_content_not_truncated(self):
+        """Short contexts and responses should pass through unchanged."""
+        sample = _make_sample_with_knowledge(
+            knowledge_context="small ctx1\n---\nsmall ctx2",
+            output="short answer",
+        )
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 1
+        assert rows[0].retrieved_contexts == ["small ctx1", "small ctx2"]
+        assert rows[0].response == "short answer"
+        # No truncation markers
+        for context in rows[0].retrieved_contexts:
+            assert "[truncated]" not in context
+        assert "[truncated]" not in rows[0].response
+
+    def test_multiple_large_context_chunks_each_truncated(self):
+        """When knowledge_context has multiple chunks separated by ---, each gets truncated."""
+        chunk1 = "alpha " * 5000
+        chunk2 = "bravo " * 5000
+        knowledge = f"{chunk1}\n---\n{chunk2}"
+        sample = _make_sample_with_knowledge(
+            knowledge_context=knowledge,
+            output="short",
+        )
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 1
+        assert len(rows[0].retrieved_contexts) == 2
+        for context in rows[0].retrieved_contexts:
+            assert context.endswith("[truncated]")
+            assert len(context) <= MAX_CONTEXT_CHARS + len(" [truncated]")
+
+
+# ---------------------------------------------------------------------------
+# max_tokens error handling tests
+# ---------------------------------------------------------------------------
+
+
+class TestMaxTokensErrorHandling:
+    """Tests that max_tokens errors return score=None instead of score=0.0."""
+
+    def _make_max_tokens_error(self) -> Exception:
+        """Create an exception that looks like a max_tokens error."""
+        return RuntimeError("max_tokens: output token limit reached")
+
+    def test_faithfulness_returns_none_on_max_tokens(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Faithfulness should return score=None on max_tokens errors."""
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(side_effect=self._make_max_tokens_error())
+
+        mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_faithfulness_class, "Faithfulness")
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with patch(
+            "raki.metrics.ragas.faithfulness.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = FaithfulnessMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score is None
+        assert "max_tokens" in result.details.get("skipped", "")
+
+    def test_relevancy_returns_none_on_max_tokens(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """AnswerRelevancy should return score=None on max_tokens errors."""
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(side_effect=self._make_max_tokens_error())
+
+        mock_relevancy_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_relevancy_class, "AnswerRelevancy")
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with (
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_llm",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_embeddings",
+                return_value=MagicMock(),
+            ),
+        ):
+            metric = AnswerRelevancyMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score is None
+        assert "max_tokens" in result.details.get("skipped", "")
+
+    def test_precision_returns_none_on_max_tokens(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """ContextPrecision should return score=None on max_tokens errors."""
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(side_effect=self._make_max_tokens_error())
+
+        mock_precision_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_precision_class, "ContextPrecisionWithReference")
+
+        ground_truth = GroundTruth(
+            question="Q?",
+            reference_answer="A",
+            domains=[],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with patch(
+            "raki.metrics.ragas.precision.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextPrecisionMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score is None
+        assert "max_tokens" in result.details.get("skipped", "")
+
+    def test_recall_returns_none_on_max_tokens(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """ContextRecall should return score=None on max_tokens errors."""
+        from raki.metrics.ragas.recall import ContextRecallMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(side_effect=self._make_max_tokens_error())
+
+        mock_recall_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_recall_class, "ContextRecall")
+
+        ground_truth = GroundTruth(
+            question="Q?",
+            reference_answer="A",
+            domains=[],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with patch(
+            "raki.metrics.ragas.recall.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextRecallMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score is None
+        assert "max_tokens" in result.details.get("skipped", "")
+
+    def test_non_max_tokens_error_still_returns_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Non-max_tokens errors should still result in score=0.0 (existing behavior)."""
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(side_effect=RuntimeError("Connection refused"))
+
+        mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_faithfulness_class, "Faithfulness")
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig()
+
+        with patch(
+            "raki.metrics.ragas.faithfulness.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = FaithfulnessMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == 0.0
+        assert result.details["samples_scored"] == 0


### PR DESCRIPTION
## Summary

Session transcripts produced 100k-310k char contexts, exceeding the judge
LLM's output token limit on every Ragas call. All faithfulness scores came
back as 0.0 on real soda sessions.

Added truncation at 10,000 chars with word-boundary cuts in `to_ragas_rows()`,
and graceful `max_tokens` error handling that returns `score=None` (N/A)
instead of `score=0.0` when all sessions fail.

Fixes #135

## Changes

- `src/raki/metrics/ragas/adapter.py`: Added `truncate_for_ragas()`, `is_max_tokens_error()`,
  `MAX_CONTEXT_CHARS=10_000`, `MAX_RESPONSE_CHARS=10_000`
- `src/raki/metrics/ragas/{faithfulness,relevancy,precision,recall}.py`: max_tokens error
  handling returning score=None
- `tests/test_metrics_ragas.py`: 17 new tests

## Review

- Python Specialist: 1 IMPORTANT (max_tokens detection false positive risk — low probability)
- Security Specialist: CLEAN — truncation after redaction, no exposure risk
- RAG Specialist: not applicable (reviewed via Python specialist)

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko