### PR TITLE
refactor: extract shared scoring loop from Ragas metrics (#182)

### DIFF
--- a/src/raki/metrics/ragas/_scoring_loop.py
+++ b/src/raki/metrics/ragas/_scoring_loop.py
@@ -90,10 +90,10 @@ async def score_rows(
                         f"for session {row.session_id}; treating as failure to "
                         "avoid polluting metric average"
                     )
-                score = result if isinstance(result, float) else result.value  # type: ignore[union-attr]
+                score = result if isinstance(result, float) else result.value  # ty: ignore[unresolved-attribute]
                 state.scores.append(score)
                 state.sample_scores[row.session_id] = score
-                reason = None if isinstance(result, float) else result.reason  # type: ignore[union-attr]
+                reason = None if isinstance(result, float) else result.reason  # ty: ignore[unresolved-attribute]
                 if judge_logger:
                     judge_logger.log(metric_name, row.user_input, score, reason)
             except Exception as exc:

--- a/src/raki/metrics/ragas/_scoring_loop.py
+++ b/src/raki/metrics/ragas/_scoring_loop.py
@@ -1,0 +1,193 @@
+"""Shared async scoring loop extracted from the four Ragas metric files.
+
+All four metrics (faithfulness, precision, recall, relevancy) duplicate
+identical error-handling logic for InstructorSilentZeroError, max_tokens
+failures, and per-session score accumulation. This module consolidates
+that logic so each metric only supplies the metric-specific score_fn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from raki.adapters.redact import redact_sensitive
+from raki.metrics.ragas.adapter import (
+    InstructorSilentZeroError,
+    RagasRow,
+    is_instructor_silent_zero,
+    is_max_tokens_error,
+)
+from raki.metrics.ragas.llm_setup import JudgeLogger
+from raki.model.report import MetricResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ScoringState:
+    """Accumulates results and failures from a parallel scoring run.
+
+    Attributes:
+        scores: Successful float scores from each scored row.
+        sample_scores: Maps session_id to its score (for per-sample reporting).
+        max_tokens_failures: Session IDs that failed due to max_tokens errors.
+        silent_zero_failures: Session IDs that hit the instructor#1658 silent-zero bug.
+    """
+
+    scores: list[float] = field(default_factory=list)
+    sample_scores: dict[str, float] = field(default_factory=dict)
+    max_tokens_failures: list[str] = field(default_factory=list)
+    silent_zero_failures: list[str] = field(default_factory=list)
+
+    @property
+    def mean_score(self) -> float:
+        """Average of all successful scores, or 0.0 if none."""
+        return sum(self.scores) / len(self.scores) if self.scores else 0.0
+
+
+async def score_rows(
+    rows: list[RagasRow],
+    score_fn: Callable[[RagasRow], Awaitable[object]],
+    metric_name: str,
+    llm_provider: str,
+    batch_size: int,
+    judge_logger: JudgeLogger | None,
+) -> ScoringState:
+    """Score all rows concurrently, collecting successes and categorised failures.
+
+    Calls ``score_fn(row)`` for each row with a semaphore limiting concurrency
+    to ``batch_size``. Handles three exception classes specially:
+
+    - ``max_tokens`` errors (provider output token limit) → max_tokens_failures
+    - :class:`InstructorSilentZeroError` (Google #1658 bug) → silent_zero_failures
+    - All other exceptions are logged but do not populate failure lists
+
+    Args:
+        rows: The rows to score.
+        score_fn: Async callable that invokes ``ragas_metric.ascore()`` for a row.
+        metric_name: Name of the metric, used in warning messages and judge log.
+        llm_provider: LLM provider string from ``MetricConfig.llm_provider``,
+            used for silent-zero detection.
+        batch_size: Maximum number of concurrent ``score_fn`` calls.
+        judge_logger: Optional audit logger for all judge calls.
+
+    Returns:
+        :class:`ScoringState` with accumulated scores and failure lists.
+    """
+    state = ScoringState()
+    semaphore = asyncio.Semaphore(batch_size)
+
+    async def score_one(row: RagasRow) -> None:
+        async with semaphore:
+            try:
+                result = await score_fn(row)
+                if is_instructor_silent_zero(result, llm_provider):
+                    raise InstructorSilentZeroError(
+                        f"instructor#1658: Google provider returned silent 0.0 "
+                        f"for session {row.session_id}; treating as failure to "
+                        "avoid polluting metric average"
+                    )
+                score = result if isinstance(result, float) else result.value  # type: ignore[union-attr]
+                state.scores.append(score)
+                state.sample_scores[row.session_id] = score
+                reason = None if isinstance(result, float) else result.reason  # type: ignore[union-attr]
+                if judge_logger:
+                    judge_logger.log(metric_name, row.user_input, score, reason)
+            except Exception as exc:
+                safe_error = redact_sensitive(f"ERROR: {exc}")
+                if is_max_tokens_error(exc):
+                    state.max_tokens_failures.append(row.session_id)
+                elif isinstance(exc, InstructorSilentZeroError):
+                    state.silent_zero_failures.append(row.session_id)
+                logger.warning(
+                    "%s scoring failed for session %s: %s",
+                    metric_name,
+                    row.session_id,
+                    safe_error,
+                )
+                if judge_logger:
+                    judge_logger.log(metric_name, row.user_input, -1.0, safe_error)
+
+    await asyncio.gather(*(score_one(row) for row in rows))
+    return state
+
+
+def build_max_tokens_result(metric_name: str, state: ScoringState) -> MetricResult | None:
+    """Return a ``score=None`` MetricResult when all failures were max_tokens errors.
+
+    Returns ``None`` when there are any successful scores or when there are no
+    max_tokens failures, so callers can use it as a guard:
+
+    .. code-block:: python
+
+        if result := build_max_tokens_result(self.name, state):
+            return result
+
+    Args:
+        metric_name: Name passed to :class:`MetricResult`.
+        state: The :class:`ScoringState` from :func:`score_rows`.
+    """
+    if not state.scores and state.max_tokens_failures:
+        return MetricResult(
+            name=metric_name,
+            score=None,
+            details={
+                "skipped": "max_tokens: all sessions exceeded output token limit",
+                "max_tokens_sessions": len(state.max_tokens_failures),
+            },
+        )
+    return None
+
+
+def build_silent_zero_result(metric_name: str, state: ScoringState) -> MetricResult | None:
+    """Return a ``score=None`` MetricResult when all failures were silent-zero errors.
+
+    Returns ``None`` when there are any successful scores or when there are no
+    silent-zero failures, so callers can use it as a guard:
+
+    .. code-block:: python
+
+        if result := build_silent_zero_result(self.name, state):
+            return result
+
+    Args:
+        metric_name: Name passed to :class:`MetricResult`.
+        state: The :class:`ScoringState` from :func:`score_rows`.
+    """
+    if not state.scores and state.silent_zero_failures:
+        return MetricResult(
+            name=metric_name,
+            score=None,
+            details={
+                "skipped": (
+                    "instructor#1658: Google provider returned only silent 0.0 scores; "
+                    "possible structured-output parsing failures"
+                ),
+                "silent_zero_sessions": len(state.silent_zero_failures),
+            },
+        )
+    return None
+
+
+def enrich_details_with_failures(details: dict, state: ScoringState) -> None:
+    """Add failure-count keys to *details* in-place.
+
+    Appends ``max_tokens_sessions`` when there are max_tokens failures.
+    Appends ``silent_zero_sessions`` and ``silent_zero_warning`` when there
+    are instructor#1658 silent-zero failures.
+
+    Args:
+        details: The metric details dict to mutate.
+        state: The :class:`ScoringState` from :func:`score_rows`.
+    """
+    if state.max_tokens_failures:
+        details["max_tokens_sessions"] = len(state.max_tokens_failures)
+    if state.silent_zero_failures:
+        details["silent_zero_sessions"] = len(state.silent_zero_failures)
+        details["silent_zero_warning"] = (
+            f"instructor#1658: {len(state.silent_zero_failures)} session(s) returned silent 0.0 "
+            "from Google provider and were excluded from the score"
+        )

--- a/src/raki/metrics/ragas/faithfulness.py
+++ b/src/raki/metrics/ragas/faithfulness.py
@@ -7,20 +7,22 @@ EXPERIMENTAL: This metric was designed for natural language answers, not code.
 Scores may be noisy for agentic code-generation sessions.
 """
 
-import asyncio
 import logging
 
-from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
 from raki.metrics.ragas.adapter import (
-    InstructorSilentZeroError,
     detect_context_source,
-    is_instructor_silent_zero,
-    is_max_tokens_error,
     to_ragas_rows,
 )
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
+from raki.metrics.ragas._scoring_loop import (
+    ScoringState,
+    build_max_tokens_result,
+    build_silent_zero_result,
+    enrich_details_with_failures,
+    score_rows,
+)
 from raki.model import EvalDataset
 from raki.model.report import MetricResult
 
@@ -81,104 +83,50 @@ class FaithfulnessMetric:
         if config.judge_log_path is not None:
             judge_logger = JudgeLogger(config.judge_log_path, config.project_root)
 
-        sample_scores: dict[str, float] = {}
-        scores: list[float] = []
-        max_tokens_failures: list[str] = []
-        silent_zero_failures: list[str] = []
+        async def score_fn(row):
+            return await ragas_metric.ascore(
+                user_input=row.user_input,
+                response=row.response,
+                retrieved_contexts=row.retrieved_contexts,
+            )
 
-        async def score_all():
-            semaphore = asyncio.Semaphore(config.batch_size)
-
-            async def score_one(row):
-                async with semaphore:
-                    try:
-                        result = await ragas_metric.ascore(
-                            user_input=row.user_input,
-                            response=row.response,
-                            retrieved_contexts=row.retrieved_contexts,
-                        )
-                        if is_instructor_silent_zero(result, config.llm_provider):
-                            raise InstructorSilentZeroError(
-                                f"instructor#1658: Google provider returned silent 0.0 "
-                                f"for session {row.session_id}; treating as failure to "
-                                "avoid polluting metric average"
-                            )
-                        score = result if isinstance(result, float) else result.value
-                        scores.append(score)
-                        sample_scores[row.session_id] = score
-                        reason = None if isinstance(result, float) else result.reason
-                        if judge_logger:
-                            judge_logger.log(self.name, row.user_input, score, reason)
-                    except Exception as exc:
-                        safe_error = redact_sensitive(f"ERROR: {exc}")
-                        if is_max_tokens_error(exc):
-                            max_tokens_failures.append(row.session_id)
-                        elif isinstance(exc, InstructorSilentZeroError):
-                            silent_zero_failures.append(row.session_id)
-                        logger.warning(
-                            "faithfulness scoring failed for session %s: %s",
-                            row.session_id,
-                            safe_error,
-                        )
-                        if judge_logger:
-                            judge_logger.log(self.name, row.user_input, -1.0, safe_error)
-
-            await asyncio.gather(*(score_one(row) for row in rows))
-
-        run_async(score_all())
+        state: ScoringState = run_async(
+            score_rows(
+                rows=rows,
+                score_fn=score_fn,
+                metric_name=self.name,
+                llm_provider=config.llm_provider,
+                batch_size=config.batch_size,
+                judge_logger=judge_logger,
+            )
+        )
 
         # If all failures were max_tokens errors, return score=None
-        if not scores and max_tokens_failures:
-            return MetricResult(
-                name=self.name,
-                score=None,
-                details={
-                    "skipped": "max_tokens: all sessions exceeded output token limit",
-                    "max_tokens_sessions": len(max_tokens_failures),
-                },
-            )
+        if result := build_max_tokens_result(self.name, state):
+            return result
 
         # If all failures were instructor#1658 silent-zero errors, return score=None
-        if not scores and silent_zero_failures:
-            return MetricResult(
-                name=self.name,
-                score=None,
-                details={
-                    "skipped": (
-                        "instructor#1658: Google provider returned only silent 0.0 scores; "
-                        "possible structured-output parsing failures"
-                    ),
-                    "silent_zero_sessions": len(silent_zero_failures),
-                },
-            )
-
-        mean_score = sum(scores) / len(scores) if scores else 0.0
+        if result := build_silent_zero_result(self.name, state):
+            return result
 
         # Determine context_source from the dataset samples
         context_source = detect_context_source(dataset)
 
         details: dict = {
-            "samples_scored": len(scores),
-            "samples_skipped": len(rows) - len(scores),
+            "samples_scored": len(state.scores),
+            "samples_skipped": len(rows) - len(state.scores),
             "experimental": True,
             "caveat": (
                 "Designed for NL answers, not code -- scores may be noisy for agentic sessions"
             ),
         }
-        if max_tokens_failures:
-            details["max_tokens_sessions"] = len(max_tokens_failures)
-        if silent_zero_failures:
-            details["silent_zero_sessions"] = len(silent_zero_failures)
-            details["silent_zero_warning"] = (
-                f"instructor#1658: {len(silent_zero_failures)} session(s) returned silent 0.0 "
-                "from Google provider and were excluded from the score"
-            )
+        enrich_details_with_failures(details, state)
         if context_source is not None:
             details["context_source"] = context_source
 
         return MetricResult(
             name=self.name,
-            score=mean_score,
+            score=state.mean_score,
             details=details,
-            sample_scores=sample_scores,
+            sample_scores=state.sample_scores,
         )

--- a/src/raki/metrics/ragas/precision.py
+++ b/src/raki/metrics/ragas/precision.py
@@ -4,19 +4,21 @@ Measures how relevant the retrieved contexts are to answering the user's questio
 given a reference answer. Higher is better.
 """
 
-import asyncio
 import logging
 
-from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
 from raki.metrics.ragas.adapter import (
-    InstructorSilentZeroError,
-    is_instructor_silent_zero,
-    is_max_tokens_error,
     to_ragas_rows,
 )
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
+from raki.metrics.ragas._scoring_loop import (
+    ScoringState,
+    build_max_tokens_result,
+    build_silent_zero_result,
+    enrich_details_with_failures,
+    score_rows,
+)
 from raki.model import EvalDataset
 from raki.model.report import MetricResult
 
@@ -63,93 +65,40 @@ class ContextPrecisionMetric:
         if config.judge_log_path is not None:
             judge_logger = JudgeLogger(config.judge_log_path, config.project_root)
 
-        sample_scores: dict[str, float] = {}
-        scores: list[float] = []
-        max_tokens_failures: list[str] = []
-        silent_zero_failures: list[str] = []
+        async def score_fn(row):
+            return await ragas_metric.ascore(
+                user_input=row.user_input,
+                retrieved_contexts=row.retrieved_contexts,
+                reference=row.reference,
+            )
 
-        async def score_all():
-            semaphore = asyncio.Semaphore(config.batch_size)
-
-            async def score_one(row):
-                async with semaphore:
-                    try:
-                        result = await ragas_metric.ascore(
-                            user_input=row.user_input,
-                            retrieved_contexts=row.retrieved_contexts,
-                            reference=row.reference,
-                        )
-                        if is_instructor_silent_zero(result, config.llm_provider):
-                            raise InstructorSilentZeroError(
-                                f"instructor#1658: Google provider returned silent 0.0 "
-                                f"for session {row.session_id}; treating as failure to "
-                                "avoid polluting metric average"
-                            )
-                        score = result if isinstance(result, float) else result.value
-                        scores.append(score)
-                        sample_scores[row.session_id] = score
-                        reason = None if isinstance(result, float) else result.reason
-                        if judge_logger:
-                            judge_logger.log(self.name, row.user_input, score, reason)
-                    except Exception as exc:
-                        safe_error = redact_sensitive(f"ERROR: {exc}")
-                        if is_max_tokens_error(exc):
-                            max_tokens_failures.append(row.session_id)
-                        elif isinstance(exc, InstructorSilentZeroError):
-                            silent_zero_failures.append(row.session_id)
-                        logger.warning(
-                            "context_precision scoring failed for session %s: %s",
-                            row.session_id,
-                            safe_error,
-                        )
-                        if judge_logger:
-                            judge_logger.log(self.name, row.user_input, -1.0, safe_error)
-
-            await asyncio.gather(*(score_one(row) for row in rows_with_ref))
-
-        run_async(score_all())
+        state: ScoringState = run_async(
+            score_rows(
+                rows=rows_with_ref,
+                score_fn=score_fn,
+                metric_name=self.name,
+                llm_provider=config.llm_provider,
+                batch_size=config.batch_size,
+                judge_logger=judge_logger,
+            )
+        )
 
         # If all failures were max_tokens errors, return score=None
-        if not scores and max_tokens_failures:
-            return MetricResult(
-                name=self.name,
-                score=None,
-                details={
-                    "skipped": "max_tokens: all sessions exceeded output token limit",
-                    "max_tokens_sessions": len(max_tokens_failures),
-                },
-            )
+        if result := build_max_tokens_result(self.name, state):
+            return result
 
         # If all failures were instructor#1658 silent-zero errors, return score=None
-        if not scores and silent_zero_failures:
-            return MetricResult(
-                name=self.name,
-                score=None,
-                details={
-                    "skipped": (
-                        "instructor#1658: Google provider returned only silent 0.0 scores; "
-                        "possible structured-output parsing failures"
-                    ),
-                    "silent_zero_sessions": len(silent_zero_failures),
-                },
-            )
+        if result := build_silent_zero_result(self.name, state):
+            return result
 
-        mean_score = sum(scores) / len(scores) if scores else 0.0
         details: dict = {
-            "samples_scored": len(scores),
-            "samples_skipped": len(rows_with_ref) - len(scores),
+            "samples_scored": len(state.scores),
+            "samples_skipped": len(rows_with_ref) - len(state.scores),
         }
-        if max_tokens_failures:
-            details["max_tokens_sessions"] = len(max_tokens_failures)
-        if silent_zero_failures:
-            details["silent_zero_sessions"] = len(silent_zero_failures)
-            details["silent_zero_warning"] = (
-                f"instructor#1658: {len(silent_zero_failures)} session(s) returned silent 0.0 "
-                "from Google provider and were excluded from the score"
-            )
+        enrich_details_with_failures(details, state)
         return MetricResult(
             name=self.name,
-            score=mean_score,
+            score=state.mean_score,
             details=details,
-            sample_scores=sample_scores,
+            sample_scores=state.sample_scores,
         )

--- a/src/raki/metrics/ragas/recall.py
+++ b/src/raki/metrics/ragas/recall.py
@@ -4,19 +4,21 @@ Measures how well the retrieved contexts cover the information needed
 to answer the question, given a reference answer. Higher is better.
 """
 
-import asyncio
 import logging
 
-from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
 from raki.metrics.ragas.adapter import (
-    InstructorSilentZeroError,
-    is_instructor_silent_zero,
-    is_max_tokens_error,
     to_ragas_rows,
 )
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_llm
+from raki.metrics.ragas._scoring_loop import (
+    ScoringState,
+    build_max_tokens_result,
+    build_silent_zero_result,
+    enrich_details_with_failures,
+    score_rows,
+)
 from raki.model import EvalDataset
 from raki.model.report import MetricResult
 
@@ -63,93 +65,40 @@ class ContextRecallMetric:
         if config.judge_log_path is not None:
             judge_logger = JudgeLogger(config.judge_log_path, config.project_root)
 
-        sample_scores: dict[str, float] = {}
-        scores: list[float] = []
-        max_tokens_failures: list[str] = []
-        silent_zero_failures: list[str] = []
+        async def score_fn(row):
+            return await ragas_metric.ascore(
+                user_input=row.user_input,
+                retrieved_contexts=row.retrieved_contexts,
+                reference=row.reference,
+            )
 
-        async def score_all():
-            semaphore = asyncio.Semaphore(config.batch_size)
-
-            async def score_one(row):
-                async with semaphore:
-                    try:
-                        result = await ragas_metric.ascore(
-                            user_input=row.user_input,
-                            retrieved_contexts=row.retrieved_contexts,
-                            reference=row.reference,
-                        )
-                        if is_instructor_silent_zero(result, config.llm_provider):
-                            raise InstructorSilentZeroError(
-                                f"instructor#1658: Google provider returned silent 0.0 "
-                                f"for session {row.session_id}; treating as failure to "
-                                "avoid polluting metric average"
-                            )
-                        score = result if isinstance(result, float) else result.value
-                        scores.append(score)
-                        sample_scores[row.session_id] = score
-                        reason = None if isinstance(result, float) else result.reason
-                        if judge_logger:
-                            judge_logger.log(self.name, row.user_input, score, reason)
-                    except Exception as exc:
-                        safe_error = redact_sensitive(f"ERROR: {exc}")
-                        if is_max_tokens_error(exc):
-                            max_tokens_failures.append(row.session_id)
-                        elif isinstance(exc, InstructorSilentZeroError):
-                            silent_zero_failures.append(row.session_id)
-                        logger.warning(
-                            "context_recall scoring failed for session %s: %s",
-                            row.session_id,
-                            safe_error,
-                        )
-                        if judge_logger:
-                            judge_logger.log(self.name, row.user_input, -1.0, safe_error)
-
-            await asyncio.gather(*(score_one(row) for row in rows_with_ref))
-
-        run_async(score_all())
+        state: ScoringState = run_async(
+            score_rows(
+                rows=rows_with_ref,
+                score_fn=score_fn,
+                metric_name=self.name,
+                llm_provider=config.llm_provider,
+                batch_size=config.batch_size,
+                judge_logger=judge_logger,
+            )
+        )
 
         # If all failures were max_tokens errors, return score=None
-        if not scores and max_tokens_failures:
-            return MetricResult(
-                name=self.name,
-                score=None,
-                details={
-                    "skipped": "max_tokens: all sessions exceeded output token limit",
-                    "max_tokens_sessions": len(max_tokens_failures),
-                },
-            )
+        if result := build_max_tokens_result(self.name, state):
+            return result
 
         # If all failures were instructor#1658 silent-zero errors, return score=None
-        if not scores and silent_zero_failures:
-            return MetricResult(
-                name=self.name,
-                score=None,
-                details={
-                    "skipped": (
-                        "instructor#1658: Google provider returned only silent 0.0 scores; "
-                        "possible structured-output parsing failures"
-                    ),
-                    "silent_zero_sessions": len(silent_zero_failures),
-                },
-            )
+        if result := build_silent_zero_result(self.name, state):
+            return result
 
-        mean_score = sum(scores) / len(scores) if scores else 0.0
         details: dict = {
-            "samples_scored": len(scores),
-            "samples_skipped": len(rows_with_ref) - len(scores),
+            "samples_scored": len(state.scores),
+            "samples_skipped": len(rows_with_ref) - len(state.scores),
         }
-        if max_tokens_failures:
-            details["max_tokens_sessions"] = len(max_tokens_failures)
-        if silent_zero_failures:
-            details["silent_zero_sessions"] = len(silent_zero_failures)
-            details["silent_zero_warning"] = (
-                f"instructor#1658: {len(silent_zero_failures)} session(s) returned silent 0.0 "
-                "from Google provider and were excluded from the score"
-            )
+        enrich_details_with_failures(details, state)
         return MetricResult(
             name=self.name,
-            score=mean_score,
+            score=state.mean_score,
             details=details,
-            sample_scores=sample_scores,
+            sample_scores=state.sample_scores,
         )

--- a/src/raki/metrics/ragas/relevancy.py
+++ b/src/raki/metrics/ragas/relevancy.py
@@ -7,20 +7,22 @@ EXPERIMENTAL: This metric was designed for natural language answers, not code.
 Scores may be noisy for agentic code-generation sessions.
 """
 
-import asyncio
 import logging
 
-from raki.adapters.redact import redact_sensitive
 from raki.metrics.protocol import MetricConfig
 from raki.metrics.ragas.adapter import (
-    InstructorSilentZeroError,
     detect_context_source,
-    is_instructor_silent_zero,
-    is_max_tokens_error,
     to_ragas_rows,
 )
 from raki.metrics.ragas.async_utils import run_async
 from raki.metrics.ragas.llm_setup import JudgeLogger, create_ragas_embeddings, create_ragas_llm
+from raki.metrics.ragas._scoring_loop import (
+    ScoringState,
+    build_max_tokens_result,
+    build_silent_zero_result,
+    enrich_details_with_failures,
+    score_rows,
+)
 from raki.model import EvalDataset
 from raki.model.report import MetricResult
 
@@ -82,103 +84,49 @@ class AnswerRelevancyMetric:
         if config.judge_log_path is not None:
             judge_logger = JudgeLogger(config.judge_log_path, config.project_root)
 
-        sample_scores: dict[str, float] = {}
-        scores: list[float] = []
-        max_tokens_failures: list[str] = []
-        silent_zero_failures: list[str] = []
+        async def score_fn(row):
+            return await ragas_metric.ascore(
+                user_input=row.user_input,
+                response=row.response,
+            )
 
-        async def score_all():
-            semaphore = asyncio.Semaphore(config.batch_size)
-
-            async def score_one(row):
-                async with semaphore:
-                    try:
-                        result = await ragas_metric.ascore(
-                            user_input=row.user_input,
-                            response=row.response,
-                        )
-                        if is_instructor_silent_zero(result, config.llm_provider):
-                            raise InstructorSilentZeroError(
-                                f"instructor#1658: Google provider returned silent 0.0 "
-                                f"for session {row.session_id}; treating as failure to "
-                                "avoid polluting metric average"
-                            )
-                        score = result if isinstance(result, float) else result.value
-                        scores.append(score)
-                        sample_scores[row.session_id] = score
-                        reason = None if isinstance(result, float) else result.reason
-                        if judge_logger:
-                            judge_logger.log(self.name, row.user_input, score, reason)
-                    except Exception as exc:
-                        safe_error = redact_sensitive(f"ERROR: {exc}")
-                        if is_max_tokens_error(exc):
-                            max_tokens_failures.append(row.session_id)
-                        elif isinstance(exc, InstructorSilentZeroError):
-                            silent_zero_failures.append(row.session_id)
-                        logger.warning(
-                            "answer_relevancy scoring failed for session %s: %s",
-                            row.session_id,
-                            safe_error,
-                        )
-                        if judge_logger:
-                            judge_logger.log(self.name, row.user_input, -1.0, safe_error)
-
-            await asyncio.gather(*(score_one(row) for row in rows))
-
-        run_async(score_all())
+        state: ScoringState = run_async(
+            score_rows(
+                rows=rows,
+                score_fn=score_fn,
+                metric_name=self.name,
+                llm_provider=config.llm_provider,
+                batch_size=config.batch_size,
+                judge_logger=judge_logger,
+            )
+        )
 
         # If all failures were max_tokens errors, return score=None
-        if not scores and max_tokens_failures:
-            return MetricResult(
-                name=self.name,
-                score=None,
-                details={
-                    "skipped": "max_tokens: all sessions exceeded output token limit",
-                    "max_tokens_sessions": len(max_tokens_failures),
-                },
-            )
+        if result := build_max_tokens_result(self.name, state):
+            return result
 
         # If all failures were instructor#1658 silent-zero errors, return score=None
-        if not scores and silent_zero_failures:
-            return MetricResult(
-                name=self.name,
-                score=None,
-                details={
-                    "skipped": (
-                        "instructor#1658: Google provider returned only silent 0.0 scores; "
-                        "possible structured-output parsing failures"
-                    ),
-                    "silent_zero_sessions": len(silent_zero_failures),
-                },
-            )
-
-        mean_score = sum(scores) / len(scores) if scores else 0.0
+        if result := build_silent_zero_result(self.name, state):
+            return result
 
         # Determine context_source from the dataset samples
         context_source = detect_context_source(dataset)
 
         details: dict = {
-            "samples_scored": len(scores),
-            "samples_skipped": len(rows) - len(scores),
+            "samples_scored": len(state.scores),
+            "samples_skipped": len(rows) - len(state.scores),
             "experimental": True,
             "caveat": (
                 "Designed for NL answers, not code -- scores may be noisy for agentic sessions"
             ),
         }
-        if max_tokens_failures:
-            details["max_tokens_sessions"] = len(max_tokens_failures)
-        if silent_zero_failures:
-            details["silent_zero_sessions"] = len(silent_zero_failures)
-            details["silent_zero_warning"] = (
-                f"instructor#1658: {len(silent_zero_failures)} session(s) returned silent 0.0 "
-                "from Google provider and were excluded from the score"
-            )
+        enrich_details_with_failures(details, state)
         if context_source is not None:
             details["context_source"] = context_source
 
         return MetricResult(
             name=self.name,
-            score=mean_score,
+            score=state.mean_score,
             details=details,
-            sample_scores=sample_scores,
+            sample_scores=state.sample_scores,
         )

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -2917,3 +2917,399 @@ class TestSelectRelevantChunksEdgeCases:
         ]
         result = select_relevant_chunks("xylophone zebra quantum", chunks)
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# ScoringLoop tests — shared scoring loop extracted from the 4 Ragas metrics
+# ---------------------------------------------------------------------------
+
+
+class TestScoringState:
+    """Unit tests for ScoringState dataclass."""
+
+    def test_default_state_is_empty(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState
+
+        state = ScoringState()
+        assert state.scores == []
+        assert state.sample_scores == {}
+        assert state.max_tokens_failures == []
+        assert state.silent_zero_failures == []
+
+    def test_mean_score_empty_returns_zero(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState
+
+        state = ScoringState()
+        assert state.mean_score == 0.0
+
+    def test_mean_score_single_value(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState
+
+        state = ScoringState(scores=[0.8])
+        assert state.mean_score == pytest.approx(0.8)
+
+    def test_mean_score_averages_multiple_values(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState
+
+        state = ScoringState(scores=[0.6, 0.8, 1.0])
+        assert state.mean_score == pytest.approx(0.8)
+
+
+class TestScoreRows:
+    """Tests for the score_rows() coroutine."""
+
+    def _make_row(self, session_id: str = "s1") -> RagasRow:
+        return RagasRow(
+            session_id=session_id,
+            user_input="How to validate?",
+            retrieved_contexts=["ctx"],
+            response="Use pydantic",
+            reference=None,
+        )
+
+    def test_successful_scoring_accumulates_scores(self):
+        """score_rows should append scores and sample_scores for each row."""
+        import asyncio
+
+        from raki.metrics.ragas._scoring_loop import ScoringState, score_rows
+
+        async def fake_score_fn(row: RagasRow) -> float:
+            return 0.85
+
+        rows = [self._make_row("s1"), self._make_row("s2")]
+        state: ScoringState = asyncio.run(
+            score_rows(
+                rows=rows,
+                score_fn=fake_score_fn,
+                metric_name="test_metric",
+                llm_provider="vertex-anthropic",
+                batch_size=4,
+                judge_logger=None,
+            )
+        )
+
+        assert len(state.scores) == 2
+        assert state.sample_scores == {"s1": pytest.approx(0.85), "s2": pytest.approx(0.85)}
+        assert state.max_tokens_failures == []
+        assert state.silent_zero_failures == []
+
+    def test_handles_structured_result_with_value_attribute(self):
+        """score_rows handles result objects with .value and .reason attributes."""
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from raki.metrics.ragas._scoring_loop import score_rows
+
+        mock_result = MagicMock()
+        mock_result.value = 0.72
+        mock_result.reason = "Good"
+
+        async def fake_score_fn(row: RagasRow):
+            return mock_result
+
+        rows = [self._make_row("s1")]
+        state = asyncio.run(
+            score_rows(
+                rows=rows,
+                score_fn=fake_score_fn,
+                metric_name="test_metric",
+                llm_provider="vertex-anthropic",
+                batch_size=4,
+                judge_logger=None,
+            )
+        )
+
+        assert state.scores == [pytest.approx(0.72)]
+        assert state.sample_scores == {"s1": pytest.approx(0.72)}
+
+    def test_max_tokens_error_recorded_in_failures(self):
+        """Exceptions containing 'max_tokens' should go into max_tokens_failures."""
+        import asyncio
+
+        from raki.metrics.ragas._scoring_loop import score_rows
+
+        async def failing_score_fn(row: RagasRow) -> float:
+            raise RuntimeError("max_tokens limit exceeded")
+
+        rows = [self._make_row("s1")]
+        state = asyncio.run(
+            score_rows(
+                rows=rows,
+                score_fn=failing_score_fn,
+                metric_name="test_metric",
+                llm_provider="vertex-anthropic",
+                batch_size=4,
+                judge_logger=None,
+            )
+        )
+
+        assert state.scores == []
+        assert state.max_tokens_failures == ["s1"]
+        assert state.silent_zero_failures == []
+
+    def test_instructor_silent_zero_recorded_in_failures(self):
+        """InstructorSilentZeroError should go into silent_zero_failures."""
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from raki.metrics.ragas._scoring_loop import score_rows
+
+        # A result that triggers silent-zero detection (value=0.0, reason=None, provider=google)
+        mock_result = MagicMock()
+        mock_result.value = 0.0
+        mock_result.reason = None
+
+        async def fake_score_fn(row: RagasRow):
+            return mock_result
+
+        rows = [self._make_row("s1")]
+        state = asyncio.run(
+            score_rows(
+                rows=rows,
+                score_fn=fake_score_fn,
+                metric_name="test_metric",
+                llm_provider="google",  # only detected for google
+                batch_size=4,
+                judge_logger=None,
+            )
+        )
+
+        assert state.scores == []
+        assert state.silent_zero_failures == ["s1"]
+        assert state.max_tokens_failures == []
+
+    def test_generic_exception_does_not_populate_failure_lists(self):
+        """Non-classified exceptions should leave both failure lists empty."""
+        import asyncio
+
+        from raki.metrics.ragas._scoring_loop import score_rows
+
+        async def failing_score_fn(row: RagasRow) -> float:
+            raise ValueError("Something else went wrong")
+
+        rows = [self._make_row("s1")]
+        state = asyncio.run(
+            score_rows(
+                rows=rows,
+                score_fn=failing_score_fn,
+                metric_name="test_metric",
+                llm_provider="vertex-anthropic",
+                batch_size=4,
+                judge_logger=None,
+            )
+        )
+
+        assert state.scores == []
+        assert state.max_tokens_failures == []
+        assert state.silent_zero_failures == []
+
+    def test_mixed_success_and_failure(self):
+        """score_rows should record only successful scores, not failed ones."""
+        import asyncio
+
+        from raki.metrics.ragas._scoring_loop import score_rows
+
+        call_count = 0
+
+        async def alternating_score_fn(row: RagasRow) -> float:
+            nonlocal call_count
+            call_count += 1
+            if row.session_id == "s2":
+                raise RuntimeError("max_tokens error for s2")
+            return 0.9
+
+        rows = [self._make_row("s1"), self._make_row("s2")]
+        state = asyncio.run(
+            score_rows(
+                rows=rows,
+                score_fn=alternating_score_fn,
+                metric_name="test_metric",
+                llm_provider="vertex-anthropic",
+                batch_size=4,
+                judge_logger=None,
+            )
+        )
+
+        assert state.scores == [pytest.approx(0.9)]
+        assert state.sample_scores == {"s1": pytest.approx(0.9)}
+        assert state.max_tokens_failures == ["s2"]
+
+    def test_judge_logger_called_on_success(self, tmp_path: Path):
+        """score_rows should call judge_logger.log for successful scores."""
+        import asyncio
+
+        from raki.metrics.ragas._scoring_loop import score_rows
+
+        judge_logger = JudgeLogger(tmp_path / "judge.jsonl", project_root=tmp_path)
+
+        async def fake_score_fn(row: RagasRow) -> float:
+            return 0.75
+
+        rows = [self._make_row("s1")]
+        asyncio.run(
+            score_rows(
+                rows=rows,
+                score_fn=fake_score_fn,
+                metric_name="faithfulness",
+                llm_provider="vertex-anthropic",
+                batch_size=4,
+                judge_logger=judge_logger,
+            )
+        )
+
+        import json
+
+        entries = [
+            json.loads(line) for line in (tmp_path / "judge.jsonl").read_text().strip().split("\n")
+        ]
+        assert len(entries) == 1
+        assert entries[0]["metric"] == "faithfulness"
+        assert entries[0]["score"] == 0.75
+
+    def test_judge_logger_called_on_failure(self, tmp_path: Path):
+        """score_rows should log score=-1.0 to judge_logger on failure."""
+        import asyncio
+
+        from raki.metrics.ragas._scoring_loop import score_rows
+
+        judge_logger = JudgeLogger(tmp_path / "judge.jsonl", project_root=tmp_path)
+
+        async def failing_score_fn(row: RagasRow) -> float:
+            raise RuntimeError("LLM error")
+
+        rows = [self._make_row("s1")]
+        asyncio.run(
+            score_rows(
+                rows=rows,
+                score_fn=failing_score_fn,
+                metric_name="faithfulness",
+                llm_provider="vertex-anthropic",
+                batch_size=4,
+                judge_logger=judge_logger,
+            )
+        )
+
+        import json
+
+        entries = [
+            json.loads(line) for line in (tmp_path / "judge.jsonl").read_text().strip().split("\n")
+        ]
+        assert len(entries) == 1
+        assert entries[0]["score"] == -1.0
+        assert "LLM error" in entries[0]["reason"]
+
+
+class TestBuildMaxTokensResult:
+    """Tests for build_max_tokens_result() helper."""
+
+    def test_returns_none_when_scores_exist(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState, build_max_tokens_result
+
+        state = ScoringState(scores=[0.8], max_tokens_failures=["s1"])
+        result = build_max_tokens_result("test_metric", state)
+        assert result is None
+
+    def test_returns_none_when_no_failures(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState, build_max_tokens_result
+
+        state = ScoringState(scores=[], max_tokens_failures=[])
+        result = build_max_tokens_result("test_metric", state)
+        assert result is None
+
+    def test_returns_metric_result_when_all_max_tokens(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState, build_max_tokens_result
+
+        state = ScoringState(scores=[], max_tokens_failures=["s1", "s2"])
+        result = build_max_tokens_result("faithfulness", state)
+        assert result is not None
+        assert result.name == "faithfulness"
+        assert result.score is None
+        assert result.details["skipped"] == "max_tokens: all sessions exceeded output token limit"
+        assert result.details["max_tokens_sessions"] == 2
+
+    def test_returns_none_when_only_silent_zero_failures(self):
+        """build_max_tokens_result should not fire when only silent-zero failures exist."""
+        from raki.metrics.ragas._scoring_loop import ScoringState, build_max_tokens_result
+
+        state = ScoringState(scores=[], max_tokens_failures=[], silent_zero_failures=["s1"])
+        result = build_max_tokens_result("test_metric", state)
+        assert result is None
+
+
+class TestBuildSilentZeroResult:
+    """Tests for build_silent_zero_result() helper."""
+
+    def test_returns_none_when_scores_exist(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState, build_silent_zero_result
+
+        state = ScoringState(scores=[0.7], silent_zero_failures=["s1"])
+        result = build_silent_zero_result("test_metric", state)
+        assert result is None
+
+    def test_returns_none_when_no_failures(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState, build_silent_zero_result
+
+        state = ScoringState(scores=[], silent_zero_failures=[])
+        result = build_silent_zero_result("test_metric", state)
+        assert result is None
+
+    def test_returns_metric_result_when_all_silent_zero(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState, build_silent_zero_result
+
+        state = ScoringState(scores=[], silent_zero_failures=["s1", "s2", "s3"])
+        result = build_silent_zero_result("context_precision", state)
+        assert result is not None
+        assert result.name == "context_precision"
+        assert result.score is None
+        assert "instructor#1658" in result.details["skipped"]
+        assert result.details["silent_zero_sessions"] == 3
+
+    def test_returns_none_when_only_max_tokens_failures(self):
+        """build_silent_zero_result should not fire when only max_tokens failures exist."""
+        from raki.metrics.ragas._scoring_loop import ScoringState, build_silent_zero_result
+
+        state = ScoringState(scores=[], max_tokens_failures=["s1"], silent_zero_failures=[])
+        result = build_silent_zero_result("test_metric", state)
+        assert result is None
+
+
+class TestEnrichDetailsWithFailures:
+    """Tests for enrich_details_with_failures() helper."""
+
+    def test_no_failures_leaves_details_unchanged(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState, enrich_details_with_failures
+
+        state = ScoringState()
+        details: dict = {"samples_scored": 5}
+        enrich_details_with_failures(details, state)
+        assert details == {"samples_scored": 5}
+
+    def test_max_tokens_failures_adds_count(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState, enrich_details_with_failures
+
+        state = ScoringState(max_tokens_failures=["s1", "s2"])
+        details: dict = {}
+        enrich_details_with_failures(details, state)
+        assert details["max_tokens_sessions"] == 2
+        assert "silent_zero_sessions" not in details
+
+    def test_silent_zero_failures_adds_count_and_warning(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState, enrich_details_with_failures
+
+        state = ScoringState(silent_zero_failures=["s1", "s2", "s3"])
+        details: dict = {}
+        enrich_details_with_failures(details, state)
+        assert details["silent_zero_sessions"] == 3
+        assert "silent_zero_warning" in details
+        assert "instructor#1658" in details["silent_zero_warning"]
+        assert "3 session(s)" in details["silent_zero_warning"]
+
+    def test_both_failure_types_adds_all_keys(self):
+        from raki.metrics.ragas._scoring_loop import ScoringState, enrich_details_with_failures
+
+        state = ScoringState(max_tokens_failures=["s1"], silent_zero_failures=["s2"])
+        details: dict = {}
+        enrich_details_with_failures(details, state)
+        assert details["max_tokens_sessions"] == 1
+        assert details["silent_zero_sessions"] == 1
+        assert "silent_zero_warning" in details


### PR DESCRIPTION
## Summary

- Extracts duplicated error handling (~80 lines per file) from 4 Ragas metric files into shared `_scoring_loop.py`
- New `run_scoring_loop()` handles: silent zero detection, max_tokens errors, JudgeLogger calls, mixed-success aggregation
- Each metric now provides only a `score_fn` callback and metric-specific detail fields
- Reduces ~337 lines of duplication to ~193 lines of shared logic
- 396 lines of new tests for the scoring loop module

## Test plan

- [x] `uv run pytest tests/ -v -m "not slow"` — 1159 passed
- [x] All 4 Ragas metrics (faithfulness, precision, recall, relevancy) use the shared loop
- [x] Error handling behavior unchanged (silent zero, max_tokens, mixed success)

Refs #182

🤖 Generated with [SODA](https://github.com/soda-ai/soda) + [Claude Code](https://claude.com/claude-code)