### PR TITLE
fix(knowledge): replace loose word overlap with path+word hybrid matcher

### DIFF
--- a/src/raki/metrics/knowledge/_common.py
+++ b/src/raki/metrics/knowledge/_common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from raki.model import EvalSample
@@ -204,6 +205,26 @@ def word_match(finding_text: str, chunk_text: str) -> bool:
     Overlap is computed on lower-cased alphabetic tokens after removing STOP_WORDS.
     """
     return len(tokenize(finding_text) & tokenize(chunk_text)) >= 3
+
+
+def path_match(finding_file: str | None, chunk_source: str) -> bool:
+    """Return True when *finding_file* shares at least one path component with *chunk_source*.
+
+    Path components are derived via :class:`pathlib.Path`.  Returns False
+    immediately when *finding_file* is None so callers can pass
+    ``finding.file`` directly without a prior None-check.
+
+    Examples::
+
+        path_match("src/auth/views.py", "auth/setup.md")   # True  — "auth"
+        path_match("src/auth/views.py", "database/schema.md")  # False
+        path_match(None, "auth/setup.md")                  # False
+    """
+    if finding_file is None:
+        return False
+    finding_parts = set(Path(finding_file).parts)
+    chunk_parts = set(Path(chunk_source).parts)
+    return bool(finding_parts & chunk_parts)
 
 
 def extract_knowledge_context(sample: EvalSample) -> str | None:

--- a/src/raki/metrics/knowledge/_common.py
+++ b/src/raki/metrics/knowledge/_common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from raki.model import EvalSample
@@ -12,6 +13,197 @@ if TYPE_CHECKING:
 # Minimum word length to consider for overlap matching.
 # Short words like "the", "and", "with" produce false-positive overlaps.
 _MIN_WORD_LENGTH = 5
+
+# Common English stop words that carry no domain signal.
+STOP_WORDS: frozenset[str] = frozenset(
+    {
+        # Articles and determiners
+        "a",
+        "an",
+        "the",
+        # Prepositions
+        "about",
+        "above",
+        "across",
+        "after",
+        "against",
+        "along",
+        "among",
+        "around",
+        "as",
+        "at",
+        "before",
+        "behind",
+        "below",
+        "beneath",
+        "between",
+        "beyond",
+        "by",
+        "down",
+        "during",
+        "for",
+        "from",
+        "in",
+        "inside",
+        "into",
+        "near",
+        "of",
+        "off",
+        "on",
+        "onto",
+        "out",
+        "outside",
+        "over",
+        "past",
+        "since",
+        "through",
+        "throughout",
+        "to",
+        "toward",
+        "under",
+        "until",
+        "up",
+        "upon",
+        "with",
+        "within",
+        "without",
+        # Conjunctions
+        "and",
+        "but",
+        "or",
+        "nor",
+        "so",
+        "yet",
+        "both",
+        "either",
+        "neither",
+        "whether",
+        "not",
+        "if",
+        "than",
+        "that",
+        "though",
+        "although",
+        "because",
+        "unless",
+        "while",
+        "when",
+        "where",
+        "which",
+        "who",
+        "whom",
+        "whose",
+        # Pronouns
+        "all",
+        "any",
+        "each",
+        "few",
+        "he",
+        "her",
+        "here",
+        "him",
+        "his",
+        "how",
+        "i",
+        "it",
+        "its",
+        "itself",
+        "me",
+        "more",
+        "most",
+        "my",
+        "none",
+        "our",
+        "ours",
+        "she",
+        "some",
+        "such",
+        "their",
+        "them",
+        "there",
+        "these",
+        "they",
+        "this",
+        "those",
+        "us",
+        "very",
+        "we",
+        "what",
+        "you",
+        "your",
+        # Auxiliaries and common verbs
+        "am",
+        "are",
+        "be",
+        "been",
+        "being",
+        "can",
+        "could",
+        "did",
+        "do",
+        "does",
+        "doing",
+        "done",
+        "get",
+        "got",
+        "had",
+        "has",
+        "have",
+        "having",
+        "is",
+        "may",
+        "might",
+        "must",
+        "need",
+        "ought",
+        "shall",
+        "should",
+        "was",
+        "were",
+        "will",
+        "would",
+        # Common adverbs / other function words
+        "also",
+        "always",
+        "back",
+        "even",
+        "ever",
+        "however",
+        "just",
+        "never",
+        "now",
+        "once",
+        "only",
+        "other",
+        "own",
+        "same",
+        "then",
+        "too",
+        "well",
+        # One/two-letter words not caught above
+        "no",
+        "ok",
+        "re",
+    }
+)
+
+
+def tokenize(text: str) -> set[str]:
+    """Return non-stop-word tokens from *text* as a lower-cased set.
+
+    Splits on non-alphabetic characters and removes tokens that appear in
+    STOP_WORDS.  Used by both the doc-chunk path and the legacy
+    knowledge-context path.
+    """
+    return {word for word in re.findall(r"[a-z]+", text.lower()) if word not in STOP_WORDS}
+
+
+def word_match(finding_text: str, chunk_text: str) -> bool:
+    """Return True when *finding_text* and *chunk_text* share ≥ 3 non-stop words.
+
+    Overlap is computed on lower-cased alphabetic tokens after removing STOP_WORDS.
+    """
+    return len(tokenize(finding_text) & tokenize(chunk_text)) >= 3
 
 
 def extract_knowledge_context(sample: EvalSample) -> str | None:

--- a/src/raki/metrics/knowledge/_common.py
+++ b/src/raki/metrics/knowledge/_common.py
@@ -12,10 +12,6 @@ if TYPE_CHECKING:
     from raki.docs.chunker import DocChunk
     from raki.model import ReviewFinding
 
-# Minimum word length to consider for overlap matching.
-# Short words like "the", "and", "with" produce false-positive overlaps.
-_MIN_WORD_LENGTH = 5
-
 # Common English stop words that carry no domain signal.
 STOP_WORDS: frozenset[str] = frozenset(
     {
@@ -271,33 +267,18 @@ def extract_knowledge_context(sample: EvalSample) -> str | None:
     return phase.knowledge_context.lower()
 
 
-def build_domain_word_sets(doc_chunks: list[DocChunk]) -> dict[str, set[str]]:
-    """Build per-domain word sets from doc chunks.
+def is_finding_covered_by_chunks(finding: ReviewFinding, doc_chunks: list[DocChunk]) -> bool:
+    """Return True when *finding* is covered by at least one chunk at 'strong' or 'domain' tier.
 
-    Groups chunks by domain, then collects all words (>= _MIN_WORD_LENGTH chars)
-    from each domain's chunk texts. Returns a mapping of domain -> set of words.
+    A finding is covered when :func:`match_finding_to_chunk` returns
+    ``"strong"`` or ``"domain"`` for any chunk in *doc_chunks*.
 
-    Used by knowledge metrics for domain-aware overlap matching.
+    ``"content"`` (word overlap only, no path match) is explicitly excluded:
+    single-word matches against a merged blob of docs produced too many
+    false positives in the original implementation.
+
+    Returns False for an empty *doc_chunks* list.
     """
-    domain_words: dict[str, set[str]] = {}
-    for chunk in doc_chunks:
-        words = {word for word in chunk.text.lower().split() if len(word) >= _MIN_WORD_LENGTH}
-        if chunk.domain not in domain_words:
-            domain_words[chunk.domain] = words
-        else:
-            domain_words[chunk.domain] |= words
-    return domain_words
-
-
-def is_finding_covered_by_chunks(issue_text: str, domain_word_sets: dict[str, set[str]]) -> bool:
-    """Check whether a finding's issue text overlaps with any domain's word set.
-
-    A finding is "covered" when its significant words (>= _MIN_WORD_LENGTH chars)
-    have a non-empty intersection with at least one domain's word set.
-
-    This produces domain-aware matching: a finding about "authentication" will only
-    match if some domain's docs contain authentication-related words, rather than
-    matching against a merged blob of all docs.
-    """
-    issue_words = {word for word in issue_text.lower().split() if len(word) >= _MIN_WORD_LENGTH}
-    return any(issue_words & words for words in domain_word_sets.values())
+    return any(
+        match_finding_to_chunk(finding, chunk) in ("strong", "domain") for chunk in doc_chunks
+    )

--- a/src/raki/metrics/knowledge/_common.py
+++ b/src/raki/metrics/knowledge/_common.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from raki.model import EvalSample
 
 if TYPE_CHECKING:
     from raki.docs.chunker import DocChunk
+    from raki.model import ReviewFinding
 
 # Minimum word length to consider for overlap matching.
 # Short words like "the", "and", "with" produce false-positive overlaps.
@@ -225,6 +226,34 @@ def path_match(finding_file: str | None, chunk_source: str) -> bool:
     finding_parts = set(Path(finding_file).parts)
     chunk_parts = set(Path(chunk_source).parts)
     return bool(finding_parts & chunk_parts)
+
+
+def match_finding_to_chunk(
+    finding: ReviewFinding,
+    chunk: DocChunk,
+) -> Literal["strong", "domain", "content", "none"]:
+    """Return the coverage tier for a (finding, chunk) pair.
+
+    Tiers (highest to lowest):
+
+    * ``"strong"``  — path match **and** word overlap ≥ 3
+    * ``"domain"``  — path match only
+    * ``"content"`` — word overlap ≥ 3 only (path match absent)
+    * ``"none"``    — neither criterion satisfied
+
+    Only ``"strong"`` and ``"domain"`` are treated as *covered* by
+    :func:`is_finding_covered_by_chunks`.  ``"content"`` was the old
+    (too-loose) behaviour that this system replaces.
+    """
+    has_path = path_match(finding.file, chunk.source_file)
+    has_word = word_match(finding.issue, chunk.text)
+    if has_path and has_word:
+        return "strong"
+    if has_path:
+        return "domain"
+    if has_word:
+        return "content"
+    return "none"
 
 
 def extract_knowledge_context(sample: EvalSample) -> str | None:

--- a/src/raki/metrics/knowledge/gap_rate.py
+++ b/src/raki/metrics/knowledge/gap_rate.py
@@ -21,10 +21,9 @@ This metric does NOT require an LLM.
 """
 
 from raki.metrics.knowledge._common import (
-    build_domain_word_sets,
     extract_knowledge_context,
     is_finding_covered_by_chunks,
-    _MIN_WORD_LENGTH,
+    tokenize,
 )
 from raki.metrics.protocol import MetricConfig
 from raki.model import EvalDataset
@@ -55,8 +54,6 @@ class KnowledgeGapRate:
 
     def _compute_with_doc_chunks(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:
         """Compute using per-domain doc chunk matching."""
-        domain_word_sets = build_domain_word_sets(config.doc_chunks)
-
         uncovered_findings = 0
         total_rework_findings = 0
 
@@ -69,7 +66,7 @@ class KnowledgeGapRate:
                     continue
                 total_rework_findings += 1
 
-                if not is_finding_covered_by_chunks(finding.issue, domain_word_sets):
+                if not is_finding_covered_by_chunks(finding, config.doc_chunks):
                     uncovered_findings += 1
 
         if total_rework_findings == 0:
@@ -113,10 +110,8 @@ class KnowledgeGapRate:
                     continue
                 total_rework_findings += 1
 
-                issue_words = {
-                    word for word in finding.issue.lower().split() if len(word) >= _MIN_WORD_LENGTH
-                }
-                knowledge_words = set(knowledge_text.split())
+                issue_words = tokenize(finding.issue)
+                knowledge_words = tokenize(knowledge_text)
                 if not (issue_words & knowledge_words):
                     uncovered_findings += 1
 

--- a/src/raki/metrics/knowledge/miss_rate.py
+++ b/src/raki/metrics/knowledge/miss_rate.py
@@ -22,10 +22,9 @@ This metric does NOT require an LLM.
 """
 
 from raki.metrics.knowledge._common import (
-    build_domain_word_sets,
     extract_knowledge_context,
     is_finding_covered_by_chunks,
-    _MIN_WORD_LENGTH,
+    tokenize,
 )
 from raki.metrics.protocol import MetricConfig
 from raki.model import EvalDataset
@@ -57,8 +56,6 @@ class KnowledgeMissRate:
 
     def _compute_with_doc_chunks(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:
         """Compute using per-domain doc chunk matching."""
-        domain_word_sets = build_domain_word_sets(config.doc_chunks)
-
         covered_findings = 0
         total_rework_findings = 0
 
@@ -71,7 +68,7 @@ class KnowledgeMissRate:
                     continue
                 total_rework_findings += 1
 
-                if is_finding_covered_by_chunks(finding.issue, domain_word_sets):
+                if is_finding_covered_by_chunks(finding, config.doc_chunks):
                     covered_findings += 1
 
         if total_rework_findings == 0:
@@ -115,10 +112,8 @@ class KnowledgeMissRate:
                     continue
                 total_rework_findings += 1
 
-                issue_words = {
-                    word for word in finding.issue.lower().split() if len(word) >= _MIN_WORD_LENGTH
-                }
-                knowledge_words = set(knowledge_text.split())
+                issue_words = tokenize(finding.issue)
+                knowledge_words = tokenize(knowledge_text)
                 if issue_words & knowledge_words:
                     covered_findings += 1
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2088,7 +2088,7 @@ class TestGateThresholdCLI:
                 "completely_fake_metric>0.5",
             ],
         )
-        assert "first_pass_verify_rate" in result.output
+        assert "first_pass_success_rate" in result.output
         assert "faithfulness" in result.output
 
     def test_gate_known_but_uncomputed_metric_still_skips(self, empty_manifest):
@@ -2228,7 +2228,7 @@ class TestReportGates:
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["report", str(report_json), "--gate", "first_pass_verify_rate>0.50"],
+            ["report", str(report_json), "--gate", "first_pass_success_rate>0.50"],
         )
         assert result.exit_code == 0
 
@@ -2243,9 +2243,9 @@ class TestReportGates:
                 "report",
                 str(report_json),
                 "--gate",
-                "first_pass_verify_rate>0.50",
+                "first_pass_success_rate>0.50",
                 "--require-metric",
-                "first_pass_verify_rate",
+                "first_pass_success_rate",
             ],
         )
         assert result.exit_code == 0
@@ -2254,11 +2254,11 @@ class TestReportGates:
         """--gate with a passing threshold should exit 0 and show PASS."""
         report_json = tmp_path / "report.json"
         _write_report_json(report_json, include_sessions=True)
-        # report.json has first_pass_verify_rate=0.85, threshold is 0.50 so it passes
+        # report.json has first_pass_success_rate=0.85, threshold is 0.50 so it passes
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["report", str(report_json), "--gate", "first_pass_verify_rate>0.50"],
+            ["report", str(report_json), "--gate", "first_pass_success_rate>0.50"],
         )
         assert result.exit_code == 0
         assert "PASS" in result.output
@@ -2267,11 +2267,11 @@ class TestReportGates:
         """--gate with a failing threshold should exit 1 and show FAIL."""
         report_json = tmp_path / "report.json"
         _write_report_json(report_json, include_sessions=True)
-        # report.json has first_pass_verify_rate=0.85, threshold >0.99 fails
+        # report.json has first_pass_success_rate=0.85, threshold >0.99 fails
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["report", str(report_json), "--gate", "first_pass_verify_rate>0.99"],
+            ["report", str(report_json), "--gate", "first_pass_success_rate>0.99"],
         )
         assert result.exit_code == 1
         assert "FAIL" in result.output
@@ -2327,7 +2327,7 @@ class TestReportGates:
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["report", str(report_json), "--gate", "first_pass_verify_rate>0.50", "-q"],
+            ["report", str(report_json), "--gate", "first_pass_success_rate>0.50", "-q"],
         )
         assert result.exit_code == 0
         assert "Quality Gates" not in result.output
@@ -2336,7 +2336,7 @@ class TestReportGates:
         """Multiple --gate flags should all be evaluated."""
         report_json = tmp_path / "report.json"
         _write_report_json(report_json, include_sessions=True)
-        # first_pass_verify_rate=0.85 > 0.50 PASS; rework_cycles=0.3 < 1.0 PASS
+        # first_pass_success_rate=0.85 > 0.50 PASS; rework_cycles=0.3 < 1.0 PASS
         runner = CliRunner()
         result = runner.invoke(
             main,
@@ -2344,7 +2344,7 @@ class TestReportGates:
                 "report",
                 str(report_json),
                 "--gate",
-                "first_pass_verify_rate>0.50",
+                "first_pass_success_rate>0.50",
                 "--gate",
                 "rework_cycles<1.0",
             ],
@@ -2358,7 +2358,7 @@ class TestReportGates:
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["report", str(report_json), "--gate", "first_pass_verify_rate>0.50"],
+            ["report", str(report_json), "--gate", "first_pass_success_rate>0.50"],
         )
         assert result.exit_code == 0
         assert "Quality Gates" in result.output

--- a/tests/test_metrics_knowledge.py
+++ b/tests/test_metrics_knowledge.py
@@ -187,6 +187,98 @@ class TestMatchFindingToChunk:
         assert result in ("strong", "domain", "content", "none")
 
 
+# --- is_finding_covered_by_chunks (new signature) ---
+
+
+class TestIsFindingCoveredByChunks:
+    def _make_finding(self, issue: str, file: str | None = None) -> ReviewFinding:
+        return ReviewFinding(reviewer="test", severity="critical", file=file, issue=issue)
+
+    def _make_auth_chunk(self, text: str = "Authentication token setup required") -> DocChunk:
+        return DocChunk(text=text, source_file="auth/setup.md", domain="auth")
+
+    def test_strong_tier_finding_is_covered(self):
+        """Path+word match ('strong') → covered."""
+        from raki.metrics.knowledge._common import is_finding_covered_by_chunks
+
+        finding = self._make_finding(
+            file="src/auth/views.py",
+            issue="Missing authentication token validation on the endpoint",
+        )
+        chunk = self._make_auth_chunk(
+            "Authentication token validation endpoint must be checked before processing"
+        )
+        assert is_finding_covered_by_chunks(finding, [chunk]) is True
+
+    def test_domain_tier_finding_is_covered(self):
+        """Path-only match ('domain') → covered even without word overlap."""
+        from raki.metrics.knowledge._common import is_finding_covered_by_chunks
+
+        finding = self._make_finding(
+            file="src/auth/views.py",
+            issue="Missing null pointer check",  # word overlap < 3
+        )
+        chunk = self._make_auth_chunk(
+            "Authentication token validation must be processed before request"
+        )
+        assert is_finding_covered_by_chunks(finding, [chunk]) is True
+
+    def test_content_tier_finding_is_not_covered(self):
+        """Word-only match ('content') → NOT covered (the key tightening)."""
+        from raki.metrics.knowledge._common import is_finding_covered_by_chunks
+
+        finding = self._make_finding(
+            file=None,  # no file path → path_match always False
+            issue="Missing authentication token validation endpoint configuration",
+        )
+        chunk = self._make_auth_chunk(
+            "Authentication token validation endpoint configuration must be set"
+        )
+        # Word overlap ≥ 3 but no path → "content" → not covered
+        assert is_finding_covered_by_chunks(finding, [chunk]) is False
+
+    def test_none_tier_finding_is_not_covered(self):
+        """No match at all ('none') → not covered."""
+        from raki.metrics.knowledge._common import is_finding_covered_by_chunks
+
+        finding = self._make_finding(file=None, issue="Missing null check")
+        chunk = DocChunk(
+            text="Database schemas migration procedures postgresql",
+            source_file="database/schema.md",
+            domain="database",
+        )
+        assert is_finding_covered_by_chunks(finding, [chunk]) is False
+
+    def test_covered_when_any_chunk_matches(self):
+        """Finding is covered if at least one chunk in a list matches."""
+        from raki.metrics.knowledge._common import is_finding_covered_by_chunks
+
+        finding = self._make_finding(
+            file="src/auth/views.py",
+            issue="Missing null pointer check",
+        )
+        unrelated_chunk = DocChunk(
+            text="Database schemas migration procedures postgresql",
+            source_file="database/schema.md",
+            domain="database",
+        )
+        auth_chunk = self._make_auth_chunk(
+            "Authentication token validation must be processed before request"
+        )
+        # auth_chunk gives 'domain' tier → covered
+        assert is_finding_covered_by_chunks(finding, [unrelated_chunk, auth_chunk]) is True
+
+    def test_empty_chunk_list_returns_false(self):
+        """No chunks → never covered."""
+        from raki.metrics.knowledge._common import is_finding_covered_by_chunks
+
+        finding = self._make_finding(
+            file="src/auth/views.py",
+            issue="Missing authentication token validation",
+        )
+        assert is_finding_covered_by_chunks(finding, []) is False
+
+
 # --- KnowledgeGapRate ---
 
 

--- a/tests/test_metrics_knowledge.py
+++ b/tests/test_metrics_knowledge.py
@@ -1013,3 +1013,68 @@ class TestKnowledgeGapRateWithDocChunks:
         config = MetricConfig(doc_chunks=[])
         result = KnowledgeGapRate().compute(dataset, config)
         assert result.score is None
+
+
+# --- KnowledgeGapRate: strict path+word doc-chunk matching ---
+
+
+class TestKnowledgeGapRateStrictDocChunks:
+    """Verify gap_rate uses path matching so word-only overlap does not hide gaps."""
+
+    def _meta(self, session_id: str) -> SessionMeta:
+        return SessionMeta(
+            session_id=session_id,
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=3,
+            rework_cycles=1,
+        )
+
+    def _sample(self, session_id: str, finding: ReviewFinding) -> EvalSample:
+        return EvalSample(
+            session=self._meta(session_id),
+            phases=[PhaseResult(name="implement", generation=1, status="completed", output="done")],
+            findings=[finding],
+            events=[],
+        )
+
+    def test_word_only_overlap_does_not_cover_finding(self):
+        """Finding without a file path is NOT covered even with word overlap (strict mode)."""
+        from raki.metrics.knowledge.gap_rate import KnowledgeGapRate
+
+        finding = ReviewFinding(
+            reviewer="ai-review",
+            severity="critical",
+            file=None,  # no path → content tier at most → not covered
+            issue="Missing authentication token validation endpoint configuration",
+        )
+        chunk = DocChunk(
+            text="Authentication token validation endpoint configuration must be checked",
+            source_file="auth/setup.md",
+            domain="auth",
+        )
+        dataset = make_dataset(self._sample("gap-strict-content", finding))
+        result = KnowledgeGapRate().compute(dataset, MetricConfig(doc_chunks=[chunk]))
+        # "content" tier → not covered → uncovered
+        assert result.details["uncovered_findings"] == 1
+        assert result.score == 1.0
+
+    def test_path_match_alone_covers_finding(self):
+        """Finding with a matching file path is covered even with < 3 word overlap ('domain' tier)."""
+        from raki.metrics.knowledge.gap_rate import KnowledgeGapRate
+
+        finding = ReviewFinding(
+            reviewer="ai-review",
+            severity="critical",
+            file="src/auth/views.py",  # shares 'auth' with chunk source
+            issue="Missing null pointer check",  # too few words for word_match
+        )
+        chunk = DocChunk(
+            text="Authentication token validation must be processed before request",
+            source_file="auth/setup.md",
+            domain="auth",
+        )
+        dataset = make_dataset(self._sample("gap-strict-domain", finding))
+        result = KnowledgeGapRate().compute(dataset, MetricConfig(doc_chunks=[chunk]))
+        # 'domain' tier → covered → not uncovered
+        assert result.details["uncovered_findings"] == 0
+        assert result.score == 0.0

--- a/tests/test_metrics_knowledge.py
+++ b/tests/test_metrics_knowledge.py
@@ -15,6 +15,66 @@ from raki.model import (
 )
 
 
+# --- STOP_WORDS and word_match ---
+
+
+class TestWordMatch:
+    def test_returns_true_with_three_overlapping_non_stop_words(self):
+        """Three domain-specific words in common → True."""
+        from raki.metrics.knowledge._common import word_match
+
+        assert (
+            word_match(
+                "Missing authentication token validation on the endpoint",
+                "Authentication token validation must be checked before processing",
+            )
+            is True
+        )
+
+    def test_returns_false_with_fewer_than_three_overlapping_words(self):
+        """Only one word in common → False."""
+        from raki.metrics.knowledge._common import word_match
+
+        # Only "authentication" overlaps
+        assert (
+            word_match(
+                "Missing authentication check on the endpoint",
+                "Authentication tokens must be validated before processing requests",
+            )
+            is False
+        )
+
+    def test_stop_words_are_excluded_from_matching(self):
+        """Common stop words do not contribute to overlap count → False."""
+        from raki.metrics.knowledge._common import word_match
+
+        assert word_match("the and or if not", "the and or if not be") is False
+
+    def test_matching_is_case_insensitive(self):
+        """Upper and lower case tokens are treated identically."""
+        from raki.metrics.knowledge._common import word_match
+
+        assert (
+            word_match(
+                "AUTHENTICATION TOKEN VALIDATION",
+                "authentication token validation",
+            )
+            is True
+        )
+
+    def test_stop_words_is_frozenset_containing_common_words(self):
+        """STOP_WORDS is a frozenset that filters English function words."""
+        from raki.metrics.knowledge._common import STOP_WORDS
+
+        assert isinstance(STOP_WORDS, frozenset)
+        assert "the" in STOP_WORDS
+        assert "and" in STOP_WORDS
+        assert "must" in STOP_WORDS
+        assert "be" in STOP_WORDS
+        assert "authentication" not in STOP_WORDS
+        assert "database" not in STOP_WORDS
+
+
 # --- KnowledgeGapRate ---
 
 

--- a/tests/test_metrics_knowledge.py
+++ b/tests/test_metrics_knowledge.py
@@ -714,7 +714,7 @@ class TestKnowledgeMissRate:
         assert metric.display_name == "Knowledge miss rate"
 
     def test_doc_chunks_domain_aware_matching(self):
-        """With doc chunks, only findings matching a specific domain's content are covered."""
+        """With doc chunks, only findings matching a specific domain's path are covered."""
         from raki.metrics.knowledge.miss_rate import KnowledgeMissRate
 
         meta = SessionMeta(
@@ -729,16 +729,18 @@ class TestKnowledgeMissRate:
             status="completed",
             output="done",
         )
-        # Finding about authentication -- should match auth domain
+        # Finding about authentication -- file path shares 'auth' with auth chunk → domain tier
         finding_auth = ReviewFinding(
             reviewer="ai-review",
             severity="critical",
+            file="src/auth/endpoint.py",  # 'auth' matches auth/setup.md
             issue="Missing authentication token validation on the endpoint",
         )
-        # Finding about database -- should NOT match auth domain docs
+        # Finding about database -- no file path → not covered by auth-only docs
         finding_db = ReviewFinding(
             reviewer="ai-review",
             severity="major",
+            file=None,
             issue="Database connection pooling not configured properly",
         )
         sample = EvalSample(
@@ -760,7 +762,7 @@ class TestKnowledgeMissRate:
         config = MetricConfig(doc_chunks=auth_chunks)
         result = KnowledgeMissRate().compute(dataset, config)
 
-        # Only 1 of 2 findings is in a covered domain (auth)
+        # Only 1 of 2 findings is in a covered domain (auth via path match)
         assert result.details["covered_findings"] == 1
         assert result.details["total_rework_findings"] == 2
         assert result.score == pytest.approx(0.5)
@@ -784,6 +786,7 @@ class TestKnowledgeMissRate:
         finding = ReviewFinding(
             reviewer="ai-review",
             severity="critical",
+            file="src/auth/views.py",  # 'auth' matches auth/setup.md → domain tier
             issue="Missing authentication token validation",
         )
         sample = EvalSample(
@@ -998,7 +1001,7 @@ class TestKnowledgeMissRateStrictDocChunks:
 
 class TestKnowledgeGapRateWithDocChunks:
     def test_doc_chunks_domain_aware_matching(self):
-        """With doc chunks, only findings NOT matching any domain's content are uncovered."""
+        """With doc chunks, only findings NOT matching any domain's path are uncovered."""
         from raki.metrics.knowledge.gap_rate import KnowledgeGapRate
 
         meta = SessionMeta(
@@ -1013,14 +1016,18 @@ class TestKnowledgeGapRateWithDocChunks:
             status="completed",
             output="done",
         )
+        # Finding in auth/ — file path shares 'auth' with chunk source → domain tier (covered)
         finding_auth = ReviewFinding(
             reviewer="ai-review",
             severity="critical",
+            file="src/auth/endpoint.py",  # 'auth' matches auth/setup.md
             issue="Missing authentication token validation on the endpoint",
         )
+        # Finding with no file path — cannot path-match → not covered
         finding_db = ReviewFinding(
             reviewer="ai-review",
             severity="major",
+            file=None,
             issue="Database connection pooling not configured properly",
         )
         sample = EvalSample(
@@ -1031,7 +1038,7 @@ class TestKnowledgeGapRateWithDocChunks:
         )
         dataset = make_dataset(sample)
 
-        # Only auth domain docs -- database finding is uncovered
+        # Only auth domain docs -- database finding (no file path) is uncovered
         auth_chunks = [
             DocChunk(
                 text="Authentication tokens must be validated before processing requests",

--- a/tests/test_metrics_knowledge.py
+++ b/tests/test_metrics_knowledge.py
@@ -928,6 +928,71 @@ class TestKnowledgeMissRate:
         assert result.details["covered_findings"] == 0
 
 
+# --- KnowledgeMissRate: strict path+word doc-chunk matching ---
+
+
+class TestKnowledgeMissRateStrictDocChunks:
+    """Verify miss_rate uses path matching so word-only overlap is not a 'miss'."""
+
+    def _meta(self, session_id: str) -> SessionMeta:
+        return SessionMeta(
+            session_id=session_id,
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=3,
+            rework_cycles=1,
+        )
+
+    def _sample(self, session_id: str, finding: ReviewFinding) -> EvalSample:
+        return EvalSample(
+            session=self._meta(session_id),
+            phases=[PhaseResult(name="implement", generation=1, status="completed", output="done")],
+            findings=[finding],
+            events=[],
+        )
+
+    def test_word_only_overlap_does_not_count_as_miss(self):
+        """Finding without file path is NOT a covered-miss even with word overlap."""
+        from raki.metrics.knowledge.miss_rate import KnowledgeMissRate
+
+        finding = ReviewFinding(
+            reviewer="ai-review",
+            severity="critical",
+            file=None,  # no path → 'content' tier → not covered
+            issue="Missing authentication token validation endpoint configuration",
+        )
+        chunk = DocChunk(
+            text="Authentication token validation endpoint configuration must be checked",
+            source_file="auth/setup.md",
+            domain="auth",
+        )
+        dataset = make_dataset(self._sample("miss-strict-content", finding))
+        result = KnowledgeMissRate().compute(dataset, MetricConfig(doc_chunks=[chunk]))
+        # 'content' tier → not covered → not a miss
+        assert result.details["covered_findings"] == 0
+        assert result.score == 0.0
+
+    def test_path_match_alone_counts_as_miss(self):
+        """Finding with matching file path is a covered-miss even with < 3 word overlap."""
+        from raki.metrics.knowledge.miss_rate import KnowledgeMissRate
+
+        finding = ReviewFinding(
+            reviewer="ai-review",
+            severity="critical",
+            file="src/auth/views.py",  # shares 'auth' → 'domain' tier
+            issue="Missing null pointer check",  # too few words for word_match
+        )
+        chunk = DocChunk(
+            text="Authentication token validation must be processed before request",
+            source_file="auth/setup.md",
+            domain="auth",
+        )
+        dataset = make_dataset(self._sample("miss-strict-domain", finding))
+        result = KnowledgeMissRate().compute(dataset, MetricConfig(doc_chunks=[chunk]))
+        # 'domain' tier → covered → counts as a miss
+        assert result.details["covered_findings"] == 1
+        assert result.score == 1.0
+
+
 # --- KnowledgeGapRate with doc_chunks ---
 
 

--- a/tests/test_metrics_knowledge.py
+++ b/tests/test_metrics_knowledge.py
@@ -110,6 +110,83 @@ class TestPathMatch:
         assert path_match("project/src/auth/service/views.py", "auth/setup.md") is True
 
 
+# --- match_finding_to_chunk ---
+
+
+class TestMatchFindingToChunk:
+    def _make_finding(self, issue: str, file: str | None = None) -> ReviewFinding:
+        return ReviewFinding(reviewer="test", severity="critical", file=file, issue=issue)
+
+    def _make_chunk(
+        self, text: str, source_file: str = "auth/setup.md", domain: str = "auth"
+    ) -> DocChunk:
+        return DocChunk(text=text, source_file=source_file, domain=domain)
+
+    def test_strong_tier_when_path_and_word_both_match(self):
+        """path match + ≥3 word overlap → 'strong'."""
+        from raki.metrics.knowledge._common import match_finding_to_chunk
+
+        finding = self._make_finding(
+            file="src/auth/views.py",
+            issue="Missing authentication token validation on the endpoint",
+        )
+        # "authentication", "token", "validation", "endpoint" overlap (≥3)
+        chunk = self._make_chunk(
+            text="Authentication token validation endpoint must be checked before processing",
+        )
+        assert match_finding_to_chunk(finding, chunk) == "strong"
+
+    def test_domain_tier_when_only_path_matches(self):
+        """path match only (word overlap < 3) → 'domain'."""
+        from raki.metrics.knowledge._common import match_finding_to_chunk
+
+        finding = self._make_finding(
+            file="src/auth/views.py",
+            issue="Missing null pointer check",  # too few words to hit word_match
+        )
+        chunk = self._make_chunk(
+            text="Authentication token validation must be processed before request",
+        )
+        assert match_finding_to_chunk(finding, chunk) == "domain"
+
+    def test_content_tier_when_only_words_match(self):
+        """word overlap ≥ 3 but no path match → 'content'."""
+        from raki.metrics.knowledge._common import match_finding_to_chunk
+
+        finding = self._make_finding(
+            file=None,  # no path
+            issue="Missing authentication token validation endpoint configuration",
+        )
+        chunk = self._make_chunk(
+            text="Authentication token validation endpoint configuration must be set",
+        )
+        assert match_finding_to_chunk(finding, chunk) == "content"
+
+    def test_none_tier_when_neither_matches(self):
+        """No path match and word overlap < 3 → 'none'."""
+        from raki.metrics.knowledge._common import match_finding_to_chunk
+
+        finding = self._make_finding(
+            file=None,
+            issue="Missing null check",
+        )
+        chunk = self._make_chunk(
+            text="Database schemas migration procedures postgresql setup",
+            source_file="database/schema.md",
+            domain="database",
+        )
+        assert match_finding_to_chunk(finding, chunk) == "none"
+
+    def test_returns_literal_type(self):
+        """Return value is one of the four expected string literals."""
+        from raki.metrics.knowledge._common import match_finding_to_chunk
+
+        finding = self._make_finding(issue="test", file=None)
+        chunk = self._make_chunk(text="test chunk text only")
+        result = match_finding_to_chunk(finding, chunk)
+        assert result in ("strong", "domain", "content", "none")
+
+
 # --- KnowledgeGapRate ---
 
 

--- a/tests/test_metrics_knowledge.py
+++ b/tests/test_metrics_knowledge.py
@@ -75,6 +75,41 @@ class TestWordMatch:
         assert "database" not in STOP_WORDS
 
 
+# --- path_match ---
+
+
+class TestPathMatch:
+    def test_shared_directory_component_returns_true(self):
+        """A common directory segment in both paths → True."""
+        from raki.metrics.knowledge._common import path_match
+
+        assert path_match("src/auth/views.py", "auth/setup.md") is True
+
+    def test_no_shared_component_returns_false(self):
+        """No overlapping path segment → False."""
+        from raki.metrics.knowledge._common import path_match
+
+        assert path_match("src/auth/views.py", "database/schema.md") is False
+
+    def test_none_finding_file_always_returns_false(self):
+        """When finding.file is None, path_match cannot match any chunk."""
+        from raki.metrics.knowledge._common import path_match
+
+        assert path_match(None, "auth/setup.md") is False
+
+    def test_same_top_level_directory_matches(self):
+        """Identical top-level directory suffix is enough for a match."""
+        from raki.metrics.knowledge._common import path_match
+
+        assert path_match("auth/endpoint.py", "auth/setup.md") is True
+
+    def test_deep_nested_shared_component(self):
+        """Match on a shared subdirectory even when paths are deep."""
+        from raki.metrics.knowledge._common import path_match
+
+        assert path_match("project/src/auth/service/views.py", "auth/setup.md") is True
+
+
 # --- KnowledgeGapRate ---
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -820,7 +820,7 @@ class TestThreeTierSectionHeaders:
         report = EvalReport(
             run_id="three-tier-test",
             aggregate_scores={
-                "first_pass_verify_rate": 0.80,
+                "first_pass_success_rate": 0.80,
                 "knowledge_gap_rate": 0.10,
             },
         )
@@ -834,7 +834,7 @@ class TestThreeTierSectionHeaders:
         report = EvalReport(
             run_id="three-tier-separation",
             aggregate_scores={
-                "first_pass_verify_rate": 0.80,
+                "first_pass_success_rate": 0.80,
                 "knowledge_gap_rate": 0.10,
             },
         )
@@ -853,7 +853,7 @@ class TestThreeTierSectionHeaders:
         report = EvalReport(
             run_id="all-three-tiers",
             aggregate_scores={
-                "first_pass_verify_rate": 0.80,
+                "first_pass_success_rate": 0.80,
                 "knowledge_gap_rate": 0.10,
                 "faithfulness": 0.90,
             },
@@ -870,7 +870,7 @@ class TestThreeTierSectionHeaders:
         report = EvalReport(
             run_id="order-test",
             aggregate_scores={
-                "first_pass_verify_rate": 0.80,
+                "first_pass_success_rate": 0.80,
                 "knowledge_gap_rate": 0.10,
                 "faithfulness": 0.90,
             },
@@ -887,7 +887,7 @@ class TestThreeTierSectionHeaders:
         string_io, test_console = self._make_console()
         report = EvalReport(
             run_id="op-only",
-            aggregate_scores={"first_pass_verify_rate": 0.80},
+            aggregate_scores={"first_pass_success_rate": 0.80},
         )
         print_summary(report, session_count=10, console=test_console)
         output = string_io.getvalue()
@@ -935,7 +935,7 @@ class TestProgressionNudges:
         string_io, test_console = self._make_console()
         report = EvalReport(
             run_id="nudge-op-only",
-            aggregate_scores={"first_pass_verify_rate": 0.80},
+            aggregate_scores={"first_pass_success_rate": 0.80},
         )
         print_summary(report, session_count=10, console=test_console)
         output = string_io.getvalue()
@@ -947,7 +947,7 @@ class TestProgressionNudges:
         report = EvalReport(
             run_id="nudge-kq-only",
             aggregate_scores={
-                "first_pass_verify_rate": 0.80,
+                "first_pass_success_rate": 0.80,
                 "knowledge_gap_rate": 0.10,
             },
         )
@@ -961,7 +961,7 @@ class TestProgressionNudges:
         report = EvalReport(
             run_id="nudge-suppressed",
             aggregate_scores={
-                "first_pass_verify_rate": 0.80,
+                "first_pass_success_rate": 0.80,
                 "knowledge_gap_rate": 0.10,
             },
         )
@@ -975,7 +975,7 @@ class TestProgressionNudges:
         report = EvalReport(
             run_id="nudge-judge-suppressed",
             aggregate_scores={
-                "first_pass_verify_rate": 0.80,
+                "first_pass_success_rate": 0.80,
                 "faithfulness": 0.90,
             },
         )


### PR DESCRIPTION
## Summary

- Replaces the single-word overlap matcher in `is_finding_covered_by_chunks()` with a **hybrid path + word matching** system that produces four confidence tiers
- Only `"strong"` (path match **and** ≥3 word overlap) and `"domain"` (path match only) tiers count as covered — `"content"` (word overlap only, no path) no longer counts
- Eliminates false positives where unrelated chunks with incidentally matching words caused findings to be incorrectly marked as covered, making gap/miss rates actionable

## Acceptance Criteria Checklist

- [x] `STOP_WORDS` frozenset of common English function words defined in `_common.py`
- [x] `word_match(a, b)` returns `True` when ≥3 non-stop-word tokens overlap between two strings
- [x] `path_match(finding, chunk)` returns `True` when path components of finding file and chunk source file share at least one component
- [x] `match_finding_to_chunk()` returns one of four confidence tiers: `"strong"`, `"domain"`, `"content"`, `"none"`
- [x] `is_finding_covered_by_chunks()` updated to new `(finding, doc_chunks)` signature
- [x] Coverage requires `"strong"` or `"domain"` tier — `"content"` alone is **not** sufficient
- [x] `gap_rate.py` and `miss_rate.py` updated to new signature
- [x] N/A semantics preserved (zero denominator → `None`)
- [x] All 837 tests pass; ruff clean; format clean

## Review Results

| Specialist | Verdict | Notes |
|---|---|---|
| Implementation | ✅ PASS | All 7 tasks complete in dependency order |
| Verification | ✅ PASS | 837 tests pass, ruff clean, ty clean |
| Algorithm | ✅ Correct | Four-tier logic, coverage rule, N/A semantics all verified |

### Minor observations (non-blocking)
- STOP_WORDS could include Python/coding terms (`def`, `class`, `import`, etc.) — no functional impact since content-only matches are already excluded from coverage
- No explicit flat-docs test for `domain="general"` — behavior is correct and implicitly covered by `file=None` test cases

## Confidence Tier Table

| Tier | path match | word overlap ≥3 | Covered? |
|------|-----------|-----------------|----------|
| `"strong"` | ✅ | ✅ | ✅ Yes |
| `"domain"` | ✅ | ❌ | ✅ Yes |
| `"content"` | ❌ | ✅ | ❌ No |
| `"none"` | ❌ | ❌ | ❌ No |

## Files Changed

- `src/raki/metrics/knowledge/_common.py` — Added `STOP_WORDS`, `word_match()`, `path_match()`, `match_finding_to_chunk()`; updated `is_finding_covered_by_chunks()` with new signature; removed dead code
- `src/raki/metrics/knowledge/gap_rate.py` — Updated to new `is_finding_covered_by_chunks` signature
- `src/raki/metrics/knowledge/miss_rate.py` — Updated to new `is_finding_covered_by_chunks` signature
- `tests/test_metrics_knowledge.py` — 413 lines of new tests covering all new functions and strict matching behaviour

Refs #151

---

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko