### PR TITLE
fix(cli): three-tier section headers and progression nudges

### DIFF
--- a/changes/133.fix
+++ b/changes/133.fix
@@ -1,0 +1,1 @@
+Fix CLI output to show three-tier section headers (Operational Health / Knowledge Quality / Retrieval Quality) and progression nudges guiding users toward the next metric tier.

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -205,6 +205,59 @@ def generate_summary_sentence(report: EvalReport, session_count: int) -> str:
     return ". ".join(sentence_parts) + "."
 
 
+def _print_metric_section(
+    output_console: Console,
+    section_scores: dict[str, float | None],
+    report: EvalReport,
+    meta: _MetricMeta,
+    session_count: int,
+    *,
+    experimental_tag: bool = False,
+    calibration_caveat: bool = False,
+) -> None:
+    """Render a single metrics section: metric lines + optional caveats."""
+    for name, score in section_scores.items():
+        tag = (
+            " [yellow]\\[experimental][/yellow]"
+            if experimental_tag and name in EXPERIMENTAL_METRICS
+            else ""
+        )
+        metric_no_data = _has_no_data(report.metric_details, name)
+        inferred_tag = ""
+        if (
+            experimental_tag
+            and not metric_no_data
+            and name in CONTEXT_SENSITIVE_METRICS
+            and _is_synthesized_context(report.metric_details, name)
+        ):
+            inferred_tag = " [cyan]\\(inferred)[/cyan]"
+        output_console.print(
+            format_metric_line(
+                name,
+                score,
+                detail=meta.description(name),
+                display_format=meta.display_format(name),
+                higher_is_better=meta.higher_is_better(name),
+                display_name=meta.display_name(name),
+                no_data=metric_no_data,
+                no_data_reason=_no_data_reason(report.metric_details, name)
+                if metric_no_data
+                else "no data",
+            )
+            + ("" if metric_no_data else tag + inferred_tag)
+        )
+    if session_count < 50:
+        output_console.print(
+            f"[dim]  \u26a0 Small sample size (n={session_count}) \u2014 "
+            "scores are directional, not definitive[/dim]"
+        )
+    if calibration_caveat:
+        output_console.print(
+            "[dim]  \u26a0 Scores produced by same-provider LLM judge "
+            "\u2014 calibration caveat applies[/dim]"
+        )
+
+
 def print_summary(
     report: EvalReport,
     session_count: int,
@@ -215,8 +268,9 @@ def print_summary(
 ) -> None:
     """Print a Rich CLI summary of the evaluation report.
 
-    Metrics are split into two categories: Operational Health and Retrieval Quality.
-    A small sample caveat is shown alongside scores when n < 50.
+    Metrics are split into three categories: Operational Health, Knowledge Quality,
+    and Retrieval Quality. A small sample caveat is shown alongside scores when n < 50.
+    Progression nudges guide the user toward unlocking the next metric tier.
 
     When *metrics* is provided, human-readable ``display_name`` and
     ``description`` values are shown instead of raw metric names.
@@ -226,75 +280,48 @@ def print_summary(
 
     meta = _MetricMeta(metrics)
 
-    non_retrieval = OPERATIONAL_METRICS | KNOWLEDGE_METRICS
     operational = {
-        name: score for name, score in report.aggregate_scores.items() if name in non_retrieval
+        name: score
+        for name, score in report.aggregate_scores.items()
+        if name in OPERATIONAL_METRICS
+    }
+    knowledge = {
+        name: score for name, score in report.aggregate_scores.items() if name in KNOWLEDGE_METRICS
     }
     retrieval = {
-        name: score for name, score in report.aggregate_scores.items() if name not in non_retrieval
+        name: score
+        for name, score in report.aggregate_scores.items()
+        if name not in OPERATIONAL_METRICS and name not in KNOWLEDGE_METRICS
     }
 
     if operational:
         output_console.print("[bold]Operational Health[/bold]")
-        for name, score in operational.items():
-            metric_no_data = _has_no_data(report.metric_details, name)
+        _print_metric_section(output_console, operational, report, meta, session_count)
+        if not knowledge:
             output_console.print(
-                format_metric_line(
-                    name,
-                    score,
-                    detail=meta.description(name),
-                    display_format=meta.display_format(name),
-                    higher_is_better=meta.higher_is_better(name),
-                    display_name=meta.display_name(name),
-                    no_data=metric_no_data,
-                    no_data_reason=_no_data_reason(report.metric_details, name)
-                    if metric_no_data
-                    else "no data",
-                )
+                "[dim]  \u2192 Add --docs-path to unlock Knowledge Quality metrics[/dim]"
             )
-        if session_count < 50:
+        output_console.print()
+
+    if knowledge:
+        output_console.print("[bold]Knowledge Quality[/bold]")
+        _print_metric_section(output_console, knowledge, report, meta, session_count)
+        if not retrieval:
             output_console.print(
-                f"[dim]  \u26a0 Small sample size (n={session_count}) \u2014 "
-                "scores are directional, not definitive[/dim]"
+                "[dim]  \u2192 Add --judge to unlock Retrieval Quality metrics[/dim]"
             )
         output_console.print()
 
     if retrieval:
         output_console.print("[bold]Retrieval Quality[/bold]")
-        for name, score in retrieval.items():
-            tag = " [yellow]\\[experimental][/yellow]" if name in EXPERIMENTAL_METRICS else ""
-            metric_no_data = _has_no_data(report.metric_details, name)
-            # Check if context was synthesized for this metric
-            inferred_tag = ""
-            if (
-                not metric_no_data
-                and name in CONTEXT_SENSITIVE_METRICS
-                and _is_synthesized_context(report.metric_details, name)
-            ):
-                inferred_tag = " [cyan]\\(inferred)[/cyan]"
-            output_console.print(
-                format_metric_line(
-                    name,
-                    score,
-                    detail=meta.description(name),
-                    display_format=meta.display_format(name),
-                    higher_is_better=meta.higher_is_better(name),
-                    display_name=meta.display_name(name),
-                    no_data=metric_no_data,
-                    no_data_reason=_no_data_reason(report.metric_details, name)
-                    if metric_no_data
-                    else "no data",
-                )
-                + ("" if metric_no_data else tag + inferred_tag)
-            )
-        if session_count < 50:
-            output_console.print(
-                f"[dim]  \u26a0 Small sample size (n={session_count}) \u2014 "
-                "scores are directional, not definitive[/dim]"
-            )
-        output_console.print(
-            "[dim]  \u26a0 Scores produced by same-provider LLM judge "
-            "\u2014 calibration caveat applies[/dim]"
+        _print_metric_section(
+            output_console,
+            retrieval,
+            report,
+            meta,
+            session_count,
+            experimental_tag=True,
+            calibration_caveat=True,
         )
         output_console.print()
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -798,6 +798,195 @@ class TestNoDataMetricDisplay:
         assert raw["aggregate_scores"]["context_recall"] is None
         assert raw["aggregate_scores"]["first_pass_verify_rate"] == 0.80
 
+
+# --- Three-tier section headers tests (bug #133) ---
+
+
+class TestThreeTierSectionHeaders:
+    """Bug #133: CLI output must show three separate section headers."""
+
+    def _make_console(self) -> tuple:
+        from io import StringIO
+
+        from rich.console import Console
+
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True)
+        return string_io, test_console
+
+    def test_knowledge_metrics_appear_under_knowledge_quality_heading(self) -> None:
+        """Knowledge metrics must appear under 'Knowledge Quality', not 'Operational Health'."""
+        string_io, test_console = self._make_console()
+        report = EvalReport(
+            run_id="three-tier-test",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.80,
+                "knowledge_gap_rate": 0.10,
+            },
+        )
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "Knowledge Quality" in output
+
+    def test_knowledge_metrics_not_under_operational_heading(self) -> None:
+        """Knowledge metrics must NOT be grouped under Operational Health."""
+        string_io, test_console = self._make_console()
+        report = EvalReport(
+            run_id="three-tier-separation",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.80,
+                "knowledge_gap_rate": 0.10,
+            },
+        )
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        # The heading "Operational Health" must appear before "Knowledge Quality"
+        op_pos = output.find("Operational Health")
+        kq_pos = output.find("Knowledge Quality")
+        assert op_pos != -1, "Operational Health heading missing"
+        assert kq_pos != -1, "Knowledge Quality heading missing"
+        assert op_pos < kq_pos, "Operational Health must precede Knowledge Quality"
+
+    def test_three_tier_all_sections_displayed(self) -> None:
+        """When all three metric categories exist, all three headings must appear."""
+        string_io, test_console = self._make_console()
+        report = EvalReport(
+            run_id="all-three-tiers",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.80,
+                "knowledge_gap_rate": 0.10,
+                "faithfulness": 0.90,
+            },
+        )
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "Operational Health" in output
+        assert "Knowledge Quality" in output
+        assert "Retrieval Quality" in output
+
+    def test_three_sections_appear_in_order(self) -> None:
+        """Three sections must appear in the order: Operational → Knowledge → Retrieval."""
+        string_io, test_console = self._make_console()
+        report = EvalReport(
+            run_id="order-test",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.80,
+                "knowledge_gap_rate": 0.10,
+                "faithfulness": 0.90,
+            },
+        )
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        op_pos = output.find("Operational Health")
+        kq_pos = output.find("Knowledge Quality")
+        rq_pos = output.find("Retrieval Quality")
+        assert op_pos < kq_pos < rq_pos
+
+    def test_only_operational_metrics_shows_one_heading(self) -> None:
+        """When only operational metrics are present, only the Operational Health heading shown."""
+        string_io, test_console = self._make_console()
+        report = EvalReport(
+            run_id="op-only",
+            aggregate_scores={"first_pass_verify_rate": 0.80},
+        )
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "Operational Health" in output
+        # Knowledge Quality and Retrieval Quality must not appear as bold section headings.
+        # Nudge text may mention "Knowledge Quality" so check no knowledge metric is listed.
+        assert "knowledge_gap_rate" not in output
+        assert "knowledge_miss_rate" not in output
+        # No retrieval-tier metric should appear either
+        assert "faithfulness" not in output
+
+    def test_only_knowledge_metrics_shows_knowledge_heading(self) -> None:
+        """When only knowledge metrics are present, only Knowledge Quality heading is shown."""
+        string_io, test_console = self._make_console()
+        report = EvalReport(
+            run_id="kq-only",
+            aggregate_scores={"knowledge_gap_rate": 0.10},
+        )
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "Knowledge Quality" in output
+        assert "Operational Health" not in output
+        # Nudge text may mention "Retrieval Quality" — assert no retrieval metric is listed
+        assert "faithfulness" not in output
+        assert "context_precision" not in output
+
+
+# --- Progression nudge tests (bug #133) ---
+
+
+class TestProgressionNudges:
+    """Bug #133: Each section should show a nudge toward the next tier when it is absent."""
+
+    def _make_console(self) -> tuple:
+        from io import StringIO
+
+        from rich.console import Console
+
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True)
+        return string_io, test_console
+
+    def test_nudge_shown_after_operational_when_no_knowledge_metrics(self) -> None:
+        """When only operational metrics are present, show nudge for --docs-path."""
+        string_io, test_console = self._make_console()
+        report = EvalReport(
+            run_id="nudge-op-only",
+            aggregate_scores={"first_pass_verify_rate": 0.80},
+        )
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "--docs-path" in output
+
+    def test_nudge_shown_after_knowledge_when_no_retrieval_metrics(self) -> None:
+        """When operational + knowledge metrics are present but no retrieval, show --judge nudge."""
+        string_io, test_console = self._make_console()
+        report = EvalReport(
+            run_id="nudge-kq-only",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.80,
+                "knowledge_gap_rate": 0.10,
+            },
+        )
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "--judge" in output
+
+    def test_no_docs_path_nudge_when_knowledge_metrics_present(self) -> None:
+        """When knowledge metrics are present, the --docs-path nudge must NOT appear."""
+        string_io, test_console = self._make_console()
+        report = EvalReport(
+            run_id="nudge-suppressed",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.80,
+                "knowledge_gap_rate": 0.10,
+            },
+        )
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "--docs-path" not in output
+
+    def test_no_judge_nudge_when_retrieval_metrics_present(self) -> None:
+        """When retrieval metrics are present, the --judge nudge must NOT appear."""
+        string_io, test_console = self._make_console()
+        report = EvalReport(
+            run_id="nudge-judge-suppressed",
+            aggregate_scores={
+                "first_pass_verify_rate": 0.80,
+                "faithfulness": 0.90,
+            },
+        )
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "--judge" not in output
+
+
+class TestNoDataMetricDisplayExtended:
+    """Additional no-data / null score tests carried from TestNoDataMetricDisplay."""
+
     def test_skipped_metric_cli_shows_na_not_null(self) -> None:
         """Bug #140: CLI must show 'N/A' for None scores, not 'null' or 'None'."""
         from io import StringIO


### PR DESCRIPTION
## Summary

- Fixes a bug where `KNOWLEDGE_METRICS` were grouped under "Operational Health" instead of their own "Knowledge Quality" section
- Refactors `print_summary()` to render three distinct tiers: **Operational Health** → **Knowledge Quality** → **Retrieval Quality**
- Adds progression nudges after each tier when the next tier is absent, guiding users toward `--docs-path` and `--judge`

## Acceptance Criteria

- [x] `print_summary()` renders three separate `[bold]` section headings in order
- [x] `OPERATIONAL_METRICS` appear only under "Operational Health"
- [x] `KNOWLEDGE_METRICS` appear only under "Knowledge Quality"
- [x] Ragas/LLM-backed metrics appear only under "Retrieval Quality"
- [x] Nudge `→ Add --docs-path to unlock Knowledge Quality metrics` shown after Operational Health when no knowledge metrics present
- [x] Nudge `→ Add --judge to unlock Retrieval Quality metrics` shown after Knowledge Quality when no retrieval metrics present
- [x] Nudges suppressed when the corresponding next tier is already present
- [x] 10 new tests pass (6 in `TestThreeTierSectionHeaders`, 4 in `TestProgressionNudges`)
- [x] Full suite: 823 passed, 0 failures

## Review Results

### Python Specialist — MINOR findings only (no blockers)

| Severity | Location | Issue |
|----------|----------|-------|
| MINOR | `tests/test_report.py:808,924` | `_make_console` return type is bare `tuple` — should be `tuple[StringIO, Console]` for type safety |
| MINOR | `src/raki/report/cli_summary.py:249` | Small sample caveat now appears 3× (once per section) when all tiers present. Previously 2×. Slightly noisier but arguably correct per-section. |
| MINOR | `tests/test_report.py:924` | `_make_console` helper duplicated between two test classes — could be extracted to a shared helper |

### Doc Specialist — CLEAN

- Three-tier headings render in correct order
- Nudges use correct CLI flags (`--docs-path`, `--judge`) and are properly suppressed when the next tier is already present
- Progressive disclosure works end-to-end

## Files Changed

| File | Action |
|------|--------|
| `src/raki/report/cli_summary.py` | Modified — three-tier layout + nudges |
| `tests/test_report.py` | Modified — 10 new tests in 2 new classes |
| `changes/133.fix` | Created — towncrier changelog fragment |

Refs #133

---
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko