### PR TITLE
feat: add LiteLLM provider adapter for judge metrics (#103)

### DIFF
--- a/changes/103.feature
+++ b/changes/103.feature
@@ -1,0 +1,8 @@
+Add ``"litellm"`` as a supported LLM provider for Ragas judge metrics.
+
+Set ``llm_provider: litellm`` in your ``MetricConfig`` to route model calls
+through LiteLLM, enabling any model supported by LiteLLM (OpenAI, Bedrock,
+Cohere, etc.) as a judge. Token usage is tracked at the ``litellm.acompletion``
+module level and reported in the standard judge-cost summary.
+
+Install the optional dependency with ``pip install raki[litellm]``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ ragas = [
     "google-genai>=1.0",
     "langchain-google-vertexai>=2.0",
 ]
+litellm = [
+    "litellm>=1.0",
+]
 html = [
     "jinja2>=3.0",
 ]
@@ -36,7 +39,7 @@ dev = [
     "towncrier>=24.8",
     "ty",
 ]
-all = ["raki[ragas,html,dev]"]
+all = ["raki[ragas,litellm,html,dev]"]
 
 [project.scripts]
 raki = "raki.cli:main"

--- a/src/raki/metrics/protocol.py
+++ b/src/raki/metrics/protocol.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from raki.model import EvalDataset
 from raki.model.report import MetricResult
 
-LLMProvider = Literal["vertex-anthropic", "anthropic", "google"]
+LLMProvider = Literal["vertex-anthropic", "anthropic", "google", "litellm"]
 
 
 @dataclass

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -4,6 +4,7 @@ Uses Ragas 0.4 llm_factory with configurable LLM client:
 - vertex-anthropic (default): AsyncAnthropicVertex for Vertex AI
 - anthropic: AsyncAnthropic for direct Anthropic API
 - google: Google GenAI client via Vertex AI
+- litellm: LiteLLM module via Ragas's LiteLLMAdapter
 """
 
 from __future__ import annotations
@@ -49,6 +50,30 @@ def patch_client_for_token_tracking(client: object, accumulator: TokenAccumulato
     client.messages.create = tracked_create  # ty: ignore[unresolved-attribute]
 
 
+def patch_litellm_for_token_tracking(litellm_module: object, accumulator: TokenAccumulator) -> None:
+    """Monkey-patch the litellm module to track token usage.
+
+    Wraps ``litellm.acompletion`` so that every call increments the accumulator
+    with the response's ``usage.prompt_tokens`` and ``usage.completion_tokens``.
+    The response is returned unmodified.
+
+    Ragas passes the ``litellm`` module itself as the client to
+    ``LiteLLMAdapter``, so patching at module level is the correct approach.
+    """
+    original_acompletion = litellm_module.acompletion  # ty: ignore[unresolved-attribute]
+
+    @functools.wraps(original_acompletion)
+    async def tracked_acompletion(*args, **kwargs):  # type: ignore[no-untyped-def]
+        response = await original_acompletion(*args, **kwargs)
+        if hasattr(response, "usage") and response.usage is not None:
+            accumulator.input_tokens += response.usage.prompt_tokens
+            accumulator.output_tokens += response.usage.completion_tokens
+        accumulator.calls += 1
+        return response
+
+    litellm_module.acompletion = tracked_acompletion  # ty: ignore[unresolved-attribute]
+
+
 def create_ragas_llm(config: MetricConfig):
     """Create a Ragas LLM using the 0.4 llm_factory.
 
@@ -57,8 +82,9 @@ def create_ragas_llm(config: MetricConfig):
     - ``vertex-anthropic`` (default) -- uses ``AsyncAnthropicVertex``
     - ``anthropic`` -- uses ``AsyncAnthropic`` (direct Anthropic API)
     - ``google`` -- uses ``google.genai.Client`` via Vertex AI
+    - ``litellm`` -- uses the ``litellm`` module via Ragas's ``LiteLLMAdapter``
 
-    Defers ragas and anthropic/google imports so this module can be imported
+    Defers ragas and provider-specific imports so this module can be imported
     without those packages installed.
 
     Raises:
@@ -91,6 +117,23 @@ def create_ragas_llm(config: MetricConfig):
             config.llm_model,
             provider="google",
             client=client,
+            temperature=config.temperature,
+            max_tokens=4096,
+        )
+        llm.model_args.pop("top_p", None)  # ty: ignore[unresolved-attribute]
+        return llm
+    elif config.llm_provider == "litellm":
+        import litellm  # ty: ignore[unresolved-import]
+
+        if config.token_accumulator is not None:
+            patch_litellm_for_token_tracking(litellm, config.token_accumulator)
+
+        from ragas.llms import llm_factory  # ty: ignore[unresolved-import]
+
+        llm = llm_factory(
+            config.llm_model,
+            provider="litellm",
+            client=litellm,
             temperature=config.temperature,
             max_tokens=4096,
         )

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -1625,6 +1625,261 @@ class TestGoogleProvider:
 
 
 # ---------------------------------------------------------------------------
+# LiteLLM provider tests — verify create_ragas_llm dispatches to LiteLLM
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMProvider:
+    """Tests for the 'litellm' provider branch in create_ragas_llm()."""
+
+    def _setup_litellm_mocks(self, monkeypatch):
+        """Set up common mocks for litellm provider tests."""
+        import sys
+        from importlib import reload
+
+        mock_litellm = MagicMock()
+        monkeypatch.setitem(sys.modules, "litellm", mock_litellm)
+
+        mock_llm = MagicMock()
+        mock_factory = MagicMock(return_value=mock_llm)
+        monkeypatch.setitem(sys.modules, "ragas.llms", MagicMock(llm_factory=mock_factory))
+
+        from raki.metrics.ragas import llm_setup
+
+        reload(llm_setup)
+
+        return {
+            "litellm": mock_litellm,
+            "llm": mock_llm,
+            "factory": mock_factory,
+            "module": llm_setup,
+        }
+
+    def test_litellm_provider_creates_llm(self, monkeypatch):
+        """litellm provider dispatches to llm_factory with provider='litellm'."""
+        mocks = self._setup_litellm_mocks(monkeypatch)
+
+        config = MetricConfig(llm_provider="litellm", llm_model="gpt-4o")
+        result = mocks["module"].create_ragas_llm(config)
+
+        mocks["factory"].assert_called_once()
+        call_kwargs = mocks["factory"].call_args
+        assert call_kwargs[0][0] == "gpt-4o"
+        assert call_kwargs[1]["provider"] == "litellm"
+        assert result is mocks["llm"]
+
+    def test_litellm_provider_passes_litellm_module_as_client(self, monkeypatch):
+        """The litellm module itself must be passed as the client."""
+        mocks = self._setup_litellm_mocks(monkeypatch)
+
+        config = MetricConfig(llm_provider="litellm", llm_model="gpt-4o")
+        mocks["module"].create_ragas_llm(config)
+
+        call_kwargs = mocks["factory"].call_args
+        assert call_kwargs[1]["client"] is mocks["litellm"]
+
+    def test_litellm_provider_forwards_temperature(self, monkeypatch):
+        """Temperature from MetricConfig is passed to llm_factory."""
+        mocks = self._setup_litellm_mocks(monkeypatch)
+
+        config = MetricConfig(llm_provider="litellm", llm_model="gpt-4o", temperature=0.3)
+        mocks["module"].create_ragas_llm(config)
+
+        call_kwargs = mocks["factory"].call_args
+        assert call_kwargs[1]["temperature"] == 0.3
+
+    def test_litellm_provider_removes_top_p(self, monkeypatch):
+        """top_p must be removed from model_args to avoid backend rejection."""
+        mocks = self._setup_litellm_mocks(monkeypatch)
+
+        # Give the mock llm a real model_args dict so pop is testable
+        mock_llm = mocks["llm"]
+        mock_llm.model_args = {"top_p": 0.9, "temperature": 0.0}
+        mocks["factory"].return_value = mock_llm
+
+        config = MetricConfig(llm_provider="litellm", llm_model="gpt-4o")
+        mocks["module"].create_ragas_llm(config)
+
+        assert "top_p" not in mock_llm.model_args
+
+    def test_litellm_in_supported_providers(self):
+        """'litellm' must appear in SUPPORTED_PROVIDERS."""
+        from raki.metrics.ragas.llm_setup import SUPPORTED_PROVIDERS
+
+        assert "litellm" in SUPPORTED_PROVIDERS
+
+    def test_litellm_provider_no_token_accumulator_skips_patch(self, monkeypatch):
+        """When token_accumulator is None, acompletion must not be patched."""
+        import sys
+        from importlib import reload
+
+        mock_litellm = MagicMock()
+        original_acompletion = mock_litellm.acompletion
+        monkeypatch.setitem(sys.modules, "litellm", mock_litellm)
+        monkeypatch.setitem(
+            sys.modules, "ragas.llms", MagicMock(llm_factory=MagicMock(return_value=MagicMock()))
+        )
+
+        from raki.metrics.ragas import llm_setup
+
+        reload(llm_setup)
+
+        config = MetricConfig(llm_provider="litellm", llm_model="gpt-4o", token_accumulator=None)
+        llm_setup.create_ragas_llm(config)
+
+        # acompletion must not have been replaced
+        assert mock_litellm.acompletion is original_acompletion
+
+
+class TestPatchLiteLLMForTokenTracking:
+    """Tests for patch_litellm_for_token_tracking()."""
+
+    def _make_usage(self, prompt_tokens: int, completion_tokens: int):
+        usage = MagicMock()
+        usage.prompt_tokens = prompt_tokens
+        usage.completion_tokens = completion_tokens
+        return usage
+
+    def test_tracks_input_and_output_tokens(self):
+        """Wrapping acompletion should increment input_tokens and output_tokens."""
+        import asyncio
+
+        from raki.metrics.protocol import TokenAccumulator
+        from raki.metrics.ragas.llm_setup import patch_litellm_for_token_tracking
+
+        accumulator = TokenAccumulator()
+        mock_response = MagicMock()
+        mock_response.usage = self._make_usage(prompt_tokens=10, completion_tokens=5)
+
+        mock_litellm = MagicMock()
+        mock_litellm.acompletion = AsyncMock(return_value=mock_response)
+
+        patch_litellm_for_token_tracking(mock_litellm, accumulator)
+        asyncio.run(mock_litellm.acompletion(model="gpt-4o", messages=[]))
+
+        assert accumulator.input_tokens == 10
+        assert accumulator.output_tokens == 5
+        assert accumulator.calls == 1
+
+    def test_accumulates_across_multiple_calls(self):
+        """Accumulator totals should grow with each acompletion call."""
+        import asyncio
+
+        from raki.metrics.protocol import TokenAccumulator
+        from raki.metrics.ragas.llm_setup import patch_litellm_for_token_tracking
+
+        accumulator = TokenAccumulator()
+        mock_litellm = MagicMock()
+
+        call_count = 0
+
+        async def fake_acompletion(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            resp.usage = self._make_usage(prompt_tokens=4, completion_tokens=2)
+            return resp
+
+        mock_litellm.acompletion = fake_acompletion
+
+        patch_litellm_for_token_tracking(mock_litellm, accumulator)
+        asyncio.run(mock_litellm.acompletion())
+        asyncio.run(mock_litellm.acompletion())
+        asyncio.run(mock_litellm.acompletion())
+
+        assert accumulator.input_tokens == 12
+        assert accumulator.output_tokens == 6
+        assert accumulator.calls == 3
+
+    def test_missing_usage_does_not_crash(self):
+        """When the response has no usage attribute, accumulator.calls still increments."""
+        import asyncio
+
+        from raki.metrics.protocol import TokenAccumulator
+        from raki.metrics.ragas.llm_setup import patch_litellm_for_token_tracking
+
+        accumulator = TokenAccumulator()
+        mock_response = MagicMock(spec=[])  # no attributes at all
+        mock_litellm = MagicMock()
+        mock_litellm.acompletion = AsyncMock(return_value=mock_response)
+
+        patch_litellm_for_token_tracking(mock_litellm, accumulator)
+        asyncio.run(mock_litellm.acompletion())
+
+        assert accumulator.input_tokens == 0
+        assert accumulator.output_tokens == 0
+        assert accumulator.calls == 1
+
+    def test_none_usage_does_not_crash(self):
+        """When response.usage is None, accumulator.calls still increments."""
+        import asyncio
+
+        from raki.metrics.protocol import TokenAccumulator
+        from raki.metrics.ragas.llm_setup import patch_litellm_for_token_tracking
+
+        accumulator = TokenAccumulator()
+        mock_response = MagicMock()
+        mock_response.usage = None
+        mock_litellm = MagicMock()
+        mock_litellm.acompletion = AsyncMock(return_value=mock_response)
+
+        patch_litellm_for_token_tracking(mock_litellm, accumulator)
+        asyncio.run(mock_litellm.acompletion())
+
+        assert accumulator.input_tokens == 0
+        assert accumulator.output_tokens == 0
+        assert accumulator.calls == 1
+
+    def test_original_response_returned_unmodified(self):
+        """The response object must be returned intact."""
+        import asyncio
+
+        from raki.metrics.protocol import TokenAccumulator
+        from raki.metrics.ragas.llm_setup import patch_litellm_for_token_tracking
+
+        sentinel = object()
+        mock_response = MagicMock()
+        mock_response.usage = self._make_usage(1, 1)
+        mock_response._sentinel = sentinel
+
+        accumulator = TokenAccumulator()
+        mock_litellm = MagicMock()
+        mock_litellm.acompletion = AsyncMock(return_value=mock_response)
+
+        patch_litellm_for_token_tracking(mock_litellm, accumulator)
+        result = asyncio.run(mock_litellm.acompletion())
+
+        assert result is mock_response
+
+    def test_litellm_provider_with_accumulator_patches_acompletion(self, monkeypatch):
+        """When token_accumulator is set, acompletion is replaced on the module."""
+        import sys
+        from importlib import reload
+
+        from raki.metrics.protocol import TokenAccumulator
+
+        accumulator = TokenAccumulator()
+        mock_litellm = MagicMock()
+        original_acompletion = mock_litellm.acompletion
+        monkeypatch.setitem(sys.modules, "litellm", mock_litellm)
+        monkeypatch.setitem(
+            sys.modules, "ragas.llms", MagicMock(llm_factory=MagicMock(return_value=MagicMock()))
+        )
+
+        from raki.metrics.ragas import llm_setup
+
+        reload(llm_setup)
+
+        config = MetricConfig(
+            llm_provider="litellm", llm_model="gpt-4o", token_accumulator=accumulator
+        )
+        llm_setup.create_ragas_llm(config)
+
+        # acompletion must have been replaced by the wrapper
+        assert mock_litellm.acompletion is not original_acompletion
+
+
+# ---------------------------------------------------------------------------
 # instructor#1658 silent-zero detection tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `litellm` to `LLMProvider` Literal type
- Adds `litellm` optional dependency in `pyproject.toml`
- New dispatch branch in `create_ragas_llm()` for LiteLLM provider
- `patch_litellm_for_token_tracking()` captures token usage from LiteLLM responses
- 255 lines of mock-based tests (no real API calls)

## Test plan

- [x] `uv run pytest tests/test_metrics_ragas.py -v` — 168 passed
- [x] LiteLLM dispatch creates correct client
- [x] Token tracking works with LiteLLM response format
- [x] Existing anthropic/vertex-anthropic paths unchanged

Refs #103

🤖 Generated with [SODA](https://github.com/soda-ai/soda) + [Claude Code](https://claude.com/claude-code)