### PR TITLE
feat(report): serialize judge config fields into report JSON (#173)

### DIFF
--- a/changes/173.feature
+++ b/changes/173.feature
@@ -1,0 +1,1 @@
+Serialize judge configuration fields (``llm_provider``, ``llm_model``, ``temperature``, ``batch_size``) into the report JSON ``config`` dict. This enables reproducibility auditing and debugging of differing scores across runs with different judge settings.

--- a/src/raki/metrics/engine.py
+++ b/src/raki/metrics/engine.py
@@ -31,7 +31,10 @@ class MetricsEngine:
         return EvalReport(
             run_id=f"eval-{uuid.uuid4().hex[:8]}",
             config={
+                "llm_provider": self._config.llm_provider,
                 "llm_model": self._config.llm_model,
+                "temperature": self._config.temperature,
+                "batch_size": self._config.batch_size,
                 "metrics": [metric.name for metric in self._metrics],
                 "skip_llm": skip_llm,
             },

--- a/src/raki/metrics/engine.py
+++ b/src/raki/metrics/engine.py
@@ -28,13 +28,14 @@ class MetricsEngine:
         aggregate = {result.name: result.score for result in results}
         details = {result.name: result.details for result in results if result.details}
         sample_results = self._build_sample_results(dataset, results)
+        llm_used = not skip_llm
         return EvalReport(
             run_id=f"eval-{uuid.uuid4().hex[:8]}",
             config={
-                "llm_provider": self._config.llm_provider,
-                "llm_model": self._config.llm_model,
-                "temperature": self._config.temperature,
-                "batch_size": self._config.batch_size,
+                "llm_provider": self._config.llm_provider if llm_used else None,
+                "llm_model": self._config.llm_model if llm_used else None,
+                "llm_temperature": self._config.temperature if llm_used else None,
+                "llm_max_tokens": self._config.max_tokens if llm_used else None,
                 "metrics": [metric.name for metric in self._metrics],
                 "skip_llm": skip_llm,
             },

--- a/src/raki/metrics/protocol.py
+++ b/src/raki/metrics/protocol.py
@@ -17,6 +17,7 @@ class MetricConfig(BaseModel):
     llm_provider: LLMProvider = "vertex-anthropic"
     llm_model: str = "claude-sonnet-4-6"
     temperature: float = 0.0
+    max_tokens: int | None = None
     batch_size: int = 4
     judge_log_path: Path | None = None  # path to judge_log.jsonl for audit logging
     project_root: Path | None = None  # root directory for path validation

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -114,6 +114,88 @@ class TestJsonReportRoundTrip:
         assert loaded.timestamp.tzinfo is not None
 
 
+class TestJudgeConfigSerialization:
+    """Tests for serialization of judge configuration fields into the report JSON."""
+
+    def test_engine_serializes_llm_provider_into_config(self) -> None:
+        """MetricsEngine must serialize llm_provider into the report config dict."""
+        from raki.metrics.engine import MetricsEngine
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+        from raki.metrics.protocol import MetricConfig
+
+        sample = make_sample("s1")
+        dataset = make_dataset(sample)
+        config = MetricConfig(llm_provider="anthropic", llm_model="claude-3-5-sonnet")
+        engine = MetricsEngine([TokenEfficiencyMetric()], config=config)
+        report = engine.run(dataset)
+        assert report.config["llm_provider"] == "anthropic"
+
+    def test_engine_serializes_batch_size_into_config(self) -> None:
+        """MetricsEngine must serialize batch_size into the report config dict."""
+        from raki.metrics.engine import MetricsEngine
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+        from raki.metrics.protocol import MetricConfig
+
+        sample = make_sample("s1")
+        dataset = make_dataset(sample)
+        config = MetricConfig(batch_size=8)
+        engine = MetricsEngine([TokenEfficiencyMetric()], config=config)
+        report = engine.run(dataset)
+        assert report.config["batch_size"] == 8
+
+    def test_engine_serializes_temperature_into_config(self) -> None:
+        """MetricsEngine must serialize temperature into the report config dict."""
+        from raki.metrics.engine import MetricsEngine
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+        from raki.metrics.protocol import MetricConfig
+
+        sample = make_sample("s1")
+        dataset = make_dataset(sample)
+        config = MetricConfig(temperature=0.5)
+        engine = MetricsEngine([TokenEfficiencyMetric()], config=config)
+        report = engine.run(dataset)
+        assert report.config["temperature"] == 0.5
+
+    def test_judge_config_fields_round_trip_in_json(self, tmp_path: Path) -> None:
+        """Judge config fields must survive a write/load JSON round-trip."""
+        from raki.metrics.engine import MetricsEngine
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+        from raki.metrics.protocol import MetricConfig
+
+        sample = make_sample("s1")
+        dataset = make_dataset(sample)
+        config = MetricConfig(
+            llm_provider="vertex-anthropic",
+            llm_model="claude-sonnet-4-6",
+            batch_size=4,
+            temperature=0.0,
+        )
+        engine = MetricsEngine([TokenEfficiencyMetric()], config=config)
+        report = engine.run(dataset)
+        output_path = tmp_path / "report.json"
+        write_json_report(report, output_path)
+        raw = json.loads(output_path.read_text())
+        assert raw["config"]["llm_provider"] == "vertex-anthropic"
+        assert raw["config"]["llm_model"] == "claude-sonnet-4-6"
+        assert raw["config"]["batch_size"] == 4
+        assert raw["config"]["temperature"] == 0.0
+
+    def test_default_judge_config_fields_present(self) -> None:
+        """Default judge config values must appear in the report config dict."""
+        from raki.metrics.engine import MetricsEngine
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+        from raki.metrics.protocol import MetricConfig
+
+        sample = make_sample("s1")
+        dataset = make_dataset(sample)
+        engine = MetricsEngine([TokenEfficiencyMetric()], config=MetricConfig())
+        report = engine.run(dataset)
+        assert "llm_provider" in report.config
+        assert "batch_size" in report.config
+        assert "temperature" in report.config
+        assert "llm_model" in report.config
+
+
 class TestJsonReportContextSource:
     def test_context_source_included_in_json_output(self, tmp_path: Path) -> None:
         """context_source field should be included in JSON report sample results."""

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -130,21 +130,8 @@ class TestJudgeConfigSerialization:
         report = engine.run(dataset)
         assert report.config["llm_provider"] == "anthropic"
 
-    def test_engine_serializes_batch_size_into_config(self) -> None:
-        """MetricsEngine must serialize batch_size into the report config dict."""
-        from raki.metrics.engine import MetricsEngine
-        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
-        from raki.metrics.protocol import MetricConfig
-
-        sample = make_sample("s1")
-        dataset = make_dataset(sample)
-        config = MetricConfig(batch_size=8)
-        engine = MetricsEngine([TokenEfficiencyMetric()], config=config)
-        report = engine.run(dataset)
-        assert report.config["batch_size"] == 8
-
-    def test_engine_serializes_temperature_into_config(self) -> None:
-        """MetricsEngine must serialize temperature into the report config dict."""
+    def test_engine_serializes_llm_temperature_into_config(self) -> None:
+        """MetricsEngine must serialize llm_temperature into the report config dict."""
         from raki.metrics.engine import MetricsEngine
         from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
         from raki.metrics.protocol import MetricConfig
@@ -154,7 +141,41 @@ class TestJudgeConfigSerialization:
         config = MetricConfig(temperature=0.5)
         engine = MetricsEngine([TokenEfficiencyMetric()], config=config)
         report = engine.run(dataset)
-        assert report.config["temperature"] == 0.5
+        assert report.config["llm_temperature"] == 0.5
+
+    def test_engine_serializes_llm_max_tokens_into_config(self) -> None:
+        """MetricsEngine must serialize llm_max_tokens into the report config dict."""
+        from raki.metrics.engine import MetricsEngine
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+        from raki.metrics.protocol import MetricConfig
+
+        sample = make_sample("s1")
+        dataset = make_dataset(sample)
+        config = MetricConfig(max_tokens=4096)
+        engine = MetricsEngine([TokenEfficiencyMetric()], config=config)
+        report = engine.run(dataset)
+        assert report.config["llm_max_tokens"] == 4096
+
+    def test_judge_fields_none_when_skip_llm(self) -> None:
+        """When skip_llm=True, all judge fields must be None in report config."""
+        from raki.metrics.engine import MetricsEngine
+        from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+        from raki.metrics.protocol import MetricConfig
+
+        sample = make_sample("s1")
+        dataset = make_dataset(sample)
+        config = MetricConfig(
+            llm_provider="vertex-anthropic",
+            llm_model="claude-sonnet-4-6",
+            temperature=0.5,
+            max_tokens=4096,
+        )
+        engine = MetricsEngine([TokenEfficiencyMetric()], config=config)
+        report = engine.run(dataset, skip_llm=True)
+        assert report.config["llm_provider"] is None
+        assert report.config["llm_model"] is None
+        assert report.config["llm_temperature"] is None
+        assert report.config["llm_max_tokens"] is None
 
     def test_judge_config_fields_round_trip_in_json(self, tmp_path: Path) -> None:
         """Judge config fields must survive a write/load JSON round-trip."""
@@ -167,8 +188,8 @@ class TestJudgeConfigSerialization:
         config = MetricConfig(
             llm_provider="vertex-anthropic",
             llm_model="claude-sonnet-4-6",
-            batch_size=4,
             temperature=0.0,
+            max_tokens=4096,
         )
         engine = MetricsEngine([TokenEfficiencyMetric()], config=config)
         report = engine.run(dataset)
@@ -177,8 +198,30 @@ class TestJudgeConfigSerialization:
         raw = json.loads(output_path.read_text())
         assert raw["config"]["llm_provider"] == "vertex-anthropic"
         assert raw["config"]["llm_model"] == "claude-sonnet-4-6"
-        assert raw["config"]["batch_size"] == 4
-        assert raw["config"]["temperature"] == 0.0
+        assert raw["config"]["llm_temperature"] == 0.0
+        assert raw["config"]["llm_max_tokens"] == 4096
+
+    def test_old_report_without_judge_fields_loads_cleanly(self, tmp_path: Path) -> None:
+        """Old JSON reports without llm_temperature/llm_max_tokens must load without error."""
+        old_report = {
+            "run_id": "eval-old",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "config": {
+                "llm_model": "claude-sonnet-4-6",
+                "metrics": ["cost_efficiency"],
+                "skip_llm": False,
+            },
+            "aggregate_scores": {"cost_efficiency": 1.5},
+            "metric_details": {},
+            "sample_results": [],
+            "manifest_hash": None,
+        }
+        output_path = tmp_path / "old-report.json"
+        output_path.write_text(json.dumps(old_report))
+        loaded = load_json_report(output_path)
+        assert loaded.run_id == "eval-old"
+        assert loaded.config.get("llm_temperature") is None
+        assert loaded.config.get("llm_max_tokens") is None
 
     def test_default_judge_config_fields_present(self) -> None:
         """Default judge config values must appear in the report config dict."""
@@ -191,9 +234,9 @@ class TestJudgeConfigSerialization:
         engine = MetricsEngine([TokenEfficiencyMetric()], config=MetricConfig())
         report = engine.run(dataset)
         assert "llm_provider" in report.config
-        assert "batch_size" in report.config
-        assert "temperature" in report.config
         assert "llm_model" in report.config
+        assert "llm_temperature" in report.config
+        assert "llm_max_tokens" in report.config
 
 
 class TestJsonReportContextSource:


### PR DESCRIPTION
## Summary

Add `llm_provider`, `llm_temperature`, and `llm_max_tokens` to the report JSON config section, alongside the existing `llm_model`. This enables downstream `--diff` comparison to detect judge calibration differences (handled in follow-up #187).

Refs #173

## Changes

- `src/raki/metrics/protocol.py`: Add `max_tokens: int | None = None` to `MetricConfig`
- `src/raki/metrics/engine.py`: Serialize all four judge fields (`llm_provider`, `llm_model`, `llm_temperature`, `llm_max_tokens`) into report config; null all when `skip_llm=True`
- `tests/test_report.py`: Tests for serialization, skip_llm nulling, old report backward compat, round-trip

## Backward compatibility

Old reports without `llm_temperature`/`llm_max_tokens` load without error — `dict.get()` returns None.

## Test plan

- [x] 933 tests pass (`uv run pytest tests/ -v -m "not slow"`)
- [x] Lint clean (`ruff check`, `ruff format --check`)
- [x] Type check clean (`ty check`)

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)