### PR TITLE
fix(ragas): comprehensive truncation for Ragas text inputs

### DIFF
--- a/src/raki/metrics/ragas/adapter.py
+++ b/src/raki/metrics/ragas/adapter.py
@@ -6,24 +6,31 @@ names without importing ragas -- this module has no ragas dependency.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
+from raki.docs.chunker import DocChunk
 from raki.model import EvalDataset, EvalSample
 from raki.model.phases import PhaseResult
-
-if TYPE_CHECKING:
-    from raki.docs.chunker import DocChunk
 
 # Maximum characters for each retrieved context chunk sent to Ragas.
 # Synthesized contexts from session transcripts can be 100k+ chars;
 # truncating prevents max_tokens errors during Ragas scoring.
-MAX_CONTEXT_CHARS: int = 10_000
+MAX_CONTEXT_CHARS: int = 1_000
 
 # Maximum characters for the response field sent to Ragas.
 # Implement phase output can contain thousands of lines of raw code/JSON;
 # Ragas faithfulness decomposes this into individual statements, which explodes.
-MAX_RESPONSE_CHARS: int = 10_000
+MAX_RESPONSE_CHARS: int = 2_000
+
+# Maximum number of retrieved context chunks sent to Ragas.
+MAX_CONTEXT_CHUNKS: int = 10
+
+# Maximum number of reference doc chunks to include.
+MAX_REFERENCE_CHUNKS: int = 10
+
+# Maximum characters per reference doc chunk.
+MAX_REFERENCE_CHARS: int = 1_000
 
 _TRUNCATION_MARKER = " [truncated]"
 
@@ -46,6 +53,96 @@ def truncate_for_ragas(text: str, max_chars: int = MAX_CONTEXT_CHARS) -> str:
         truncated = truncated[:last_space]
 
     return truncated + _TRUNCATION_MARKER
+
+
+def _extract_response_summary(sample: EvalSample, implement_phase: PhaseResult) -> str:
+    """Extract a concise response summary from structured phase data.
+
+    Prefers structured fields (triage approach, plan tasks, implement
+    deviations/commits) over raw implement output.  Falls back to
+    truncated ``implement_phase.output`` when no structured data exists.
+
+    The result is capped at :data:`MAX_RESPONSE_CHARS`.
+    """
+    parts: list[str] = []
+
+    # Collect triage approach (latest generation only, consistent with _find_phase)
+    latest_triage = _find_phase(sample, "triage")
+    if latest_triage and latest_triage.output_structured:
+        approach = latest_triage.output_structured.get("approach", "")
+        if isinstance(approach, str) and approach:
+            parts.append(f"Approach: {approach}")
+
+    # Collect plan task descriptions (latest generation only)
+    latest_plan = _find_phase(sample, "plan")
+    if latest_plan and latest_plan.output_structured:
+        tasks = latest_plan.output_structured.get("tasks", [])
+        if isinstance(tasks, list):
+            for task in tasks:
+                if isinstance(task, dict):
+                    description = task.get("description", "")
+                    if description:
+                        parts.append(f"Task: {description}")
+
+    # Collect implement deviations and commit messages
+    if implement_phase.output_structured:
+        deviations = implement_phase.output_structured.get("deviations", [])
+        if isinstance(deviations, list):
+            for deviation in deviations:
+                if isinstance(deviation, str) and deviation:
+                    parts.append(f"Deviation: {deviation}")
+
+        commits = implement_phase.output_structured.get("commits", [])
+        if isinstance(commits, list):
+            for commit in commits:
+                if isinstance(commit, dict):
+                    message = commit.get("message", "")
+                    if message:
+                        parts.append(f"Commit: {message}")
+
+    if parts:
+        summary = "\n".join(parts)
+        return truncate_for_ragas(summary, max_chars=MAX_RESPONSE_CHARS)
+
+    # Fallback: truncated raw output
+    return truncate_for_ragas(implement_phase.output, max_chars=MAX_RESPONSE_CHARS)
+
+
+def select_relevant_chunks(
+    query: str,
+    chunks: Sequence[DocChunk],
+    top_k: int = MAX_REFERENCE_CHUNKS,
+) -> list[DocChunk]:
+    """Select the most relevant doc chunks by keyword overlap with *query*.
+
+    Scores each chunk by the number of shared tokens (case-insensitive
+    word split) with the query.  Returns the top *top_k* chunks, each
+    truncated to :data:`MAX_REFERENCE_CHARS`.
+    """
+    if not chunks:
+        return []
+
+    query_tokens = set(query.lower().split())
+
+    scored: list[tuple[int, int, DocChunk]] = []
+    for idx, chunk in enumerate(chunks):
+        chunk_tokens = set(chunk.text.lower().split())
+        overlap = len(query_tokens & chunk_tokens)
+        scored.append((overlap, idx, chunk))
+
+    # Sort by overlap descending, then by original order for ties
+    scored.sort(key=lambda item: (-item[0], item[1]))
+
+    selected = [(overlap, idx, chunk) for overlap, idx, chunk in scored[:top_k] if overlap > 0]
+
+    return [
+        DocChunk(
+            text=truncate_for_ragas(chunk.text, max_chars=MAX_REFERENCE_CHARS),
+            source_file=chunk.source_file,
+            domain=chunk.domain,
+        )
+        for _overlap, _idx, chunk in selected
+    ]
 
 
 @dataclass
@@ -72,10 +169,6 @@ def to_ragas_rows(
     ``reference`` field so that precision/recall metrics can compute real
     scores instead of returning N/A.
     """
-    doc_reference: str | None = None
-    if doc_chunks:
-        doc_reference = "\n\n".join(chunk.text for chunk in doc_chunks)
-
     rows: list[RagasRow] = []
     for sample in dataset.samples:
         implement = _find_phase(sample, "implement") or _find_phase(sample, "session")
@@ -86,15 +179,19 @@ def to_ragas_rows(
             for chunk in implement.knowledge_context.split("\n---\n")
             if chunk.strip()
         ]
+        # Cap retrieved contexts at MAX_CONTEXT_CHUNKS
+        contexts = contexts[:MAX_CONTEXT_CHUNKS]
         if not contexts:
             continue
         user_input = _extract_question(sample)
-        response = truncate_for_ragas(implement.output, max_chars=MAX_RESPONSE_CHARS)
+        response = _extract_response_summary(sample, implement)
         reference = None
         if sample.ground_truth and sample.ground_truth.reference_answer:
             reference = sample.ground_truth.reference_answer
-        elif doc_reference:
-            reference = doc_reference
+        elif doc_chunks:
+            # Per-sample chunk selection based on user_input
+            selected = select_relevant_chunks(user_input, doc_chunks)
+            reference = "\n\n".join(chunk.text for chunk in selected) if selected else None
         rows.append(
             RagasRow(
                 session_id=sample.session.session_id,

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -22,8 +22,13 @@ from raki.metrics.protocol import MetricConfig
 from raki.docs.chunker import DocChunk
 from raki.metrics.ragas.adapter import (
     MAX_CONTEXT_CHARS,
+    MAX_CONTEXT_CHUNKS,
+    MAX_REFERENCE_CHARS,
+    MAX_REFERENCE_CHUNKS,
     MAX_RESPONSE_CHARS,
     RagasRow,
+    _extract_response_summary,
+    select_relevant_chunks,
     to_ragas_rows,
     truncate_for_ragas,
 )
@@ -113,7 +118,8 @@ class TestToRagasRows:
         assert len(rows) == 1
         assert rows[0].retrieved_contexts == ["entry 1", "entry 2"]
         assert rows[0].user_input == "How to validate?"
-        assert rows[0].response == "The answer based on knowledge"
+        # _extract_response_summary prefers triage approach over raw output
+        assert "Add validation" in rows[0].response
         assert rows[0].reference == "Use pydantic"
 
     def test_uses_ticket_summary_when_no_ground_truth(self):
@@ -225,14 +231,22 @@ class TestToRagasRowsWithDocChunks:
         """Rows without ground_truth should get reference from doc_chunks."""
         sample = _make_sample_with_knowledge(ground_truth=None)
         doc_chunks = [
-            DocChunk(text="Auth requires JWT tokens", source_file="auth.md", domain="auth"),
-            DocChunk(text="Validate with pydantic", source_file="validation.md", domain="general"),
+            DocChunk(
+                text="Add authentication with JWT tokens",
+                source_file="auth.md",
+                domain="auth",
+            ),
+            DocChunk(
+                text="Add validation with pydantic models",
+                source_file="validation.md",
+                domain="general",
+            ),
         ]
         rows = to_ragas_rows(EvalDataset(samples=[sample]), doc_chunks=doc_chunks)
         assert len(rows) == 1
         assert rows[0].reference is not None
-        assert "Auth requires JWT tokens" in rows[0].reference
-        assert "Validate with pydantic" in rows[0].reference
+        assert "authentication with JWT tokens" in rows[0].reference
+        assert "validation with pydantic models" in rows[0].reference
 
     def test_ground_truth_takes_precedence_over_doc_chunks(self):
         """When ground_truth has reference_answer, it should be used instead of doc_chunks."""
@@ -285,7 +299,11 @@ class TestPrecisionWithDocChunks:
         dataset = EvalDataset(samples=[sample])
 
         doc_chunks = [
-            DocChunk(text="Reference doc content", source_file="ref.md", domain="general"),
+            DocChunk(
+                text="Add validation for reference doc content",
+                source_file="ref.md",
+                domain="general",
+            ),
         ]
         config = MetricConfig(doc_chunks=doc_chunks)
 
@@ -334,7 +352,11 @@ class TestRecallWithDocChunks:
         dataset = EvalDataset(samples=[sample])
 
         doc_chunks = [
-            DocChunk(text="Reference doc content", source_file="ref.md", domain="general"),
+            DocChunk(
+                text="Add validation for reference doc content",
+                source_file="ref.md",
+                domain="general",
+            ),
         ]
         config = MetricConfig(doc_chunks=doc_chunks)
 
@@ -879,7 +901,8 @@ class TestFaithfulnessMetric:
         mock_metric_instance.ascore.assert_called_once()
         call_kwargs = mock_metric_instance.ascore.call_args.kwargs
         assert call_kwargs["user_input"] == "How to validate?"
-        assert call_kwargs["response"] == "The answer based on knowledge"
+        # _extract_response_summary picks up triage approach from the sample
+        assert "Add validation" in call_kwargs["response"]
         assert call_kwargs["retrieved_contexts"] == ["entry 1", "entry 2"]
 
     def test_handles_float_return_from_ascore(self, monkeypatch: pytest.MonkeyPatch):
@@ -1097,7 +1120,8 @@ class TestAnswerRelevancyMetric:
         mock_metric_instance.ascore.assert_called_once()
         call_kwargs = mock_metric_instance.ascore.call_args.kwargs
         assert call_kwargs["user_input"] == "How to validate?"
-        assert call_kwargs["response"] == "The answer based on knowledge"
+        # _extract_response_summary picks up triage approach from the sample
+        assert "Add validation" in call_kwargs["response"]
         assert "retrieved_contexts" not in call_kwargs
 
     def test_handles_float_return_from_ascore(self, monkeypatch: pytest.MonkeyPatch):
@@ -1701,12 +1725,12 @@ class TestTruncateForRagas:
         assert not content_part.endswith("cha")  # should not cut mid-word
 
     def test_truncation_uses_default_max_context_chars(self):
-        """Default max_chars should be MAX_CONTEXT_CHARS (10_000)."""
-        assert MAX_CONTEXT_CHARS == 10_000
+        """Default max_chars should be MAX_CONTEXT_CHARS (1_000)."""
+        assert MAX_CONTEXT_CHARS == 1_000
 
     def test_max_response_chars_constant(self):
         """MAX_RESPONSE_CHARS should be defined for response truncation."""
-        assert MAX_RESPONSE_CHARS == 10_000
+        assert MAX_RESPONSE_CHARS == 2_000
 
     def test_empty_string_unchanged(self):
         """Empty string should be returned as-is."""
@@ -1737,19 +1761,52 @@ class TestToRagasRowsTruncation:
     def test_truncates_large_response(self):
         """The response field should be truncated to MAX_RESPONSE_CHARS."""
         huge_output = "code_line(); " * 5000  # ~65000 chars
-        sample = _make_sample_with_knowledge(
-            knowledge_context="normal context",
+        # Use a sample without triage to force fallback to raw output truncation
+        meta = SessionMeta(
+            session_id="large-resp",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=1,
+            rework_cycles=0,
+        )
+        implement = PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
             output=huge_output,
+            knowledge_context="normal context",
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[implement],
+            findings=[],
+            events=[],
         )
         rows = to_ragas_rows(EvalDataset(samples=[sample]))
         assert len(rows) == 1
         assert len(rows[0].response) <= MAX_RESPONSE_CHARS + len(" [truncated]")
+        assert rows[0].response.endswith("[truncated]")
 
     def test_short_content_not_truncated(self):
         """Short contexts and responses should pass through unchanged."""
-        sample = _make_sample_with_knowledge(
-            knowledge_context="small ctx1\n---\nsmall ctx2",
+        # Use a sample without triage phase to test raw output passthrough
+        meta = SessionMeta(
+            session_id="short-test",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=1,
+            rework_cycles=0,
+        )
+        implement = PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
             output="short answer",
+            knowledge_context="small ctx1\n---\nsmall ctx2",
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[implement],
+            findings=[],
+            events=[],
         )
         rows = to_ragas_rows(EvalDataset(samples=[sample]))
         assert len(rows) == 1
@@ -1775,6 +1832,346 @@ class TestToRagasRowsTruncation:
         for context in rows[0].retrieved_contexts:
             assert context.endswith("[truncated]")
             assert len(context) <= MAX_CONTEXT_CHARS + len(" [truncated]")
+
+
+# ---------------------------------------------------------------------------
+# _extract_response_summary tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractResponseSummary:
+    """Tests for the _extract_response_summary helper function."""
+
+    def test_prefers_triage_plan_over_raw_output(self):
+        """When triage approach, plan tasks, and implement deviations exist, use them."""
+        meta = SessionMeta(
+            session_id="summary-1",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=3,
+            rework_cycles=0,
+        )
+        triage = PhaseResult(
+            name="triage",
+            generation=1,
+            status="completed",
+            output="triage output",
+            output_structured={"approach": "Add input validation to the CLI"},
+        )
+        plan = PhaseResult(
+            name="plan",
+            generation=1,
+            status="completed",
+            output="plan output",
+            output_structured={
+                "tasks": [
+                    {"description": "Create validator module"},
+                    {"description": "Add CLI flag --validate"},
+                ]
+            },
+        )
+        implement = PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
+            output="x" * 50_000,  # Very large raw output
+            output_structured={
+                "deviations": ["Skipped edge case for empty input"],
+                "commits": [{"message": "feat: add validation"}],
+            },
+            knowledge_context="some context",
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[triage, plan, implement],
+            findings=[],
+            events=[],
+        )
+        result = _extract_response_summary(sample, implement)
+
+        # Should contain structured content, not raw output
+        assert "Add input validation to the CLI" in result
+        assert "Create validator module" in result
+        assert "Add CLI flag --validate" in result
+        assert "Skipped edge case for empty input" in result
+        assert "feat: add validation" in result
+        # Should NOT be the raw 50k output
+        assert len(result) <= MAX_RESPONSE_CHARS
+
+    def test_falls_back_to_truncated_output(self):
+        """When no structured fields exist, fall back to truncated implement output."""
+        meta = SessionMeta(
+            session_id="summary-2",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=1,
+            rework_cycles=0,
+        )
+        implement = PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
+            output="word " * 1000,  # 5000 chars
+            knowledge_context="some context",
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[implement],
+            findings=[],
+            events=[],
+        )
+        result = _extract_response_summary(sample, implement)
+
+        # Should be the truncated raw output
+        assert len(result) <= MAX_RESPONSE_CHARS + len(" [truncated]")
+        assert result.endswith("[truncated]")
+
+    def test_caps_at_max_response_chars(self):
+        """Even structured summary should be capped at MAX_RESPONSE_CHARS."""
+        meta = SessionMeta(
+            session_id="summary-3",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=3,
+            rework_cycles=0,
+        )
+        triage = PhaseResult(
+            name="triage",
+            generation=1,
+            status="completed",
+            output="triage",
+            output_structured={"approach": "very long approach " * 200},
+        )
+        plan = PhaseResult(
+            name="plan",
+            generation=1,
+            status="completed",
+            output="plan",
+            output_structured={"tasks": [{"description": "task desc " * 200}]},
+        )
+        implement = PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
+            output="output",
+            knowledge_context="ctx",
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[triage, plan, implement],
+            findings=[],
+            events=[],
+        )
+        result = _extract_response_summary(sample, implement)
+        assert len(result) <= MAX_RESPONSE_CHARS + len(" [truncated]")
+
+    def test_short_output_returned_as_is_when_no_structured(self):
+        """Short implement output returned without truncation when no structured data."""
+        meta = SessionMeta(
+            session_id="summary-4",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=1,
+            rework_cycles=0,
+        )
+        implement = PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
+            output="short answer",
+            knowledge_context="ctx",
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[implement],
+            findings=[],
+            events=[],
+        )
+        result = _extract_response_summary(sample, implement)
+        assert result == "short answer"
+
+
+# ---------------------------------------------------------------------------
+# select_relevant_chunks tests
+# ---------------------------------------------------------------------------
+
+
+class TestSelectRelevantChunks:
+    """Tests for the select_relevant_chunks function."""
+
+    def test_returns_most_relevant_chunks(self):
+        """Chunks with more keyword overlap should be ranked higher."""
+        chunks = [
+            DocChunk(
+                text="unrelated content about cooking recipes", source_file="a.md", domain="x"
+            ),
+            DocChunk(
+                text="validation using pydantic models and fields",
+                source_file="b.md",
+                domain="y",
+            ),
+            DocChunk(
+                text="pydantic validation with Field validators for input",
+                source_file="c.md",
+                domain="z",
+            ),
+        ]
+        result = select_relevant_chunks("How to validate input with pydantic?", chunks)
+        # The chunk with more overlapping words should come first
+        assert "pydantic validation" in result[0].text or "pydantic models" in result[0].text
+
+    def test_respects_top_k_limit(self):
+        """Should return at most top_k chunks."""
+        chunks = [
+            DocChunk(text=f"chunk number {idx} with keyword", source_file=f"{idx}.md", domain="d")
+            for idx in range(20)
+        ]
+        result = select_relevant_chunks("keyword", chunks, top_k=5)
+        assert len(result) == 5
+
+    def test_default_top_k_is_max_reference_chunks(self):
+        """Default top_k should be MAX_REFERENCE_CHUNKS (10)."""
+        chunks = [
+            DocChunk(text=f"chunk {idx} keyword", source_file=f"{idx}.md", domain="d")
+            for idx in range(20)
+        ]
+        result = select_relevant_chunks("keyword", chunks)
+        assert len(result) == MAX_REFERENCE_CHUNKS
+
+    def test_handles_empty_query(self):
+        """Empty query should return empty list (all chunks have zero overlap)."""
+        chunks = [
+            DocChunk(text="some content", source_file="a.md", domain="d"),
+        ]
+        result = select_relevant_chunks("", chunks)
+        assert len(result) == 0
+
+    def test_handles_empty_chunks(self):
+        """Empty chunk list should return empty list."""
+        result = select_relevant_chunks("some query", [])
+        assert result == []
+
+    def test_truncates_each_chunk_to_max_reference_chars(self):
+        """Each returned chunk should be truncated to MAX_REFERENCE_CHARS."""
+        long_text = "keyword " * 500  # 4000 chars
+        chunks = [
+            DocChunk(text=long_text, source_file="big.md", domain="d"),
+        ]
+        result = select_relevant_chunks("keyword", chunks)
+        assert len(result) == 1
+        assert len(result[0].text) <= MAX_REFERENCE_CHARS + len(" [truncated]")
+
+    def test_fewer_chunks_than_top_k(self):
+        """When fewer chunks than top_k exist, return all of them."""
+        chunks = [
+            DocChunk(text="keyword text", source_file="a.md", domain="d"),
+            DocChunk(text="keyword stuff", source_file="b.md", domain="d"),
+        ]
+        result = select_relevant_chunks("keyword", chunks, top_k=10)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# to_ragas_rows context caps tests
+# ---------------------------------------------------------------------------
+
+
+class TestToRagasRowsContextCaps:
+    """Tests for retrieved context capping in to_ragas_rows."""
+
+    def test_caps_retrieved_contexts_at_max_context_chunks(self):
+        """Retrieved contexts should be sliced to MAX_CONTEXT_CHUNKS."""
+        # Create knowledge_context with many chunks
+        many_chunks = "\n---\n".join(f"chunk {idx}" for idx in range(25))
+        sample = _make_sample_with_knowledge(
+            knowledge_context=many_chunks,
+            output="short response",
+        )
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 1
+        assert len(rows[0].retrieved_contexts) == MAX_CONTEXT_CHUNKS
+
+    def test_truncates_reference_per_chunk_not_whole_join(self):
+        """When doc_chunks are provided, each should be truncated individually."""
+        long_chunk_text = "validation input " * 250  # 4250 chars each, overlaps with user_input
+        doc_chunks = [
+            DocChunk(text=long_chunk_text, source_file=f"doc{idx}.md", domain="d")
+            for idx in range(3)
+        ]
+        sample = _make_sample_with_knowledge(ground_truth=None)
+        rows = to_ragas_rows(EvalDataset(samples=[sample]), doc_chunks=doc_chunks)
+        assert len(rows) == 1
+        assert rows[0].reference is not None
+        # Reference should be a join of individually truncated chunks
+        # Each chunk should be at most MAX_REFERENCE_CHARS (not the full 4000)
+        ref_parts = rows[0].reference.split("\n\n")
+        for part in ref_parts:
+            assert len(part) <= MAX_REFERENCE_CHARS + len(" [truncated]")
+
+
+class TestToRagasRowsResponseSummary:
+    """Tests that to_ragas_rows uses _extract_response_summary."""
+
+    def test_uses_structured_summary_instead_of_raw_output(self):
+        """to_ragas_rows should call _extract_response_summary, not raw truncation."""
+        meta = SessionMeta(
+            session_id="resp-summary",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=3,
+            rework_cycles=0,
+        )
+        triage = PhaseResult(
+            name="triage",
+            generation=1,
+            status="completed",
+            output="triage out",
+            output_structured={"approach": "Refactor authentication module"},
+        )
+        plan = PhaseResult(
+            name="plan",
+            generation=1,
+            status="completed",
+            output="plan out",
+            output_structured={"tasks": [{"description": "Update auth tokens"}]},
+        )
+        implement = PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
+            output="x" * 50_000,
+            knowledge_context="entry 1\n---\nentry 2",
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[triage, plan, implement],
+            findings=[],
+            events=[],
+        )
+        rows = to_ragas_rows(EvalDataset(samples=[sample]))
+        assert len(rows) == 1
+        # Should contain the structured approach, not the 50k raw output
+        assert "Refactor authentication module" in rows[0].response
+        assert len(rows[0].response) <= MAX_RESPONSE_CHARS + len(" [truncated]")
+
+
+# ---------------------------------------------------------------------------
+# Updated truncation constant tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatedConstants:
+    """Tests that constants have been updated to new values."""
+
+    def test_max_context_chars(self):
+        assert MAX_CONTEXT_CHARS == 1_000
+
+    def test_max_response_chars(self):
+        assert MAX_RESPONSE_CHARS == 2_000
+
+    def test_max_context_chunks(self):
+        assert MAX_CONTEXT_CHUNKS == 10
+
+    def test_max_reference_chunks(self):
+        assert MAX_REFERENCE_CHUNKS == 10
+
+    def test_max_reference_chars(self):
+        assert MAX_REFERENCE_CHARS == 1_000
 
 
 # ---------------------------------------------------------------------------
@@ -1944,3 +2341,139 @@ class TestMaxTokensErrorHandling:
 
         assert result.score == 0.0
         assert result.details["samples_scored"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Edge-case tests for _extract_response_summary and select_relevant_chunks
+# ---------------------------------------------------------------------------
+
+
+class TestExtractResponseSummaryEdgeCases:
+    """Edge-case tests for _extract_response_summary."""
+
+    def _make_sample_with_phases(self, phases: list[PhaseResult]) -> EvalSample:
+        meta = SessionMeta(
+            session_id="edge-case",
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=len(phases),
+            rework_cycles=0,
+        )
+        return EvalSample(
+            session=meta,
+            phases=phases,
+            findings=[],
+            events=[],
+        )
+
+    def test_extract_summary_missing_approach_key(self):
+        """Triage with output_structured that has no 'approach' key should not crash."""
+        triage = PhaseResult(
+            name="triage",
+            generation=1,
+            status="completed",
+            output="triage output",
+            output_structured={"severity": "high"},
+        )
+        implement = PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
+            output="fallback output",
+            knowledge_context="ctx",
+        )
+        sample = self._make_sample_with_phases([triage, implement])
+        result = _extract_response_summary(sample, implement)
+        # Should fall back to raw output since no approach was found
+        assert result == "fallback output"
+
+    def test_extract_summary_non_string_approach(self):
+        """Triage with approach as a dict should skip it."""
+        triage = PhaseResult(
+            name="triage",
+            generation=1,
+            status="completed",
+            output="triage output",
+            output_structured={"approach": {"nested": "value"}},
+        )
+        implement = PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
+            output="fallback output",
+            knowledge_context="ctx",
+        )
+        sample = self._make_sample_with_phases([triage, implement])
+        result = _extract_response_summary(sample, implement)
+        # approach is a dict, not a string, so it should be skipped
+        assert result == "fallback output"
+
+    def test_extract_summary_plan_tasks_non_dict_entries(self):
+        """Plan with tasks as list of strings should skip non-dict entries."""
+        triage = PhaseResult(
+            name="triage",
+            generation=1,
+            status="completed",
+            output="triage output",
+            output_structured={"approach": "Fix the bug"},
+        )
+        plan = PhaseResult(
+            name="plan",
+            generation=1,
+            status="completed",
+            output="plan output",
+            output_structured={"tasks": ["string task 1", "string task 2"]},
+        )
+        implement = PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
+            output="impl output",
+            knowledge_context="ctx",
+        )
+        sample = self._make_sample_with_phases([triage, plan, implement])
+        result = _extract_response_summary(sample, implement)
+        # Should have approach but no tasks (strings are skipped, only dicts accepted)
+        assert "Fix the bug" in result
+        assert "string task 1" not in result
+
+    def test_extract_summary_latest_generation_only(self):
+        """Session with multiple triage phases should use only the latest generation."""
+        triage_gen1 = PhaseResult(
+            name="triage",
+            generation=1,
+            status="completed",
+            output="old triage",
+            output_structured={"approach": "Old approach from gen 1"},
+        )
+        triage_gen2 = PhaseResult(
+            name="triage",
+            generation=2,
+            status="completed",
+            output="new triage",
+            output_structured={"approach": "New approach from gen 2"},
+        )
+        implement = PhaseResult(
+            name="implement",
+            generation=2,
+            status="completed",
+            output="impl output",
+            knowledge_context="ctx",
+        )
+        sample = self._make_sample_with_phases([triage_gen1, triage_gen2, implement])
+        result = _extract_response_summary(sample, implement)
+        # Should use only the latest generation (gen 2)
+        assert "New approach from gen 2" in result
+        assert "Old approach from gen 1" not in result
+
+
+class TestSelectRelevantChunksEdgeCases:
+    """Edge-case tests for select_relevant_chunks."""
+
+    def test_select_relevant_chunks_zero_overlap_returns_empty(self):
+        """Query with no overlapping words should return empty list."""
+        chunks = [
+            DocChunk(text="alpha bravo charlie", source_file="a.md", domain="d"),
+            DocChunk(text="delta echo foxtrot", source_file="b.md", domain="d"),
+        ]
+        result = select_relevant_chunks("xylophone zebra quantum", chunks)
+        assert result == []


### PR DESCRIPTION
## Summary
Fixes faithfulness and context_recall max_tokens failures on real data.

Three changes:
1. **Response**: extract triage/plan summary (2k chars) instead of raw code (10k)
2. **Doc reference**: select top-10 relevant chunks per session by keyword overlap
3. **Retrieved contexts**: cap at 10 chunks of 1k chars each

Fixes #135

## Review
- Python Specialist: needs_fixes -> fixed (4 IMPORTANT: DocChunk import cleanup, zero-overlap filtering, phase deduplication, type checking)
- RAG Specialist: needs_fixes -> noted (IMPORTANT: context limit is aggressive but matches issue spec; stop-word filtering deferred as follow-up)

## Test coverage
- 24 new tests covering response summary extraction, chunk selection, context capping, edge cases
- 813 total tests pass (4 slow deselected)
- Ruff lint/format clean, ty clean (pre-existing diagnostics only)

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko