### PR TITLE
feat(report): warn when judge configs differ in --diff comparison (#187)

### DIFF
--- a/changes/187.feature
+++ b/changes/187.feature
@@ -1,0 +1,1 @@
+Warn when judge configurations differ in ``--diff`` comparison. When ``raki report --diff`` compares two reports that used different LLM judge settings (model or provider), a yellow warning is now shown so users know the retrieval quality scores may not be directly comparable.

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -379,6 +379,12 @@ def print_diff_summary(
         f"Comparing [bold]{diff.baseline_run_id}[/bold] → [bold]{diff.compare_run_id}[/bold]"
     )
 
+    # Judge config mismatch warnings
+    if diff.judge_config_mismatch:
+        for warning_message in diff.judge_config_mismatch:
+            output_console.print(f"[yellow]Warning: {warning_message}[/yellow]")
+        output_console.print()
+
     # Coverage line
     match_result = diff.match_result
     matched_count = len(match_result.matched_ids)

--- a/src/raki/report/diff.py
+++ b/src/raki/report/diff.py
@@ -89,11 +89,7 @@ def compare_judge_configs(baseline: EvalReport, compare: EvalReport) -> list[str
 
     # One used a judge, the other did not
     if baseline_skip != compare_skip:
-        which = "compare" if baseline_skip else "baseline"
-        return [
-            f"judge was enabled in only one report ({which} has no judge metrics) "
-            f"— retrieval scores are not comparable"
-        ]
+        return ["unknown baseline — cannot compare judge calibration"]
 
     # Both used a judge — compare individual config fields
     warnings: list[str] = []

--- a/src/raki/report/diff.py
+++ b/src/raki/report/diff.py
@@ -50,6 +50,7 @@ class DiffReport:
     improvements: list[SessionTransition] = field(default_factory=list)
     regressions: list[SessionTransition] = field(default_factory=list)
     has_session_data: bool = True
+    judge_config_mismatch: list[str] = field(default_factory=list)
 
 
 # Verdict rank for sorting: lower rank = worse verdict
@@ -65,6 +66,49 @@ def is_higher_is_better(metric_name: str) -> bool:
     if meta is None:
         return True
     return bool(meta.get("higher_is_better", True))
+
+
+def compare_judge_configs(baseline: EvalReport, compare: EvalReport) -> list[str]:
+    """Return warning messages when judge configs differ between two reports.
+
+    Compares the ``llm_provider`` and ``llm_model`` fields stored in each report's
+    ``config`` dict.  Returns an empty list when:
+
+    - Neither report used a judge (``skip_llm=True`` or config absent).
+    - Both reports used identical judge settings.
+
+    Returns one warning per differing field when both used a judge with different
+    settings, or a single warning when only one report used a judge.
+    """
+    baseline_skip = bool(baseline.config.get("skip_llm", True))
+    compare_skip = bool(compare.config.get("skip_llm", True))
+
+    # Neither used a judge — nothing to compare
+    if baseline_skip and compare_skip:
+        return []
+
+    # One used a judge, the other did not
+    if baseline_skip != compare_skip:
+        which = "compare" if baseline_skip else "baseline"
+        return [
+            f"judge was enabled in only one report ({which} has no judge metrics) "
+            f"— retrieval scores are not comparable"
+        ]
+
+    # Both used a judge — compare individual config fields
+    warnings: list[str] = []
+    judge_fields = [
+        ("llm_provider", "judge provider"),
+        ("llm_model", "judge model"),
+    ]
+    for config_key, label in judge_fields:
+        baseline_val = baseline.config.get(config_key)
+        compare_val = compare.config.get(config_key)
+        if baseline_val != compare_val:
+            warnings.append(
+                f"{label} differs: {baseline_val!r} (baseline) vs {compare_val!r} (compare)"
+            )
+    return warnings
 
 
 def match_sessions(baseline: EvalReport, compare: EvalReport) -> MatchResult:
@@ -190,10 +234,12 @@ def compute_transitions(
 def generate_diff_report(baseline: EvalReport, compare: EvalReport) -> DiffReport:
     """Generate a complete diff report from two evaluation reports.
 
-    Computes session matching, metric deltas, and verdict transitions.
+    Computes session matching, metric deltas, verdict transitions, and warns
+    when the judge configuration differs between the two runs.
     """
     match_result = match_sessions(baseline, compare)
     deltas = compute_deltas(baseline.aggregate_scores, compare.aggregate_scores)
+    judge_warnings = compare_judge_configs(baseline, compare)
 
     has_session_data = bool(baseline.sample_results and compare.sample_results)
 
@@ -217,4 +263,5 @@ def generate_diff_report(baseline: EvalReport, compare: EvalReport) -> DiffRepor
         improvements=improvements,
         regressions=regressions,
         has_session_data=has_session_data,
+        judge_config_mismatch=judge_warnings,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -971,6 +971,7 @@ def _write_diff_report_json(
     session_ids: list[str] | None = None,
     rework_cycles: int = 0,
     verify_status: str = "completed",
+    config: dict | None = None,
 ) -> None:
     """Write a minimal EvalReport JSON file for diff testing."""
     scores = aggregate_scores or {
@@ -978,12 +979,14 @@ def _write_diff_report_json(
         "rework_cycles": 0.3,
         "cost_efficiency": 7.50,
     }
-    data = {
+    data: dict = {
         "run_id": run_id,
         "timestamp": "2026-04-10T00:00:00Z",
         "aggregate_scores": scores,
         "sample_results": [],
     }
+    if config is not None:
+        data["config"] = config
     if include_sessions and session_ids:
         for session_id in session_ids:
             verify_output = "PASS" if verify_status == "completed" else "FAIL"
@@ -1302,6 +1305,36 @@ class TestCliReportDiff:
         result = runner.invoke(main, ["report", "--diff", str(baseline), str(compare)])
         assert result.exit_code == 0
         assert "Improvement" in result.output or "improvement" in result.output.lower()
+
+    def test_diff_exit_code_0_with_judge_config_warnings(self, tmp_path):
+        """Judge config warnings should NOT affect exit code (still 0)."""
+        baseline = tmp_path / "baseline.json"
+        compare = tmp_path / "compare.json"
+        _write_diff_report_json(
+            baseline,
+            run_id="base",
+            aggregate_scores={"first_pass_success_rate": 0.78},
+            config={
+                "skip_llm": False,
+                "llm_provider": "anthropic",
+                "llm_model": "claude-opus-4",
+            },
+        )
+        _write_diff_report_json(
+            compare,
+            run_id="comp",
+            aggregate_scores={"first_pass_success_rate": 0.91},
+            config={
+                "skip_llm": False,
+                "llm_provider": "anthropic",
+                "llm_model": "claude-sonnet-4-6",
+            },
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "--diff", str(baseline), str(compare)])
+        assert result.exit_code == 0
+        assert "claude-opus-4" in result.output
+        assert "claude-sonnet-4-6" in result.output
 
 
 class TestCLIInversion:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -13,6 +13,7 @@ from raki.report.diff import (
     MatchResult,
     MetricDelta,
     SessionTransition,
+    compare_judge_configs,
     compute_deltas,
     compute_transitions,
     generate_diff_report,
@@ -31,6 +32,22 @@ def _make_eval_report(
     return EvalReport(
         run_id=run_id,
         timestamp=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        aggregate_scores=aggregate_scores,
+        sample_results=sample_results or [],
+    )
+
+
+def _make_eval_report_with_config(
+    run_id: str,
+    aggregate_scores: dict[str, float],
+    config: dict,
+    sample_results: list[SampleResult] | None = None,
+) -> EvalReport:
+    """Create an EvalReport with an explicit judge config dict for testing."""
+    return EvalReport(
+        run_id=run_id,
+        timestamp=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        config=config,
         aggregate_scores=aggregate_scores,
         sample_results=sample_results or [],
     )
@@ -601,3 +618,240 @@ class TestMetricDeltaDirection:
         compare_scores = {"some_new_metric": 0.7}
         deltas = compute_deltas(baseline_scores, compare_scores)
         assert deltas[0].direction == "improved"
+
+
+class TestCompareJudgeConfigs:
+    def test_both_skip_llm_returns_empty(self):
+        """When neither report used a judge, no warnings are returned."""
+        baseline = _make_eval_report_with_config("base", {}, config={"skip_llm": True})
+        compare = _make_eval_report_with_config("comp", {}, config={"skip_llm": True})
+        warnings = compare_judge_configs(baseline, compare)
+        assert warnings == []
+
+    def test_matching_judge_config_returns_empty(self):
+        """When both reports used the same judge config, no warnings."""
+        config = {
+            "skip_llm": False,
+            "llm_provider": "anthropic",
+            "llm_model": "claude-opus-4",
+        }
+        baseline = _make_eval_report_with_config("base", {}, config=config)
+        compare = _make_eval_report_with_config("comp", {}, config=config)
+        warnings = compare_judge_configs(baseline, compare)
+        assert warnings == []
+
+    def test_different_model_returns_warning(self):
+        """When reports used different LLM models, a warning is returned."""
+        baseline = _make_eval_report_with_config(
+            "base",
+            {},
+            config={"skip_llm": False, "llm_provider": "anthropic", "llm_model": "claude-opus-4"},
+        )
+        compare = _make_eval_report_with_config(
+            "comp",
+            {},
+            config={
+                "skip_llm": False,
+                "llm_provider": "anthropic",
+                "llm_model": "claude-sonnet-4-6",
+            },
+        )
+        warnings = compare_judge_configs(baseline, compare)
+        assert len(warnings) == 1
+        assert "model" in warnings[0].lower()
+        assert "claude-opus-4" in warnings[0]
+        assert "claude-sonnet-4-6" in warnings[0]
+
+    def test_different_provider_returns_warning(self):
+        """When reports used different LLM providers, a warning is returned."""
+        baseline = _make_eval_report_with_config(
+            "base",
+            {},
+            config={
+                "skip_llm": False,
+                "llm_provider": "anthropic",
+                "llm_model": "claude-opus-4",
+            },
+        )
+        compare = _make_eval_report_with_config(
+            "comp",
+            {},
+            config={"skip_llm": False, "llm_provider": "google", "llm_model": "claude-opus-4"},
+        )
+        warnings = compare_judge_configs(baseline, compare)
+        assert len(warnings) == 1
+        assert "provider" in warnings[0].lower()
+        assert "anthropic" in warnings[0]
+        assert "google" in warnings[0]
+
+    def test_both_model_and_provider_differ_returns_two_warnings(self):
+        """When both model and provider differ, two separate warnings are returned."""
+        baseline = _make_eval_report_with_config(
+            "base",
+            {},
+            config={
+                "skip_llm": False,
+                "llm_provider": "anthropic",
+                "llm_model": "claude-opus-4",
+            },
+        )
+        compare = _make_eval_report_with_config(
+            "comp",
+            {},
+            config={
+                "skip_llm": False,
+                "llm_provider": "google",
+                "llm_model": "gemini-pro",
+            },
+        )
+        warnings = compare_judge_configs(baseline, compare)
+        assert len(warnings) == 2
+
+    def test_one_uses_judge_other_does_not(self):
+        """When one report used a judge and the other did not, a warning is returned."""
+        baseline = _make_eval_report_with_config(
+            "base",
+            {},
+            config={
+                "skip_llm": False,
+                "llm_provider": "anthropic",
+                "llm_model": "claude-opus-4",
+            },
+        )
+        compare = _make_eval_report_with_config("comp", {}, config={"skip_llm": True})
+        warnings = compare_judge_configs(baseline, compare)
+        assert len(warnings) >= 1
+        assert any("judge" in warning.lower() for warning in warnings)
+
+    def test_missing_config_treated_as_no_judge(self):
+        """When config is missing (old reports), treated as skip_llm=True — no warnings."""
+        baseline = _make_eval_report("base", {})  # no config
+        compare = _make_eval_report("comp", {})  # no config
+        warnings = compare_judge_configs(baseline, compare)
+        assert warnings == []
+
+    def test_one_missing_config_one_has_judge(self):
+        """When one report has no config (old format) and the other used a judge, warn."""
+        baseline = _make_eval_report("base", {})  # no config
+        compare = _make_eval_report_with_config(
+            "comp",
+            {},
+            config={"skip_llm": False, "llm_provider": "anthropic", "llm_model": "claude-opus-4"},
+        )
+        warnings = compare_judge_configs(baseline, compare)
+        assert len(warnings) >= 1
+
+
+class TestDiffReportJudgeConfigMismatch:
+    def test_diff_report_has_judge_config_mismatch_field(self):
+        """DiffReport dataclass includes the judge_config_mismatch field."""
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(),
+        )
+        assert hasattr(diff, "judge_config_mismatch")
+        assert diff.judge_config_mismatch == []
+
+    def test_generate_diff_report_populates_judge_config_mismatch_when_models_differ(self):
+        """generate_diff_report populates judge_config_mismatch when LLM models differ."""
+        baseline = _make_eval_report_with_config(
+            "base",
+            {"faithfulness": 0.8},
+            config={
+                "skip_llm": False,
+                "llm_provider": "anthropic",
+                "llm_model": "claude-opus-4",
+            },
+        )
+        compare = _make_eval_report_with_config(
+            "comp",
+            {"faithfulness": 0.9},
+            config={
+                "skip_llm": False,
+                "llm_provider": "anthropic",
+                "llm_model": "claude-sonnet-4-6",
+            },
+        )
+        diff = generate_diff_report(baseline, compare)
+        assert len(diff.judge_config_mismatch) > 0
+
+    def test_generate_diff_report_no_mismatch_when_configs_match(self):
+        """generate_diff_report has empty judge_config_mismatch when configs are identical."""
+        config = {"skip_llm": False, "llm_provider": "anthropic", "llm_model": "claude-opus-4"}
+        baseline = _make_eval_report_with_config("base", {"faithfulness": 0.8}, config=config)
+        compare = _make_eval_report_with_config("comp", {"faithfulness": 0.9}, config=config)
+        diff = generate_diff_report(baseline, compare)
+        assert diff.judge_config_mismatch == []
+
+    def test_generate_diff_report_no_mismatch_when_no_judge_used(self):
+        """No warnings when both reports were run without --judge."""
+        baseline = _make_eval_report("base", {"first_pass_success_rate": 0.78})
+        compare = _make_eval_report("comp", {"first_pass_success_rate": 0.91})
+        diff = generate_diff_report(baseline, compare)
+        assert diff.judge_config_mismatch == []
+
+
+class TestPrintDiffSummaryJudgeConfigWarning:
+    def _capture_diff_output(self, diff: DiffReport) -> str:
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=False, width=120)
+        print_diff_summary(diff, console=test_console)
+        return string_io.getvalue()
+
+    def test_shows_judge_config_warning_when_model_differs(self):
+        """print_diff_summary shows a warning when judge models differ."""
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(matched_ids={"s1"}, baseline_total=1, compare_total=1),
+            judge_config_mismatch=[
+                "judge model differs: 'claude-opus-4' (baseline) vs 'claude-sonnet-4-6' (compare)"
+            ],
+        )
+        output = self._capture_diff_output(diff)
+        assert "claude-opus-4" in output
+        assert "claude-sonnet-4-6" in output
+
+    def test_shows_judge_config_warning_when_provider_differs(self):
+        """print_diff_summary shows a warning when judge providers differ."""
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(matched_ids={"s1"}, baseline_total=1, compare_total=1),
+            judge_config_mismatch=[
+                "judge provider differs: 'anthropic' (baseline) vs 'google' (compare)"
+            ],
+        )
+        output = self._capture_diff_output(diff)
+        assert "anthropic" in output
+        assert "google" in output
+
+    def test_no_judge_warning_when_no_mismatch(self):
+        """print_diff_summary does not emit judge config warnings when configs match."""
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(matched_ids={"s1"}, baseline_total=1, compare_total=1),
+            judge_config_mismatch=[],
+        )
+        output = self._capture_diff_output(diff)
+        assert "judge model" not in output.lower()
+        assert "judge provider" not in output.lower()
+
+    def test_warning_contains_yellow_markup_or_warning_word(self):
+        """Warning message uses yellow styling or the word 'warning'."""
+        diff = DiffReport(
+            baseline_run_id="base",
+            compare_run_id="comp",
+            match_result=MatchResult(matched_ids={"s1"}, baseline_total=1, compare_total=1),
+            judge_config_mismatch=["judge model differs: 'a' (baseline) vs 'b' (compare)"],
+        )
+        string_io = StringIO()
+        # Use force_terminal=True to capture markup / ANSI output
+        test_console = Console(file=string_io, force_terminal=True, width=120)
+        print_diff_summary(diff, console=test_console)
+        raw_output = string_io.getvalue()
+        # Either the raw ANSI contains yellow escape or the plain text has "warning"
+        plain_output = self._capture_diff_output(diff)
+        assert "warning" in plain_output.lower() or "yellow" in raw_output.lower()

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -720,8 +720,8 @@ class TestCompareJudgeConfigs:
         )
         compare = _make_eval_report_with_config("comp", {}, config={"skip_llm": True})
         warnings = compare_judge_configs(baseline, compare)
-        assert len(warnings) >= 1
-        assert any("judge" in warning.lower() for warning in warnings)
+        assert len(warnings) == 1
+        assert "unknown baseline — cannot compare judge calibration" in warnings[0]
 
     def test_missing_config_treated_as_no_judge(self):
         """When config is missing (old reports), treated as skip_llm=True — no warnings."""
@@ -739,7 +739,8 @@ class TestCompareJudgeConfigs:
             config={"skip_llm": False, "llm_provider": "anthropic", "llm_model": "claude-opus-4"},
         )
         warnings = compare_judge_configs(baseline, compare)
-        assert len(warnings) >= 1
+        assert len(warnings) == 1
+        assert "unknown baseline — cannot compare judge calibration" in warnings[0]
 
 
 class TestDiffReportJudgeConfigMismatch:


### PR DESCRIPTION
## Summary

When comparing reports via `--diff`, warn the user if judge configurations differ between baseline and compare reports. Different judge models/providers can explain metric deltas not caused by agent quality changes.

Refs #187

## Changes

- `src/raki/report/diff.py`: `compare_judge_configs()` function, `judge_config_mismatch` field on `DiffReport`
- `src/raki/report/cli_summary.py`: Yellow warnings in diff output
- `tests/test_diff.py`: 16 tests covering all warning scenarios
- `tests/test_cli.py`: CLI exit code test

## Test plan

- [x] 950 tests pass
- [x] Lint clean
- [x] "unknown baseline" exact text verified
- [x] Exit code 0 with differing configs verified

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>