### PR TITLE
fix(cli): validate --gate metric names early, exit 2 for unknown metrics

### DIFF
--- a/changes/136.fix
+++ b/changes/136.fix
@@ -1,0 +1,1 @@
+``--gate`` now rejects completely unknown metric names with exit code 2 and a helpful error listing valid metrics, instead of silently skipping the gate check.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,10 +83,3 @@ showcontent = true
 testpaths = ["tests"]
 pythonpath = ["tests"]
 markers = ["slow: marks tests requiring LLM calls"]
-
-[dependency-groups]
-dev = [
-    "pytest>=9.0.3",
-    "ruff>=0.15.11",
-    "ty>=0.0.32",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,3 +83,10 @@ showcontent = true
 testpaths = ["tests"]
 pythonpath = ["tests"]
 markers = ["slow: marks tests requiring LLM calls"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "ruff>=0.15.11",
+    "ty>=0.0.32",
+]

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -219,6 +219,24 @@ def run(
                 param_hint="'--metrics'",
             )
 
+    # Validate --gate metric names before doing any heavy loading
+    if gate_thresholds:
+        from raki.gates.thresholds import parse_threshold
+
+        all_known = _all_metric_names()
+        try:
+            parsed_gates_early = [parse_threshold(raw) for raw in gate_thresholds]
+        except ValueError as exc:
+            raise click.BadParameter(str(exc), param_hint="'--gate'") from exc
+        unknown_gate_metrics = {thr.metric for thr in parsed_gates_early} - set(all_known.keys())
+        if unknown_gate_metrics:
+            valid_list = ", ".join(sorted(all_known.keys()))
+            raise click.BadParameter(
+                f"Unknown metric(s) in --gate: {', '.join(sorted(unknown_gate_metrics))}. "
+                f"Valid metrics: {valid_list}",
+                param_hint="'--gate'",
+            )
+
     manifest_file = _resolve_manifest(manifest_path, quiet=quiet, con=out)
 
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1950,6 +1950,88 @@ class TestGateThresholdCLI:
             assert result.exit_code == 0
             assert "Quality Gates" not in result.output
 
+    def test_gate_unknown_metric_exits_2(self, empty_manifest):
+        """--gate with a completely unknown metric name should exit 2 (not silently skip)."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--gate",
+                "completely_fake_metric>0.5",
+            ],
+        )
+        assert result.exit_code == 2
+
+    def test_gate_unknown_metric_shows_error_message(self, empty_manifest):
+        """--gate with an unknown metric name should show a friendly error message."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--gate",
+                "completely_fake_metric>0.5",
+            ],
+        )
+        assert "completely_fake_metric" in result.output
+        assert "unknown" in result.output.lower() or "invalid" in result.output.lower()
+
+    def test_gate_unknown_metric_lists_valid_metrics(self, empty_manifest):
+        """--gate with an unknown metric name should list valid metric names."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--gate",
+                "completely_fake_metric>0.5",
+            ],
+        )
+        assert "first_pass_verify_rate" in result.output
+        assert "faithfulness" in result.output
+
+    def test_gate_known_but_uncomputed_metric_still_skips(self, empty_manifest):
+        """--gate with a known-but-not-computed metric (e.g. faithfulness without --judge)
+        should SKIP gracefully (exit 0), not exit 2."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--gate",
+                "faithfulness>0.85",
+                "-q",
+            ],
+        )
+        # faithfulness is a valid metric name, so no error
+        assert result.exit_code == 0
+
+    def test_gate_validation_happens_before_evaluation(self, empty_manifest):
+        """--gate validation of metric names should happen before heavy evaluation."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--gate",
+                "typo_metricc>0.5",
+            ],
+        )
+        assert result.exit_code == 2
+        # The error message should mention --gate
+        assert "--gate" in result.output or "gate" in result.output.lower()
+
 
 class TestRegressionCLI:
     """Tests for --fail-on-regression on the report --diff command."""


### PR DESCRIPTION
## Summary

Fixes ticket 136: when `--gate unknown_metric>0.5` was specified, the CLI silently skipped the gate (exit 0), giving no indication that the metric name was invalid. This was especially dangerous for typos like `faithfullness` instead of `faithfulness`.

- Added early validation of `--gate` metric names against the full known metric registry (`_all_metric_names()`) **before** any heavy loading, mirroring the existing `--metrics` validation pattern.
- **Unknown metrics** → exit 2 with `Error: Invalid value for '--gate': Unknown metric(s) in --gate: ..., Valid metrics: ...`
- **Known-but-not-computed metrics** (e.g. `faithfulness` without `--judge`) → exit 0 SKIP, preserving existing behaviour.
- Removed a spurious `[dependency-groups]` block accidentally committed to `pyproject.toml` (local dev-tooling workaround).

## Files Changed

| File | Purpose |
|------|---------|
| `src/raki/cli.py` | Added `--gate` metric-name validation block (lines 222–238) |
| `tests/test_cli.py` | 5 new tests in `TestGateThresholdCLI` |
| `changes/136.fix` | Towncrier changelog fragment |
| `pyproject.toml` | Removed spurious `[dependency-groups]` block |

## Acceptance Criteria

- [x] `--gate typo_metric>0.5` exits 2 with a user-friendly error listing valid metrics
- [x] `--gate faithfulness>0.85` (valid name, LLM not running) exits 0 (skip preserved)
- [x] `--gate bad_syntax` exits 2 (parse error preserved)
- [x] All 695 non-slow tests pass
- [x] `ruff check`, `ty check`, and `raki validate --deep` are clean

## Review Results

### Python Specialist — `needs_fixes` (addressed)

| Severity | Finding | Status |
|----------|---------|--------|
| **IMPORTANT** | `pyproject.toml`: `[dependency-groups].dev` duplicated and conflicted with `[project.optional-dependencies].dev` — spurious local workaround, should not ship | ✅ **Fixed** in second commit |
| MINOR | `_all_metric_names()` called redundantly when both `--metrics` and `--gate` are provided | Accepted — negligible cost, keeps code readable |
| MINOR | Gate thresholds parsed twice (early validation + evaluation); `parsed_gates_early` discarded | Accepted — correctness preserved, not on hot path |
| MINOR | Three tests cover same CLI invocation but assert single aspects each | Accepted — clarity over concision |

Core fix logic (`cli.py:222–238`) confirmed **correct and well-structured**.

### Security Specialist — `clean`

No credential, path-traversal, or exit-code-bypass concerns. Input validation is strictly improved. Manifest-sourced thresholds (line 467) continue to SKIP unknown metrics — existing safe behaviour, unchanged.

## References

Refs #136

---

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko