### PR TITLE
feat: add pipeline/orchestrator metadata to session adapter (#175)

### DIFF
--- a/changes/175.feature
+++ b/changes/175.feature
@@ -1,0 +1,15 @@
+``SessionMeta`` gains three optional fields — ``orchestrator``, ``provider``, and
+``pipeline_phases`` — that expose pipeline/orchestrator metadata from each session.
+
+Both adapters now populate these fields automatically:
+
+- **session-schema**: ``orchestrator`` is inferred from the ``branch`` prefix (e.g.
+  ``"soda/101"`` → ``"soda"``); ``pipeline_phases`` is the ordered list of phase
+  names from the session's phases dict.
+- **alcove / bridge**: ``orchestrator`` is ``"bridge"`` for bridge-format sessions
+  and ``"alcove"`` for classic Claude Code transcripts; ``provider`` is taken from
+  the top-level ``provider`` field when present; ``pipeline_phases`` is populated
+  from the phases dict.
+
+All three fields default to ``None``, so existing code and serialised data are
+100% backward-compatible. (#175)

--- a/src/raki/adapters/alcove.py
+++ b/src/raki/adapters/alcove.py
@@ -338,6 +338,9 @@ class AlcoveAdapter:
             total_phases = _detect_phase_count(tool_sequence)
 
         ticket = task_name or session_id
+        orchestrator = "bridge" if is_bridge else "alcove"
+        provider: str | None = raw.get("provider")
+        pipeline_phases: list[str] | None = list(phases_dict.keys()) if phases_dict else None
         meta = SessionMeta(
             session_id=session_id,
             ticket=ticket if ticket != session_id else None,
@@ -346,6 +349,9 @@ class AlcoveAdapter:
             total_phases=total_phases,
             rework_cycles=rework_cycles,
             model_id=model_id,
+            orchestrator=orchestrator,
+            provider=provider,
+            pipeline_phases=pipeline_phases,
         )
 
         sample = EvalSample(

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -86,6 +86,11 @@ class SessionSchemaAdapter:
         if not model_id:
             model_id = _extract_model_id_from_events(events)
 
+        # Infer orchestrator from branch prefix, e.g. "soda/101" → "soda"
+        branch: str | None = meta_raw.get("branch")
+        orchestrator: str | None = branch.split("/")[0] if branch and "/" in branch else None
+        pipeline_phases: list[str] | None = list(phases_dict.keys()) if phases_dict else None
+
         meta = SessionMeta(
             session_id=session_id,
             ticket=str(meta_raw.get("ticket")),
@@ -94,6 +99,8 @@ class SessionSchemaAdapter:
             total_phases=len(phases_dict),
             rework_cycles=meta_raw.get("rework_cycles", 0),
             model_id=model_id,
+            orchestrator=orchestrator,
+            pipeline_phases=pipeline_phases,
         )
         phases = self._load_phases(source, meta_raw, events)
         findings = self._load_findings(source)

--- a/src/raki/model/dataset.py
+++ b/src/raki/model/dataset.py
@@ -18,6 +18,12 @@ class SessionMeta(BaseModel):
     rework_cycles: int
     knowledge_version: str | None = None
     model_id: str | None = None
+    # Pipeline/orchestrator metadata (ticket #175)
+    orchestrator: str | None = None  # e.g. "soda", "bridge", "alcove"
+    provider: str | None = (
+        None  # LLM provider reported by the orchestrator (distinct from MetricConfig.llm_provider)
+    )
+    pipeline_phases: list[str] | None = None  # ordered phase names from the session
 
 
 class EvalSample(BaseModel):

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -2677,3 +2677,123 @@ class TestSodaContextExtraction:
         adapter = SessionSchemaAdapter()
         sample = adapter.load(tmp_path)
         assert sample.context_source is None
+
+
+# --- Ticket #175: pipeline/orchestrator metadata ---
+
+
+def test_session_schema_orchestrator_from_branch_prefix(tmp_path):
+    """branch field 'soda/101' should yield orchestrator='soda'."""
+    meta = {
+        "ticket": "175",
+        "summary": "orchestrator inference",
+        "branch": "soda/101",
+        "started_at": "2026-04-24T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {"triage": {"status": "completed"}, "implement": {"status": "completed"}},
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    assert sample.session.orchestrator == "soda"
+
+
+def test_session_schema_orchestrator_none_without_branch(tmp_path):
+    """Without a branch field, orchestrator should be None."""
+    meta = {
+        "ticket": "175b",
+        "summary": "no orchestrator",
+        "started_at": "2026-04-24T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    assert sample.session.orchestrator is None
+
+
+def test_session_schema_orchestrator_none_branch_no_slash(tmp_path):
+    """A branch value without a slash yields orchestrator=None."""
+    meta = {
+        "ticket": "175c",
+        "summary": "branch no slash",
+        "branch": "main",
+        "started_at": "2026-04-24T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    assert sample.session.orchestrator is None
+
+
+def test_session_schema_pipeline_phases_from_phases_dict(tmp_path):
+    """pipeline_phases should reflect the ordered keys from meta.json phases dict."""
+    meta = {
+        "ticket": "175d",
+        "summary": "pipeline phases",
+        "branch": "soda/175",
+        "started_at": "2026-04-24T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {
+            "triage": {"status": "completed"},
+            "plan": {"status": "completed"},
+            "implement": {"status": "completed"},
+        },
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    assert sample.session.pipeline_phases == ["triage", "plan", "implement"]
+
+
+def test_session_schema_pipeline_phases_none_when_empty(tmp_path):
+    """pipeline_phases should be None when phases dict is empty."""
+    meta = {
+        "ticket": "175e",
+        "summary": "empty phases",
+        "started_at": "2026-04-24T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    assert sample.session.pipeline_phases is None
+
+
+def test_session_schema_provider_defaults_to_none(tmp_path):
+    """provider should always be None for session-schema adapter (not populated)."""
+    meta = {
+        "ticket": "175f",
+        "summary": "provider default",
+        "started_at": "2026-04-24T08:00:00Z",
+        "total_cost": 5.0,
+        "rework_cycles": 0,
+        "phases": {},
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "events.jsonl").write_text("")
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    assert sample.session.provider is None
+
+
+def test_session_schema_fixture_orchestrator(pass_simple_dir):
+    """pass-simple fixture has branch='soda/101' so orchestrator should be 'soda'."""
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(pass_simple_dir)
+    assert sample.session.orchestrator == "soda"
+    assert sample.session.pipeline_phases == ["triage", "plan", "implement", "verify", "review"]

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -2797,3 +2797,109 @@ def test_session_schema_fixture_orchestrator(pass_simple_dir):
     sample = adapter.load(pass_simple_dir)
     assert sample.session.orchestrator == "soda"
     assert sample.session.pipeline_phases == ["triage", "plan", "implement", "verify", "review"]
+
+
+# --- Ticket #175: AlcoveAdapter pipeline/orchestrator metadata ---
+
+
+def test_alcove_classic_orchestrator_is_alcove(tmp_path):
+    """Classic alcove format (no task_id) should yield orchestrator='alcove'."""
+    data = {
+        "session_id": "classic-001",
+        "transcript": [
+            {"type": "system", "model": "claude-sonnet-4-20250514"},
+            {
+                "type": "result",
+                "total_cost_usd": 0.01,
+                "duration_ms": 1000,
+            },
+        ],
+    }
+    fixture = tmp_path / "classic.json"
+    fixture.write_text(json.dumps(data))
+    adapter = AlcoveAdapter()
+    sample = adapter.load(fixture)
+    assert sample.session.orchestrator == "alcove"
+
+
+def test_alcove_bridge_orchestrator_is_bridge(tmp_path):
+    """Bridge format (has task_id) should yield orchestrator='bridge'."""
+    source = _bridge_session(tmp_path)
+    adapter = AlcoveAdapter()
+    sample = adapter.load(source)
+    assert sample.session.orchestrator == "bridge"
+
+
+def test_alcove_provider_from_raw(tmp_path):
+    """provider field in the JSON should be populated on SessionMeta.provider."""
+    data = {
+        "session_id": "prov-001",
+        "provider": "anthropic",
+        "transcript": [
+            {"type": "system", "model": "claude-sonnet-4-20250514"},
+            {"type": "result", "total_cost_usd": 0.01, "duration_ms": 1000},
+        ],
+    }
+    fixture = tmp_path / "provider-session.json"
+    fixture.write_text(json.dumps(data))
+    adapter = AlcoveAdapter()
+    sample = adapter.load(fixture)
+    assert sample.session.provider == "anthropic"
+
+
+def test_alcove_provider_none_when_absent(tmp_path):
+    """provider should be None when not present in the JSON."""
+    data = {
+        "session_id": "prov-002",
+        "transcript": [
+            {"type": "system", "model": "claude-sonnet-4-20250514"},
+            {"type": "result", "total_cost_usd": 0.01, "duration_ms": 1000},
+        ],
+    }
+    fixture = tmp_path / "no-provider.json"
+    fixture.write_text(json.dumps(data))
+    adapter = AlcoveAdapter()
+    sample = adapter.load(fixture)
+    assert sample.session.provider is None
+
+
+def test_alcove_pipeline_phases_from_phases_dict(tmp_path):
+    """pipeline_phases should reflect ordered phase keys from the phases dict."""
+    source = _bridge_session(
+        tmp_path,
+        overrides={
+            "phases": {
+                "triage": {"status": "completed"},
+                "implement": {"status": "completed"},
+                "verify": {"status": "completed"},
+            }
+        },
+    )
+    adapter = AlcoveAdapter()
+    sample = adapter.load(source)
+    assert sample.session.pipeline_phases == ["triage", "implement", "verify"]
+
+
+def test_alcove_pipeline_phases_none_when_no_phases(tmp_path):
+    """pipeline_phases should be None when phases dict is absent."""
+    data = {
+        "session_id": "phases-none",
+        "transcript": [
+            {"type": "system", "model": "claude-sonnet-4-20250514"},
+            {"type": "result", "total_cost_usd": 0.01, "duration_ms": 1000},
+        ],
+    }
+    fixture = tmp_path / "no-phases.json"
+    fixture.write_text(json.dumps(data))
+    adapter = AlcoveAdapter()
+    sample = adapter.load(fixture)
+    assert sample.session.pipeline_phases is None
+
+
+def test_alcove_classic_fixture_orchestrator():
+    """The classic alcove fixture should have orchestrator='alcove' and no pipeline_phases."""
+    adapter = AlcoveAdapter()
+    sample = adapter.load(ALCOVE_FIXTURE)
+    assert sample.session.orchestrator == "alcove"
+    assert sample.session.pipeline_phases is None
+    assert sample.session.provider is None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -30,6 +30,9 @@ def test_session_meta_required_fields():
     assert meta.knowledge_version is None
     assert meta.model_id is None
     assert meta.total_cost_usd is None
+    assert meta.orchestrator is None
+    assert meta.provider is None
+    assert meta.pipeline_phases is None
 
 
 def test_session_meta_all_fields():
@@ -46,6 +49,22 @@ def test_session_meta_all_fields():
     )
     assert meta.total_cost_usd == 26.1
     assert meta.knowledge_version == "abc123"
+
+
+def test_session_meta_pipeline_fields():
+    """orchestrator, provider, pipeline_phases default to None and accept values."""
+    meta = SessionMeta(
+        session_id="175",
+        started_at=datetime(2026, 4, 24, tzinfo=timezone.utc),
+        total_phases=3,
+        rework_cycles=0,
+        orchestrator="soda",
+        provider="anthropic",
+        pipeline_phases=["triage", "implement", "verify"],
+    )
+    assert meta.orchestrator == "soda"
+    assert meta.provider == "anthropic"
+    assert meta.pipeline_phases == ["triage", "implement", "verify"]
 
 
 def test_phase_result_minimal():


### PR DESCRIPTION
## Summary

- Adds `orchestrator`, `provider`, and `pipeline_phases` fields to `SessionMeta`
- `SessionSchemaAdapter` populates `orchestrator` (inferred from structure) and `pipeline_phases` (phase names from events)
- `AlcoveAdapter` populates `orchestrator` ("bridge" or "alcove"), `provider` from bridge format
- 226 new lines of tests covering all adapter paths

## Test plan

- [x] `uv run pytest tests/test_adapters.py tests/test_model.py -v` — 167 passed
- [x] New fields are optional (None default), backwards compatible with existing reports

Refs #175

🤖 Generated with [SODA](https://github.com/soda-ai/soda) + [Claude Code](https://claude.com/claude-code)