### PR TITLE
fix(cli): use CWD as project root for --docs-path guard

### DIFF
--- a/changes/131.fix
+++ b/changes/131.fix
@@ -1,0 +1,4 @@
+Fixed ``--docs-path`` guard using ``manifest_file.parent`` as the project root
+instead of the current working directory.  Docs paths within CWD but outside the
+manifest's parent directory (e.g. repo-root ``docs/`` with the manifest in a
+``config/`` subdirectory) are now accepted correctly.

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -293,7 +293,7 @@ def run(
 
     if effective_docs_path is not None:
         resolved_docs = Path(effective_docs_path).resolve()
-        project_root = manifest_file.parent.resolve()
+        project_root = Path.cwd().resolve()
         try:
             resolved_docs.relative_to(project_root)
         except ValueError:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1408,8 +1408,9 @@ class TestReportPositionalArg:
 class TestDocsPathCLI:
     """Tests for --docs-path flag on the run command."""
 
-    def test_docs_path_option_accepted(self, manifest_with_session, tmp_path):
+    def test_docs_path_option_accepted(self, manifest_with_session, tmp_path, monkeypatch):
         """--docs-path should be accepted as a valid CLI option."""
+        monkeypatch.chdir(tmp_path)
         manifest, _sessions = manifest_with_session
         docs_dir = tmp_path / "docs"
         docs_dir.mkdir()
@@ -1431,8 +1432,9 @@ class TestDocsPathCLI:
         )
         assert result.exit_code == 2
 
-    def test_docs_path_adds_knowledge_metrics(self, manifest_with_session, tmp_path):
+    def test_docs_path_adds_knowledge_metrics(self, manifest_with_session, tmp_path, monkeypatch):
         """--docs-path should add knowledge metrics to the output."""
+        monkeypatch.chdir(tmp_path)
         manifest, _sessions = manifest_with_session
         docs_dir = tmp_path / "docs"
         docs_dir.mkdir()
@@ -1459,8 +1461,9 @@ class TestDocsPathCLI:
         assert "knowledge_gap_rate" in metric_names
         assert "knowledge_miss_rate" in metric_names
 
-    def test_docs_path_logs_loaded_count(self, manifest_with_session, tmp_path):
+    def test_docs_path_logs_loaded_count(self, manifest_with_session, tmp_path, monkeypatch):
         """--docs-path should log how many chunks were loaded."""
+        monkeypatch.chdir(tmp_path)
         manifest, _sessions = manifest_with_session
         docs_dir = tmp_path / "docs"
         docs_dir.mkdir()
@@ -1473,8 +1476,9 @@ class TestDocsPathCLI:
         assert result.exit_code == 0
         assert "doc" in result.output.lower()
 
-    def test_docs_path_overrides_manifest_docs(self, tmp_path, pass_simple_dir):
+    def test_docs_path_overrides_manifest_docs(self, tmp_path, pass_simple_dir, monkeypatch):
         """CLI --docs-path should override manifest docs.path."""
+        monkeypatch.chdir(tmp_path)
         sessions = tmp_path / "sessions"
         sessions.mkdir()
         session_dest = sessions / "101"
@@ -1502,8 +1506,9 @@ class TestDocsPathCLI:
         )
         assert result.exit_code == 0
 
-    def test_manifest_docs_used_when_no_cli_flag(self, tmp_path, pass_simple_dir):
+    def test_manifest_docs_used_when_no_cli_flag(self, tmp_path, pass_simple_dir, monkeypatch):
         """Manifest docs.path should be used when --docs-path is not given."""
+        monkeypatch.chdir(tmp_path)
         sessions = tmp_path / "sessions"
         sessions.mkdir()
         session_dest = sessions / "101"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1537,17 +1537,19 @@ class TestDocsPathCLI:
         metric_names = set(data.get("aggregate_scores", {}).keys())
         assert "knowledge_gap_rate" in metric_names
 
-    def test_docs_path_outside_project_root_rejected(self, tmp_path):
-        """--docs-path pointing outside the project root should fail with UsageError."""
-        # Create project directory with manifest
+    def test_docs_path_outside_project_root_rejected(self, tmp_path, monkeypatch):
+        """--docs-path pointing outside the CWD (project root) should fail with UsageError."""
+        # Create project directory — this is the CWD (project root)
         project_dir = tmp_path / "project"
         project_dir.mkdir()
+        monkeypatch.chdir(project_dir)
+
         sessions = project_dir / "sessions"
         sessions.mkdir()
         manifest_file = project_dir / "raki.yaml"
         manifest_file.write_text(f"sessions:\n  path: {sessions}\n  format: auto\n")
 
-        # Create docs directory outside the project root
+        # Create docs directory outside the CWD (project root)
         outside_docs = tmp_path / "outside_docs"
         outside_docs.mkdir()
         (outside_docs / "guide.md").write_text("# Guide\nContent.\n")
@@ -1559,6 +1561,38 @@ class TestDocsPathCLI:
         )
         assert result.exit_code != 0
         assert "must be within the project root" in result.output
+
+    def test_docs_path_within_cwd_but_outside_manifest_parent_accepted(self, tmp_path, monkeypatch):
+        """--docs-path within CWD but outside manifest parent directory should be accepted.
+
+        Regression test for bug where the guard used manifest_file.parent as the
+        project root instead of CWD.  When the manifest lives in a subdirectory
+        (e.g. discovered from a nested config/ folder), docs at the repo root must
+        still be accepted.
+        """
+        # CWD is the project root (tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        # Manifest is in a subdirectory — simulates auto-discovery from a nested location
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        sessions = config_dir / "sessions"
+        sessions.mkdir()
+        manifest_file = config_dir / "raki.yaml"
+        manifest_file.write_text(f"sessions:\n  path: {sessions}\n  format: auto\n")
+
+        # docs is at the project root — within CWD but NOT within manifest parent (config/)
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        (docs_dir / "guide.md").write_text("# Guide\nContent.\n")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "-m", str(manifest_file), "--docs-path", str(docs_dir), "-q"],
+        )
+        # Should succeed: docs_dir is within CWD even though it's outside config/
+        assert result.exit_code == 0
 
 
 class TestRagasMetricsSync:


### PR DESCRIPTION
## Summary

The `--docs-path` traversal-safety guard compared the resolved docs path against `manifest_file.parent.resolve()` instead of `Path.cwd().resolve()`. This incorrectly rejected valid docs paths that were inside the project root (CWD) but outside the manifest's parent directory — a common scenario when the manifest is auto-discovered from a subdirectory (e.g. `config/raki.yaml`) while docs live at the repo root (`docs/`).

**Change:** `manifest_file.parent.resolve()` → `Path.cwd().resolve()` on line 296 of `src/raki/cli.py`.

## Acceptance Criteria

- [x] Regression test `test_docs_path_within_cwd_but_outside_manifest_parent_accepted` added and passes — reproduces the exact failure scenario (manifest in `config/` subdir, docs at repo root)
- [x] Path-traversal guard still rejects docs paths outside CWD (`test_docs_path_outside_project_root_rejected` passes)
- [x] All 8 `TestDocsPathCLI` tests pass (5 existing tests updated with `monkeypatch.chdir(tmp_path)` to align with CWD semantics)
- [x] Error message correctly reports CWD as the project root
- [x] `MetricConfig.project_root=manifest_file.parent.resolve()` (line 334) is correctly left unchanged — separate concern
- [x] Towncrier changelog fragment added (`changes/131.fix`)
- [x] 813 passed, 0 failed; ruff clean

## Review Results

### Python Specialist — ✅ Clean
Single-line fix with minimal blast radius. Regression test precisely reproduces the bug scenario. Existing tests correctly updated with `monkeypatch.chdir(tmp_path)`. `test_docs_path_nonexistent_exits_2` correctly omits chdir since Click rejects non-existent paths before the traversal guard runs.

### Security Specialist — ✅ Clean
Path traversal guard intact: `resolve()` + `relative_to()` correctly rejects docs paths outside CWD. `resolve()` follows symlinks before the `relative_to()` check, so a symlink inside CWD pointing outside CWD is correctly rejected. Manifest `docs.path` fallback passes through the same guard.

### Doc Specialist — ✅ Clean
Changelog fragment is clear, concise, and uses RST formatting consistent with towncrier conventions. Error message is user-actionable, now correctly naming CWD as the project root.

Refs #131

---

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko