### PR TITLE
fix(gates): round actual values to 4dp in --gate output

### DIFF
--- a/src/raki/gates/thresholds.py
+++ b/src/raki/gates/thresholds.py
@@ -166,11 +166,12 @@ def format_threshold_results(results: list[ThresholdResult]) -> str:
             detail = result.reason
         elif result.passed:
             status = "PASS"
-            detail = f"actual={result.actual}"
+            actual_val = result.actual
+            detail = f"actual={round(actual_val, 4)}" if actual_val is not None else ""
         else:
             status = "FAIL"
             if result.actual is not None:
-                detail = f"actual={result.actual}"
+                detail = f"actual={round(result.actual, 4)}"
             else:
                 detail = result.reason
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -292,6 +292,32 @@ class TestFormatResults:
         assert "SKIP" in output
         assert "faithfulness" in output
 
+    def test_actual_value_is_rounded_not_raw_float(self):
+        """Bug #141: format_threshold_results should round actual, not show raw float."""
+        results = [
+            ThresholdResult(
+                threshold=Threshold(metric="faithfulness", operator=">", value=0.80),
+                actual=0.8333333333333334,
+                passed=True,
+            ),
+        ]
+        output = format_threshold_results(results)
+        assert "0.8333333333333334" not in output
+        assert "0.8333" in output
+
+    def test_actual_value_rounded_on_fail(self):
+        """Bug #141: FAIL line should also display a rounded actual value."""
+        results = [
+            ThresholdResult(
+                threshold=Threshold(metric="rework_cycles", operator="<", value=1.0),
+                actual=2.6666666666666665,
+                passed=False,
+            ),
+        ]
+        output = format_threshold_results(results)
+        assert "2.6666666666666665" not in output
+        assert "2.6667" in output
+
     def test_multiple_results_formatted(self):
         results = [
             ThresholdResult(


### PR DESCRIPTION
## Summary

- `--gate` output was displaying raw Python floats (e.g. `actual=0.8333333333333334`) in PASS/FAIL lines
- Fixed `format_threshold_results()` in `src/raki/gates/thresholds.py` to round `actual` values to 4 decimal places using `round(val, 4)` in both PASS and FAIL branches
- Added a `None` guard in the PASS branch to satisfy the `ty` type checker (`actual` is typed `float | None`)
- Added two regression tests in `tests/test_gates.py` (`TestFormatResults`) covering both PASS and FAIL paths

## Acceptance Criteria

- [x] PASS lines display `actual=0.8333` instead of `actual=0.8333333333333334`
- [x] FAIL lines display rounded actual values to 4 decimal places
- [x] `N/A` semantics unchanged — `None` actual values still handled correctly
- [x] All 815 tests pass
- [x] `ruff check` and `ruff format --check` clean
- [x] No new `ty` errors introduced

## Review Results

| Specialist | Verdict |
|---|---|
| Python | ✅ clean |

**Notes from Python specialist:**
- `round(val, 4)` correctly handles repeating decimals in both PASS and FAIL branches
- `None` guard is a proper defensive check satisfying the type checker
- Regression tests assert both *absence* of raw float and *presence* of rounded value
- N/A semantics are unchanged

Refs #141

---

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko