### PR TITLE
feat(adapters): support bridge/alcove session format

### DIFF
--- a/src/raki/adapters/alcove.py
+++ b/src/raki/adapters/alcove.py
@@ -27,13 +27,32 @@ _INFORMATIONAL_BASH_PREFIXES = (
 )
 
 
+def _extract_session_id(raw: dict) -> str:
+    """Extract session ID from either alcove or bridge format.
+
+    Bridge format uses ``id`` at the top level.
+    Classic alcove format uses ``session_id``.
+    Falls back to ``task_id`` or the system entry's ``session_id``.
+    """
+    if "session_id" in raw:
+        return raw["session_id"]
+    if "id" in raw:
+        return raw["id"]
+    if "task_id" in raw:
+        return raw["task_id"]
+    for entry in raw.get("transcript", []):
+        if entry.get("type") == "system" and "session_id" in entry:
+            return entry["session_id"]
+    raise KeyError("No session_id or id found in transcript file")
+
+
 class AlcoveAdapter:
     name: str = "alcove"
-    description: str = "Single-file JSON transcript with session_id and transcript array"
-    detection_hint: str = "*.json file containing session_id + transcript"
+    description: str = "Single-file JSON transcript from Claude Code or Alcove bridge"
+    detection_hint: str = "*.json file containing (session_id or id) + transcript"
 
     def detect(self, source: Path) -> bool:
-        """Detect Alcove format via substring search of first 4KB."""
+        """Detect Alcove/bridge format via substring search of first 4KB."""
         if source.is_symlink():
             return False
         if not source.is_file() or source.suffix != ".json":
@@ -41,12 +60,15 @@ class AlcoveAdapter:
         try:
             with source.open(encoding="utf-8", errors="replace") as file_handle:
                 header = file_handle.read(DETECT_READ_SIZE)
-            return '"session_id"' in header and '"transcript"' in header
+            has_transcript = '"transcript"' in header
+            has_session_id = '"session_id"' in header
+            has_bridge_id = '"id"' in header and '"task_id"' in header
+            return has_transcript and (has_session_id or has_bridge_id)
         except OSError:
             return False
 
     def load(self, source: Path) -> EvalSample:
-        """Parse an Alcove single-file transcript into an EvalSample."""
+        """Parse a Claude Code or bridge transcript into an EvalSample."""
         if source.is_symlink():
             raise ValueError(f"Source must be a regular file (no symlinks): {source}")
         resolved = source.resolve()
@@ -58,8 +80,10 @@ class AlcoveAdapter:
                 f"File exceeds {MAX_ALCOVE_FILE_SIZE // (1024 * 1024)}MB limit: {source}"
             )
         raw = json.loads(resolved.read_text(encoding="utf-8"))
-        session_id = raw["session_id"]
         transcript = raw["transcript"]
+        is_bridge = "task_id" in raw
+
+        session_id = _extract_session_id(raw)
 
         model_id: str | None = None
         tool_calls: list[ToolCall] = []
@@ -69,6 +93,11 @@ class AlcoveAdapter:
         started_at: datetime | None = None
         tokens_in = 0
         tokens_out = 0
+        session_status = raw.get("status", "completed") if is_bridge else "completed"
+        task_name: str | None = raw.get("task_name") if is_bridge else None
+
+        if is_bridge and raw.get("started_at"):
+            started_at = datetime.fromisoformat(raw["started_at"])
 
         for entry in transcript:
             entry_type = entry.get("type")
@@ -107,8 +136,10 @@ class AlcoveAdapter:
                 if not model_id and model_usage:
                     model_id = next(iter(model_usage), None)
 
+        ticket = task_name or session_id
         meta = SessionMeta(
             session_id=session_id,
+            ticket=ticket if ticket != session_id else None,
             started_at=started_at or datetime.now(timezone.utc),
             total_cost_usd=total_cost_usd,
             total_phases=1,
@@ -120,7 +151,7 @@ class AlcoveAdapter:
         phase = PhaseResult(
             name="session",
             generation=1,
-            status="completed",
+            status="completed" if session_status == "completed" else "failed",
             cost_usd=total_cost_usd,
             duration_ms=duration_ms,
             tokens_in=tokens_in or None,

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1209,6 +1209,146 @@ def test_session_schema_no_token_counts_from_either_source(tmp_path):
     assert impl_phases[0].tokens_out is None
 
 
+# --- Alcove bridge format tests ---
+
+
+def _bridge_session(tmp_path, overrides=None):
+    """Create a minimal bridge-format session file and return its path."""
+    data = {
+        "id": "bridge-001",
+        "task_id": "task-abc",
+        "submitter": "workflow",
+        "task_name": "Upgrade Dependencies",
+        "status": "completed",
+        "started_at": "2026-04-22T10:00:00Z",
+        "duration": "2m30s",
+        "transcript": [
+            {"type": "system", "model": "claude-sonnet-4-6", "session_id": "task-abc"},
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "usage": {"input_tokens": 100, "output_tokens": 50},
+                    "content": [{"type": "text", "text": "I will upgrade deps."}],
+                },
+            },
+            {
+                "type": "result",
+                "total_cost_usd": 0.42,
+                "duration_ms": 150000,
+                "modelUsage": {"claude-sonnet-4-6": {"inputTokens": 100, "outputTokens": 50}},
+            },
+        ],
+    }
+    if overrides:
+        data.update(overrides)
+    session_file = tmp_path / "bridge-session.json"
+    session_file.write_text(json.dumps(data))
+    return session_file
+
+
+def test_bridge_format_detected(tmp_path):
+    source = _bridge_session(tmp_path)
+    adapter = AlcoveAdapter()
+    assert adapter.detect(source) is True
+
+
+def test_bridge_session_id_from_id_field(tmp_path):
+    source = _bridge_session(tmp_path)
+    adapter = AlcoveAdapter()
+    sample = adapter.load(source)
+    assert sample.session.session_id == "bridge-001"
+
+
+def test_bridge_task_name_as_ticket(tmp_path):
+    source = _bridge_session(tmp_path)
+    adapter = AlcoveAdapter()
+    sample = adapter.load(source)
+    assert sample.session.ticket == "Upgrade Dependencies"
+
+
+def test_bridge_started_at_from_top_level(tmp_path):
+    source = _bridge_session(tmp_path)
+    adapter = AlcoveAdapter()
+    sample = adapter.load(source)
+    assert sample.session.started_at.year == 2026
+    assert sample.session.started_at.hour == 10
+
+
+def test_bridge_cost_from_result(tmp_path):
+    source = _bridge_session(tmp_path)
+    adapter = AlcoveAdapter()
+    sample = adapter.load(source)
+    assert sample.session.total_cost_usd == 0.42
+
+
+def test_bridge_model_from_system(tmp_path):
+    source = _bridge_session(tmp_path)
+    adapter = AlcoveAdapter()
+    sample = adapter.load(source)
+    assert sample.session.model_id == "claude-sonnet-4-6"
+
+
+def test_bridge_failed_status(tmp_path):
+    source = _bridge_session(tmp_path, overrides={"status": "failed"})
+    adapter = AlcoveAdapter()
+    sample = adapter.load(source)
+    assert sample.phases[0].status == "failed"
+
+
+def test_bridge_no_task_name_no_ticket(tmp_path):
+    data = {
+        "id": "bridge-002",
+        "task_id": "task-xyz",
+        "submitter": "workflow",
+        "status": "completed",
+        "started_at": "2026-04-22T10:00:00Z",
+        "transcript": [
+            {"type": "system", "model": "claude-sonnet-4-6"},
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "content": [{"type": "text", "text": "done"}],
+                },
+            },
+            {"type": "result", "total_cost_usd": 0.01, "duration_ms": 1000},
+        ],
+    }
+    session_file = tmp_path / "no-task-name.json"
+    session_file.write_text(json.dumps(data))
+    adapter = AlcoveAdapter()
+    sample = adapter.load(session_file)
+    assert sample.session.ticket is None
+
+
+def test_bridge_classic_format_still_works(tmp_path):
+    """Classic session_id format must continue working."""
+    data = {
+        "session_id": "classic-001",
+        "transcript": [
+            {"type": "system", "model": "claude-sonnet-4-6"},
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "content": [{"type": "text", "text": "hello"}],
+                },
+            },
+            {"type": "result", "total_cost_usd": 0.01, "duration_ms": 1000},
+        ],
+    }
+    session_file = tmp_path / "classic.json"
+    session_file.write_text(json.dumps(data))
+    adapter = AlcoveAdapter()
+    assert adapter.detect(session_file) is True
+    sample = adapter.load(session_file)
+    assert sample.session.session_id == "classic-001"
+    assert sample.session.ticket is None
+
+
 # --- Alcove context synthesis tests (issue #114) ---
 
 


### PR DESCRIPTION
## Summary

Updates the AlcoveAdapter to handle both classic Claude Code transcripts
and the bridge/alcove session format used by automated workflows.

Bridge format uses `id` + `task_id` at the top level instead of `session_id`,
and includes `task_name`, `status`, `started_at`, `provider`, and `repos`.
The transcript entry structure is identical.

**Tested with real bridge session data** — 60 tool calls, 163 transcript
entries, context synthesis working.

Both formats continue to pass all 21 alcove tests + full 813-test suite.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko