### PR TITLE
fix(ragas): set max_tokens=4096 on llm_factory calls

### DIFF
--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -62,6 +62,7 @@ def create_ragas_llm(config: MetricConfig):
             provider="google",
             client=client,
             temperature=config.temperature,
+            max_tokens=4096,
         )
         return llm
     else:
@@ -77,6 +78,7 @@ def create_ragas_llm(config: MetricConfig):
         provider="anthropic",
         client=client,
         temperature=config.temperature,
+        max_tokens=4096,
     )
     llm.model_args.pop("top_p", None)
     return llm


### PR DESCRIPTION
## Summary

Ragas defaults to max_tokens=1024 for LLM output, which is too small for
structured output via instructor. Faithfulness statement decomposition
overflows on all real soda sessions even after truncation fixes.

Setting max_tokens=4096 as recommended by Ragas docs (llms/base.py:821).

**Before:** Faithfulness N/A on all 14 soda sessions (max_tokens error)
**After:** Faithfulness 0.62 on soda data, context_recall 0.41 with --docs-path

Fixes #135

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko