### PR TITLE
feat: show judge model name in HTML and CLI report headers (#207)

### DIFF
--- a/changes/207.feature
+++ b/changes/207.feature
@@ -1,0 +1,5 @@
+Show the judge model name and provider in CLI and HTML report headers.
+
+When a judge model is configured, the judge cost line now reads:
+``Judge: claude-sonnet-4-6 (vertex-anthropic) · 20 calls, 41,861 in / 11,558 out tokens``
+instead of the bare token-count summary.

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -336,8 +336,16 @@ def print_summary(
         judge_calls = judge_cost["calls"]
         judge_in = f"{judge_cost['input_tokens']:,}"
         judge_out = f"{judge_cost['output_tokens']:,}"
+        judge_model = report.config.get("llm_model")
+        judge_provider = report.config.get("llm_provider")
+        if judge_model and judge_provider:
+            model_prefix = f"{judge_model} ({judge_provider}) · "
+        elif judge_model:
+            model_prefix = f"{judge_model} · "
+        else:
+            model_prefix = ""
         output_console.print(
-            f"[dim]Judge: {judge_calls} calls, {judge_in} in / {judge_out} out tokens[/dim]"
+            f"[dim]Judge: {model_prefix}{judge_calls} calls, {judge_in} in / {judge_out} out tokens[/dim]"
         )
         output_console.print()
 

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -621,6 +621,8 @@ def write_html_report(
         return html_color_for_score(score, higher, fmt)
 
     judge_cost = report.config.get("judge_cost")
+    judge_model = report.config.get("llm_model")
+    judge_provider = report.config.get("llm_provider")
 
     html_content = template.render(
         report=report,
@@ -647,6 +649,8 @@ def write_html_report(
         no_data_metrics=no_data_metrics,
         agent_models=agent_models,
         judge_cost=judge_cost,
+        judge_model=judge_model,
+        judge_provider=judge_provider,
         metric_warnings=report.warnings,
     )
 

--- a/src/raki/report/templates/report.html.j2
+++ b/src/raki/report/templates/report.html.j2
@@ -723,7 +723,7 @@
       <span><strong>Timestamp:</strong> {{ report.timestamp.strftime('%Y-%m-%d %H:%M:%S UTC') }}</span>
       <span><strong>Sessions:</strong> {{ session_count }}</span>
       {% if agent_models %}<span><strong>Agent model:</strong> {{ agent_models | join(", ") }}</span>{% endif %}
-      {% if judge_cost %}<span><strong>Judge:</strong> {{ judge_cost.calls }} calls, {{ "{:,}".format(judge_cost.input_tokens) }} in / {{ "{:,}".format(judge_cost.output_tokens) }} out tokens</span>{% endif %}
+      {% if judge_cost %}<span><strong>Judge:</strong> {% if judge_model %}{{ judge_model }}{% if judge_provider %} ({{ judge_provider }}){% endif %} &middot; {% endif %}{{ judge_cost.calls }} calls, {{ "{:,}".format(judge_cost.input_tokens) }} in / {{ "{:,}".format(judge_cost.output_tokens) }} out tokens</span>{% endif %}
     </div>
   </header>
 

--- a/tests/test_judge_cost.py
+++ b/tests/test_judge_cost.py
@@ -279,6 +279,82 @@ class TestCliSummaryJudgeCost:
         output = string_io.getvalue()
         assert "Judge:" not in output
 
+    def test_judge_model_and_provider_shown_in_summary(self) -> None:
+        """When llm_model and llm_provider are set, both appear in the judge cost line."""
+        from rich.console import Console
+
+        from raki.report.cli_summary import print_summary
+
+        report = EvalReport(
+            run_id="judge-model-provider-test",
+            config={
+                "llm_model": "claude-sonnet-4-6",
+                "llm_provider": "vertex-anthropic",
+                "judge_cost": {
+                    "input_tokens": 41861,
+                    "output_tokens": 11558,
+                    "calls": 20,
+                },
+            },
+            aggregate_scores={"first_pass_success_rate": 0.8},
+        )
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=False, width=120)
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "claude-sonnet-4-6" in output
+        assert "vertex-anthropic" in output
+        assert "20 calls" in output
+
+    def test_judge_model_only_shown_in_summary(self) -> None:
+        """When only llm_model is set (no provider), model appears without provider."""
+        from rich.console import Console
+
+        from raki.report.cli_summary import print_summary
+
+        report = EvalReport(
+            run_id="judge-model-only-test",
+            config={
+                "llm_model": "claude-opus-4",
+                "judge_cost": {
+                    "input_tokens": 5000,
+                    "output_tokens": 1000,
+                    "calls": 5,
+                },
+            },
+            aggregate_scores={"first_pass_success_rate": 0.8},
+        )
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=False, width=120)
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "claude-opus-4" in output
+        assert "(" not in output or "vertex-anthropic" not in output
+        assert "5 calls" in output
+
+    def test_judge_cost_only_no_model_in_summary(self) -> None:
+        """When llm_model is absent, no model prefix appears in the judge cost line."""
+        from rich.console import Console
+
+        from raki.report.cli_summary import print_summary
+
+        report = EvalReport(
+            run_id="judge-cost-only-test",
+            config={
+                "judge_cost": {
+                    "input_tokens": 15000,
+                    "output_tokens": 3000,
+                    "calls": 24,
+                },
+            },
+            aggregate_scores={"first_pass_success_rate": 0.8},
+        )
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=False, width=120)
+        print_summary(report, session_count=10, console=test_console)
+        output = string_io.getvalue()
+        assert "Judge: 24 calls" in output
+
 
 # --- HTML report tests ---
 
@@ -323,3 +399,70 @@ class TestHtmlReportJudgeCost:
         write_html_report(report, output_path, session_count=10)
         html_content = output_path.read_text()
         assert "Judge:" not in html_content
+
+    def test_judge_model_and_provider_in_html_report(self, tmp_path: Path) -> None:
+        """When llm_model and llm_provider are set, both appear in the HTML header."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="html-judge-model-provider-test",
+            config={
+                "llm_model": "claude-sonnet-4-6",
+                "llm_provider": "vertex-anthropic",
+                "judge_cost": {
+                    "input_tokens": 41861,
+                    "output_tokens": 11558,
+                    "calls": 20,
+                },
+            },
+            aggregate_scores={"first_pass_success_rate": 0.8},
+        )
+        output_path = tmp_path / "report.html"
+        write_html_report(report, output_path, session_count=10)
+        html_content = output_path.read_text()
+        assert "claude-sonnet-4-6" in html_content
+        assert "vertex-anthropic" in html_content
+        assert "20 calls" in html_content
+
+    def test_judge_model_only_in_html_report(self, tmp_path: Path) -> None:
+        """When only llm_model is set, model appears without provider in HTML header."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="html-judge-model-only-test",
+            config={
+                "llm_model": "claude-opus-4",
+                "judge_cost": {
+                    "input_tokens": 5000,
+                    "output_tokens": 1000,
+                    "calls": 5,
+                },
+            },
+            aggregate_scores={"first_pass_success_rate": 0.8},
+        )
+        output_path = tmp_path / "report.html"
+        write_html_report(report, output_path, session_count=10)
+        html_content = output_path.read_text()
+        assert "claude-opus-4" in html_content
+        assert "5 calls" in html_content
+
+    def test_judge_cost_only_no_model_in_html_report(self, tmp_path: Path) -> None:
+        """When llm_model is absent, no model prefix appears in the HTML judge span."""
+        from raki.report.html_report import write_html_report
+
+        report = EvalReport(
+            run_id="html-judge-cost-only-test",
+            config={
+                "judge_cost": {
+                    "input_tokens": 15000,
+                    "output_tokens": 3000,
+                    "calls": 24,
+                },
+            },
+            aggregate_scores={"first_pass_success_rate": 0.8},
+        )
+        output_path = tmp_path / "report.html"
+        write_html_report(report, output_path, session_count=10)
+        html_content = output_path.read_text()
+        assert "24 calls" in html_content
+        assert "Judge:" in html_content


### PR DESCRIPTION
## Summary

- CLI judge cost line now includes model name: `Judge: claude-sonnet-4-6 (vertex-anthropic) · 20 calls, 41,861 in / 11,558 out tokens`
- HTML report header shows judge model alongside token counts
- 6 new test cases covering both CLI and HTML rendering

## Test plan

- [x] `uv run pytest tests/test_judge_cost.py tests/test_report.py tests/test_report_html.py -v` — 250 passed
- [x] Judge model shown when present, gracefully hidden when absent (no `--judge` run)

Refs #207

🤖 Generated with [SODA](https://github.com/soda-ai/soda) + [Claude Code](https://claude.com/claude-code)