### PR TITLE
fix(ragas): detect and skip instructor#1658 silent-zero scores from Google provider

### DIFF
--- a/changes/169.fix
+++ b/changes/169.fix
@@ -1,0 +1,1 @@
+Fix Google judge provider silently returning 0.0 scores when ``instructor`` (issue #1658) fails to parse structured output. Affected sessions are now skipped with a warning and the metric returns ``score=None`` instead of a misleading zero average. Also removes ``top_p`` from Google LLM ``model_args`` to prevent API rejection when both ``temperature`` and ``top_p`` are set.

--- a/src/raki/metrics/ragas/adapter.py
+++ b/src/raki/metrics/ragas/adapter.py
@@ -244,6 +244,46 @@ def is_max_tokens_error(exc: Exception) -> bool:
     return "max_tokens" in message
 
 
+class InstructorSilentZeroError(RuntimeError):
+    """Raised when the instructor#1658 silent-zero bug is detected for the Google provider.
+
+    When ``instructor`` fails to parse Google's structured output it silently
+    returns a Pydantic model with default field values (``value=0.0``,
+    ``reason=None``) instead of raising a ``ValidationError``.  Raising this
+    exception lets the existing per-session error handler log a warning and
+    skip the session so the silent zero does not pollute the metric average.
+
+    See: https://github.com/instructor-ai/instructor/issues/1658
+    """
+
+
+def is_instructor_silent_zero(result: object, provider: str) -> bool:
+    """Detect the instructor#1658 silent-zero bug for the Google provider.
+
+    When ``instructor`` fails to parse Google's structured output it silently
+    returns a Pydantic model with default field values (``value=0.0``,
+    ``reason=None``) instead of raising a ``ValidationError``.
+
+    Returns ``True`` only when **all** of the following hold:
+
+    - *provider* is ``"google"``
+    - *result* is a structured object (not a plain ``float``)
+    - ``result.value`` is exactly ``0.0``
+    - ``result.reason`` is ``None`` or an empty string
+
+    Args:
+        result: The value returned by ``ragas_metric.ascore()``.
+        provider: The LLM provider string from ``MetricConfig.llm_provider``.
+    """
+    if provider != "google":
+        return False
+    if isinstance(result, float):
+        return False
+    value = getattr(result, "value", None)
+    reason = getattr(result, "reason", None)
+    return value == 0.0 and not reason
+
+
 def detect_context_source(dataset: EvalDataset) -> str | None:
     """Determine the predominant context_source across dataset samples.
 

--- a/src/raki/metrics/ragas/faithfulness.py
+++ b/src/raki/metrics/ragas/faithfulness.py
@@ -165,6 +165,14 @@ class FaithfulnessMetric:
                 "Designed for NL answers, not code -- scores may be noisy for agentic sessions"
             ),
         }
+        if max_tokens_failures:
+            details["max_tokens_sessions"] = len(max_tokens_failures)
+        if silent_zero_failures:
+            details["silent_zero_sessions"] = len(silent_zero_failures)
+            details["silent_zero_warning"] = (
+                f"instructor#1658: {len(silent_zero_failures)} session(s) returned silent 0.0 "
+                "from Google provider and were excluded from the score"
+            )
         if context_source is not None:
             details["context_source"] = context_source
 

--- a/src/raki/metrics/ragas/faithfulness.py
+++ b/src/raki/metrics/ragas/faithfulness.py
@@ -12,7 +12,13 @@ import logging
 
 from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
-from raki.metrics.ragas.adapter import detect_context_source, is_max_tokens_error, to_ragas_rows
+from raki.metrics.ragas.adapter import (
+    InstructorSilentZeroError,
+    detect_context_source,
+    is_instructor_silent_zero,
+    is_max_tokens_error,
+    to_ragas_rows,
+)
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
 from raki.model import EvalDataset
@@ -78,6 +84,7 @@ class FaithfulnessMetric:
         sample_scores: dict[str, float] = {}
         scores: list[float] = []
         max_tokens_failures: list[str] = []
+        silent_zero_failures: list[str] = []
 
         async def score_all():
             semaphore = asyncio.Semaphore(config.batch_size)
@@ -90,6 +97,12 @@ class FaithfulnessMetric:
                             response=row.response,
                             retrieved_contexts=row.retrieved_contexts,
                         )
+                        if is_instructor_silent_zero(result, config.llm_provider):
+                            raise InstructorSilentZeroError(
+                                f"instructor#1658: Google provider returned silent 0.0 "
+                                f"for session {row.session_id}; treating as failure to "
+                                "avoid polluting metric average"
+                            )
                         score = result if isinstance(result, float) else result.value
                         scores.append(score)
                         sample_scores[row.session_id] = score
@@ -100,6 +113,8 @@ class FaithfulnessMetric:
                         safe_error = redact_sensitive(f"ERROR: {exc}")
                         if is_max_tokens_error(exc):
                             max_tokens_failures.append(row.session_id)
+                        elif isinstance(exc, InstructorSilentZeroError):
+                            silent_zero_failures.append(row.session_id)
                         logger.warning(
                             "faithfulness scoring failed for session %s: %s",
                             row.session_id,
@@ -120,6 +135,20 @@ class FaithfulnessMetric:
                 details={
                     "skipped": "max_tokens: all sessions exceeded output token limit",
                     "max_tokens_sessions": len(max_tokens_failures),
+                },
+            )
+
+        # If all failures were instructor#1658 silent-zero errors, return score=None
+        if not scores and silent_zero_failures:
+            return MetricResult(
+                name=self.name,
+                score=None,
+                details={
+                    "skipped": (
+                        "instructor#1658: Google provider returned only silent 0.0 scores; "
+                        "possible structured-output parsing failures"
+                    ),
+                    "silent_zero_sessions": len(silent_zero_failures),
                 },
             )
 

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -64,6 +64,7 @@ def create_ragas_llm(config: MetricConfig):
             temperature=config.temperature,
             max_tokens=4096,
         )
+        llm.model_args.pop("top_p", None)  # ty: ignore[unresolved-attribute]
         return llm
     else:
         supported_list = ", ".join(SUPPORTED_PROVIDERS)
@@ -80,7 +81,7 @@ def create_ragas_llm(config: MetricConfig):
         temperature=config.temperature,
         max_tokens=4096,
     )
-    llm.model_args.pop("top_p", None)
+    llm.model_args.pop("top_p", None)  # ty: ignore[unresolved-attribute]
     return llm
 
 

--- a/src/raki/metrics/ragas/precision.py
+++ b/src/raki/metrics/ragas/precision.py
@@ -135,12 +135,21 @@ class ContextPrecisionMetric:
             )
 
         mean_score = sum(scores) / len(scores) if scores else 0.0
+        details: dict = {
+            "samples_scored": len(scores),
+            "samples_skipped": len(rows_with_ref) - len(scores),
+        }
+        if max_tokens_failures:
+            details["max_tokens_sessions"] = len(max_tokens_failures)
+        if silent_zero_failures:
+            details["silent_zero_sessions"] = len(silent_zero_failures)
+            details["silent_zero_warning"] = (
+                f"instructor#1658: {len(silent_zero_failures)} session(s) returned silent 0.0 "
+                "from Google provider and were excluded from the score"
+            )
         return MetricResult(
             name=self.name,
             score=mean_score,
-            details={
-                "samples_scored": len(scores),
-                "samples_skipped": len(rows_with_ref) - len(scores),
-            },
+            details=details,
             sample_scores=sample_scores,
         )

--- a/src/raki/metrics/ragas/precision.py
+++ b/src/raki/metrics/ragas/precision.py
@@ -9,7 +9,12 @@ import logging
 
 from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
-from raki.metrics.ragas.adapter import is_max_tokens_error, to_ragas_rows
+from raki.metrics.ragas.adapter import (
+    InstructorSilentZeroError,
+    is_instructor_silent_zero,
+    is_max_tokens_error,
+    to_ragas_rows,
+)
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
 from raki.model import EvalDataset
@@ -61,6 +66,7 @@ class ContextPrecisionMetric:
         sample_scores: dict[str, float] = {}
         scores: list[float] = []
         max_tokens_failures: list[str] = []
+        silent_zero_failures: list[str] = []
 
         async def score_all():
             semaphore = asyncio.Semaphore(config.batch_size)
@@ -73,6 +79,12 @@ class ContextPrecisionMetric:
                             retrieved_contexts=row.retrieved_contexts,
                             reference=row.reference,
                         )
+                        if is_instructor_silent_zero(result, config.llm_provider):
+                            raise InstructorSilentZeroError(
+                                f"instructor#1658: Google provider returned silent 0.0 "
+                                f"for session {row.session_id}; treating as failure to "
+                                "avoid polluting metric average"
+                            )
                         score = result if isinstance(result, float) else result.value
                         scores.append(score)
                         sample_scores[row.session_id] = score
@@ -83,6 +95,8 @@ class ContextPrecisionMetric:
                         safe_error = redact_sensitive(f"ERROR: {exc}")
                         if is_max_tokens_error(exc):
                             max_tokens_failures.append(row.session_id)
+                        elif isinstance(exc, InstructorSilentZeroError):
+                            silent_zero_failures.append(row.session_id)
                         logger.warning(
                             "context_precision scoring failed for session %s: %s",
                             row.session_id,
@@ -103,6 +117,20 @@ class ContextPrecisionMetric:
                 details={
                     "skipped": "max_tokens: all sessions exceeded output token limit",
                     "max_tokens_sessions": len(max_tokens_failures),
+                },
+            )
+
+        # If all failures were instructor#1658 silent-zero errors, return score=None
+        if not scores and silent_zero_failures:
+            return MetricResult(
+                name=self.name,
+                score=None,
+                details={
+                    "skipped": (
+                        "instructor#1658: Google provider returned only silent 0.0 scores; "
+                        "possible structured-output parsing failures"
+                    ),
+                    "silent_zero_sessions": len(silent_zero_failures),
                 },
             )
 

--- a/src/raki/metrics/ragas/recall.py
+++ b/src/raki/metrics/ragas/recall.py
@@ -135,12 +135,21 @@ class ContextRecallMetric:
             )
 
         mean_score = sum(scores) / len(scores) if scores else 0.0
+        details: dict = {
+            "samples_scored": len(scores),
+            "samples_skipped": len(rows_with_ref) - len(scores),
+        }
+        if max_tokens_failures:
+            details["max_tokens_sessions"] = len(max_tokens_failures)
+        if silent_zero_failures:
+            details["silent_zero_sessions"] = len(silent_zero_failures)
+            details["silent_zero_warning"] = (
+                f"instructor#1658: {len(silent_zero_failures)} session(s) returned silent 0.0 "
+                "from Google provider and were excluded from the score"
+            )
         return MetricResult(
             name=self.name,
             score=mean_score,
-            details={
-                "samples_scored": len(scores),
-                "samples_skipped": len(rows_with_ref) - len(scores),
-            },
+            details=details,
             sample_scores=sample_scores,
         )

--- a/src/raki/metrics/ragas/recall.py
+++ b/src/raki/metrics/ragas/recall.py
@@ -9,7 +9,12 @@ import logging
 
 from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
-from raki.metrics.ragas.adapter import is_max_tokens_error, to_ragas_rows
+from raki.metrics.ragas.adapter import (
+    InstructorSilentZeroError,
+    is_instructor_silent_zero,
+    is_max_tokens_error,
+    to_ragas_rows,
+)
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
 from raki.model import EvalDataset
@@ -61,6 +66,7 @@ class ContextRecallMetric:
         sample_scores: dict[str, float] = {}
         scores: list[float] = []
         max_tokens_failures: list[str] = []
+        silent_zero_failures: list[str] = []
 
         async def score_all():
             semaphore = asyncio.Semaphore(config.batch_size)
@@ -73,6 +79,12 @@ class ContextRecallMetric:
                             retrieved_contexts=row.retrieved_contexts,
                             reference=row.reference,
                         )
+                        if is_instructor_silent_zero(result, config.llm_provider):
+                            raise InstructorSilentZeroError(
+                                f"instructor#1658: Google provider returned silent 0.0 "
+                                f"for session {row.session_id}; treating as failure to "
+                                "avoid polluting metric average"
+                            )
                         score = result if isinstance(result, float) else result.value
                         scores.append(score)
                         sample_scores[row.session_id] = score
@@ -83,6 +95,8 @@ class ContextRecallMetric:
                         safe_error = redact_sensitive(f"ERROR: {exc}")
                         if is_max_tokens_error(exc):
                             max_tokens_failures.append(row.session_id)
+                        elif isinstance(exc, InstructorSilentZeroError):
+                            silent_zero_failures.append(row.session_id)
                         logger.warning(
                             "context_recall scoring failed for session %s: %s",
                             row.session_id,
@@ -103,6 +117,20 @@ class ContextRecallMetric:
                 details={
                     "skipped": "max_tokens: all sessions exceeded output token limit",
                     "max_tokens_sessions": len(max_tokens_failures),
+                },
+            )
+
+        # If all failures were instructor#1658 silent-zero errors, return score=None
+        if not scores and silent_zero_failures:
+            return MetricResult(
+                name=self.name,
+                score=None,
+                details={
+                    "skipped": (
+                        "instructor#1658: Google provider returned only silent 0.0 scores; "
+                        "possible structured-output parsing failures"
+                    ),
+                    "silent_zero_sessions": len(silent_zero_failures),
                 },
             )
 

--- a/src/raki/metrics/ragas/relevancy.py
+++ b/src/raki/metrics/ragas/relevancy.py
@@ -165,6 +165,14 @@ class AnswerRelevancyMetric:
                 "Designed for NL answers, not code -- scores may be noisy for agentic sessions"
             ),
         }
+        if max_tokens_failures:
+            details["max_tokens_sessions"] = len(max_tokens_failures)
+        if silent_zero_failures:
+            details["silent_zero_sessions"] = len(silent_zero_failures)
+            details["silent_zero_warning"] = (
+                f"instructor#1658: {len(silent_zero_failures)} session(s) returned silent 0.0 "
+                "from Google provider and were excluded from the score"
+            )
         if context_source is not None:
             details["context_source"] = context_source
 

--- a/src/raki/metrics/ragas/relevancy.py
+++ b/src/raki/metrics/ragas/relevancy.py
@@ -12,7 +12,13 @@ import logging
 
 from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
-from raki.metrics.ragas.adapter import detect_context_source, is_max_tokens_error, to_ragas_rows
+from raki.metrics.ragas.adapter import (
+    InstructorSilentZeroError,
+    detect_context_source,
+    is_instructor_silent_zero,
+    is_max_tokens_error,
+    to_ragas_rows,
+)
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_embeddings, create_ragas_llm
 from raki.model import EvalDataset
@@ -79,6 +85,7 @@ class AnswerRelevancyMetric:
         sample_scores: dict[str, float] = {}
         scores: list[float] = []
         max_tokens_failures: list[str] = []
+        silent_zero_failures: list[str] = []
 
         async def score_all():
             semaphore = asyncio.Semaphore(config.batch_size)
@@ -90,6 +97,12 @@ class AnswerRelevancyMetric:
                             user_input=row.user_input,
                             response=row.response,
                         )
+                        if is_instructor_silent_zero(result, config.llm_provider):
+                            raise InstructorSilentZeroError(
+                                f"instructor#1658: Google provider returned silent 0.0 "
+                                f"for session {row.session_id}; treating as failure to "
+                                "avoid polluting metric average"
+                            )
                         score = result if isinstance(result, float) else result.value
                         scores.append(score)
                         sample_scores[row.session_id] = score
@@ -100,6 +113,8 @@ class AnswerRelevancyMetric:
                         safe_error = redact_sensitive(f"ERROR: {exc}")
                         if is_max_tokens_error(exc):
                             max_tokens_failures.append(row.session_id)
+                        elif isinstance(exc, InstructorSilentZeroError):
+                            silent_zero_failures.append(row.session_id)
                         logger.warning(
                             "answer_relevancy scoring failed for session %s: %s",
                             row.session_id,
@@ -120,6 +135,20 @@ class AnswerRelevancyMetric:
                 details={
                     "skipped": "max_tokens: all sessions exceeded output token limit",
                     "max_tokens_sessions": len(max_tokens_failures),
+                },
+            )
+
+        # If all failures were instructor#1658 silent-zero errors, return score=None
+        if not scores and silent_zero_failures:
+            return MetricResult(
+                name=self.name,
+                score=None,
+                details={
+                    "skipped": (
+                        "instructor#1658: Google provider returned only silent 0.0 scores; "
+                        "possible structured-output parsing failures"
+                    ),
+                    "silent_zero_sessions": len(silent_zero_failures),
                 },
             )
 

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -26,8 +26,10 @@ from raki.metrics.ragas.adapter import (
     MAX_REFERENCE_CHARS,
     MAX_REFERENCE_CHUNKS,
     MAX_RESPONSE_CHARS,
+    InstructorSilentZeroError,
     RagasRow,
     _extract_response_summary,
+    is_instructor_silent_zero,
     select_relevant_chunks,
     to_ragas_rows,
     truncate_for_ragas,
@@ -1620,6 +1622,444 @@ class TestGoogleProvider:
         mock_genai.Client.assert_called_once_with(
             vertexai=True, project="test-project", location="us-central1"
         )
+
+
+# ---------------------------------------------------------------------------
+# instructor#1658 silent-zero detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsInstructorSilentZero:
+    """Tests for the is_instructor_silent_zero() detection function."""
+
+    def test_returns_true_for_google_zero_no_reason(self):
+        """Google provider + zero value + no reason → silent-zero detected."""
+        result = MagicMock()
+        result.value = 0.0
+        result.reason = None
+        assert is_instructor_silent_zero(result, "google") is True
+
+    def test_returns_true_for_google_zero_empty_reason(self):
+        """Empty-string reason is also considered 'no reason'."""
+        result = MagicMock()
+        result.value = 0.0
+        result.reason = ""
+        assert is_instructor_silent_zero(result, "google") is True
+
+    def test_returns_false_for_google_zero_with_reason(self):
+        """When reason is present, 0.0 is a legitimate score, not a silent failure."""
+        result = MagicMock()
+        result.value = 0.0
+        result.reason = "No relevant context found for the question"
+        assert is_instructor_silent_zero(result, "google") is False
+
+    def test_returns_false_for_google_nonzero_no_reason(self):
+        """Non-zero value with no reason is not the silent-zero bug."""
+        result = MagicMock()
+        result.value = 0.85
+        result.reason = None
+        assert is_instructor_silent_zero(result, "google") is False
+
+    def test_returns_false_for_anthropic_zero_no_reason(self):
+        """Silent-zero detection applies only to the google provider."""
+        result = MagicMock()
+        result.value = 0.0
+        result.reason = None
+        assert is_instructor_silent_zero(result, "anthropic") is False
+
+    def test_returns_false_for_vertex_anthropic_zero_no_reason(self):
+        """vertex-anthropic provider is not affected by instructor#1658."""
+        result = MagicMock()
+        result.value = 0.0
+        result.reason = None
+        assert is_instructor_silent_zero(result, "vertex-anthropic") is False
+
+    def test_returns_false_for_plain_float_result(self):
+        """A plain float return from ascore() bypasses structured-output parsing entirely."""
+        assert is_instructor_silent_zero(0.0, "google") is False
+
+    def test_instructor_silent_zero_error_is_runtime_error(self):
+        """InstructorSilentZeroError must subclass RuntimeError for consistent handling."""
+        exc = InstructorSilentZeroError("test message")
+        assert isinstance(exc, RuntimeError)
+
+    def test_instructor_silent_zero_error_message(self):
+        """Error message should mention instructor#1658 for traceability."""
+        msg = "instructor#1658: silent zero"
+        exc = InstructorSilentZeroError(msg)
+        assert "instructor#1658" in str(exc)
+
+
+class TestSilentZeroHandlingFaithfulness:
+    """Faithfulness metric skips sessions with instructor#1658 silent-zero scores."""
+
+    def test_silent_zero_skipped_not_averaged(self, monkeypatch: pytest.MonkeyPatch):
+        """When Google returns 0.0 with no reason, session is skipped, not averaged."""
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.0
+        mock_result.reason = None  # instructor#1658 silent zero
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_faithfulness_class, "Faithfulness")
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig(llm_provider="google")
+
+        with patch(
+            "raki.metrics.ragas.faithfulness.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = FaithfulnessMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score is None
+        assert "instructor#1658" in result.details.get("skipped", "")
+        assert result.details.get("silent_zero_sessions") == 1
+
+    def test_legitimate_zero_from_google_with_reason_is_kept(self, monkeypatch: pytest.MonkeyPatch):
+        """When Google returns 0.0 with a reason, it is a real score and must be included."""
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.0
+        mock_result.reason = "No faithful statements found"
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_faithfulness_class, "Faithfulness")
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig(llm_provider="google")
+
+        with patch(
+            "raki.metrics.ragas.faithfulness.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = FaithfulnessMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.0)
+        assert result.details["samples_scored"] == 1
+
+    def test_non_google_zero_no_reason_is_kept(self, monkeypatch: pytest.MonkeyPatch):
+        """Silent-zero guard only fires for google; anthropic 0.0 without reason is kept."""
+        from raki.metrics.ragas.faithfulness import FaithfulnessMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.0
+        mock_result.reason = None
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_faithfulness_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_faithfulness_class, "Faithfulness")
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig(llm_provider="anthropic")
+
+        with patch(
+            "raki.metrics.ragas.faithfulness.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = FaithfulnessMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.0)
+        assert result.details["samples_scored"] == 1
+
+
+class TestSilentZeroHandlingPrecision:
+    """ContextPrecision metric skips sessions with instructor#1658 silent-zero scores."""
+
+    def test_silent_zero_skipped_not_averaged(self, monkeypatch: pytest.MonkeyPatch):
+        """When Google returns 0.0 with no reason, session is skipped, not averaged."""
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.0
+        mock_result.reason = None  # instructor#1658 silent zero
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_precision_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_precision_class, "ContextPrecisionWithReference")
+
+        ground_truth = GroundTruth(
+            question="How to validate?",
+            reference_answer="Use pydantic",
+            domains=["validation"],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig(llm_provider="google")
+
+        with patch(
+            "raki.metrics.ragas.precision.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextPrecisionMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score is None
+        assert "instructor#1658" in result.details.get("skipped", "")
+        assert result.details.get("silent_zero_sessions") == 1
+
+    def test_legitimate_zero_from_google_with_reason_is_kept(self, monkeypatch: pytest.MonkeyPatch):
+        """When Google returns 0.0 with a reason, it is a real score."""
+        from raki.metrics.ragas.precision import ContextPrecisionMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.0
+        mock_result.reason = "No relevant context found"
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_precision_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_precision_class, "ContextPrecisionWithReference")
+
+        ground_truth = GroundTruth(
+            question="Q?",
+            reference_answer="A",
+            domains=[],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig(llm_provider="google")
+
+        with patch(
+            "raki.metrics.ragas.precision.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextPrecisionMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.0)
+        assert result.details["samples_scored"] == 1
+
+
+class TestSilentZeroHandlingRecall:
+    """ContextRecall metric skips sessions with instructor#1658 silent-zero scores."""
+
+    def test_silent_zero_skipped_not_averaged(self, monkeypatch: pytest.MonkeyPatch):
+        """When Google returns 0.0 with no reason, session is skipped, not averaged."""
+        from raki.metrics.ragas.recall import ContextRecallMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.0
+        mock_result.reason = None  # instructor#1658 silent zero
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_recall_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_recall_class, "ContextRecall")
+
+        ground_truth = GroundTruth(
+            question="How to validate?",
+            reference_answer="Use pydantic",
+            domains=["validation"],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig(llm_provider="google")
+
+        with patch(
+            "raki.metrics.ragas.recall.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextRecallMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score is None
+        assert "instructor#1658" in result.details.get("skipped", "")
+        assert result.details.get("silent_zero_sessions") == 1
+
+    def test_legitimate_zero_from_google_with_reason_is_kept(self, monkeypatch: pytest.MonkeyPatch):
+        """When Google returns 0.0 with a reason, it is a real score."""
+        from raki.metrics.ragas.recall import ContextRecallMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.0
+        mock_result.reason = "No recall found"
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_recall_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_recall_class, "ContextRecall")
+
+        ground_truth = GroundTruth(
+            question="Q?",
+            reference_answer="A",
+            domains=[],
+        )
+        sample = _make_sample_with_knowledge(ground_truth=ground_truth)
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig(llm_provider="google")
+
+        with patch(
+            "raki.metrics.ragas.recall.create_ragas_llm",
+            return_value=MagicMock(),
+        ):
+            metric = ContextRecallMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.0)
+        assert result.details["samples_scored"] == 1
+
+
+class TestSilentZeroHandlingRelevancy:
+    """AnswerRelevancy metric skips sessions with instructor#1658 silent-zero scores."""
+
+    def test_silent_zero_skipped_not_averaged(self, monkeypatch: pytest.MonkeyPatch):
+        """When Google returns 0.0 with no reason, session is skipped, not averaged."""
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.0
+        mock_result.reason = None  # instructor#1658 silent zero
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_relevancy_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_relevancy_class, "AnswerRelevancy")
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig(llm_provider="google")
+
+        with (
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_llm",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_embeddings",
+                return_value=MagicMock(),
+            ),
+        ):
+            metric = AnswerRelevancyMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score is None
+        assert "instructor#1658" in result.details.get("skipped", "")
+        assert result.details.get("silent_zero_sessions") == 1
+
+    def test_legitimate_zero_from_google_with_reason_is_kept(self, monkeypatch: pytest.MonkeyPatch):
+        """When Google returns 0.0 with a reason, it is a real score."""
+        from raki.metrics.ragas.relevancy import AnswerRelevancyMetric
+
+        mock_result = MagicMock()
+        mock_result.value = 0.0
+        mock_result.reason = "The response does not address the question"
+
+        mock_metric_instance = MagicMock()
+        mock_metric_instance.ascore = AsyncMock(return_value=mock_result)
+
+        mock_relevancy_class = MagicMock(return_value=mock_metric_instance)
+        _install_ragas_mock(monkeypatch, mock_relevancy_class, "AnswerRelevancy")
+
+        sample = _make_sample_with_knowledge()
+        dataset = EvalDataset(samples=[sample])
+        config = MetricConfig(llm_provider="google")
+
+        with (
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_llm",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "raki.metrics.ragas.relevancy.create_ragas_embeddings",
+                return_value=MagicMock(),
+            ),
+        ):
+            metric = AnswerRelevancyMetric()
+            result = metric.compute(dataset, config)
+
+        assert result.score == pytest.approx(0.0)
+        assert result.details["samples_scored"] == 1
+
+
+class TestGoogleProviderTopPRemoval:
+    """Google provider must have top_p removed from model_args (mirrors Anthropic fix)."""
+
+    def test_google_provider_pops_top_p_from_model_args(self, monkeypatch):
+        """top_p must be removed from Google LLM model_args to prevent API rejection."""
+        import sys
+
+        mock_client = MagicMock()
+        mock_genai = MagicMock()
+        mock_genai.Client.return_value = mock_client
+        mock_google_module = MagicMock()
+        mock_google_module.genai = mock_genai
+        monkeypatch.setitem(sys.modules, "google", mock_google_module)
+        monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
+
+        # LLM returned by factory has top_p in model_args
+        mock_llm = MagicMock()
+        mock_llm.model_args = {"temperature": 0.0, "top_p": 0.9, "max_tokens": 4096}
+        mock_factory = MagicMock(return_value=mock_llm)
+        monkeypatch.setitem(sys.modules, "ragas.llms", MagicMock(llm_factory=mock_factory))
+
+        from importlib import reload
+
+        from raki.metrics.ragas import llm_setup
+
+        reload(llm_setup)
+
+        config = MetricConfig(llm_provider="google", llm_model="gemini-2.5-pro")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+        monkeypatch.setenv("VERTEXAI_LOCATION", "us-central1")
+
+        result = llm_setup.create_ragas_llm(config)
+
+        # top_p must have been removed
+        assert "top_p" not in result.model_args
+
+    def test_google_provider_top_p_removal_is_safe_when_absent(self, monkeypatch):
+        """Removing top_p when not present must not raise KeyError."""
+        import sys
+
+        mock_client = MagicMock()
+        mock_genai = MagicMock()
+        mock_genai.Client.return_value = mock_client
+        mock_google_module = MagicMock()
+        mock_google_module.genai = mock_genai
+        monkeypatch.setitem(sys.modules, "google", mock_google_module)
+        monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
+
+        # LLM returned by factory has no top_p
+        mock_llm = MagicMock()
+        mock_llm.model_args = {"temperature": 0.0, "max_tokens": 4096}
+        mock_factory = MagicMock(return_value=mock_llm)
+        monkeypatch.setitem(sys.modules, "ragas.llms", MagicMock(llm_factory=mock_factory))
+
+        from importlib import reload
+
+        from raki.metrics.ragas import llm_setup
+
+        reload(llm_setup)
+
+        config = MetricConfig(llm_provider="google", llm_model="gemini-2.5-pro")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+
+        # Must not raise
+        result = llm_setup.create_ragas_llm(config)
+        assert result is mock_llm
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Detects when the `instructor` library silently returns `value=0.0` / `reason=None` (instead of raising a `ValidationError`) for Google/Gemini structured output (upstream bug [instructor#1658](https://github.com/jxnl/instructor/issues/1658))
- Adds `InstructorSilentZeroError` and `is_instructor_silent_zero()` in `src/raki/metrics/ragas/adapter.py`; integrates detection in all four Ragas metric scorers (faithfulness, precision, recall, relevancy)
- Returns `score=None` (N/A) when every session in a run hits a silent-zero failure, preventing misleading 0.0 averages
- Removes `top_p` from Google LLM `model_args` (mirrors existing Anthropic fix) to prevent API rejection

## Acceptance Criteria

- [x] Silent-zero detection fires only for `provider=="google"` with `value==0.0` AND no reason
- [x] Legitimate 0.0 scores (with a reason) are preserved
- [x] `score=None` returned when all sessions hit silent-zero failures
- [x] `top_p` removed from Google LLM path
- [x] 20 new unit tests added and passing
- [x] All 926 tests pass (4 slow/LLM integration tests deselected per convention)
- [x] No pre-commit hook failures (ruff check, ruff format, ty check)
- [x] Merge conflict in `tests/test_cli.py` resolved (kept ruff-formatted multi-line signature)

## Review Results

### Verification ✅
926 passed, 4 deselected. All 20 new tests pass. `ruff check`, `ruff format`, and `ty check` clean. `raki validate --deep` operational metrics compute successfully. The 12 `warning[unused-ignore-comment]` diagnostics from `ty` are all pre-existing on the base branch.

### Code Review 🔴 → ✅ (rework applied)
**CRITICAL (fixed):** Unresolved Git conflict markers in `tests/test_cli.py` at lines 1623–1629 caused a `SyntaxError`. Resolved by keeping the ruff-formatted multi-line method signature and removing the conflict markers.

**Minor (acknowledged, non-blocking):** No partial-success test (some sessions succeed, some hit silent zero). Pre-existing `0.0` fallback when `scores` is empty and no recognized failure type was tracked — not introduced by this PR.

## Refs

Refs #169

---

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko