### PR TITLE
fix: knowledge_miss_rate on SODA sessions — skip synthesized context (#183)

### DIFF
--- a/changes/183.fix
+++ b/changes/183.fix
@@ -1,0 +1,15 @@
+Fix ``knowledge_miss_rate`` and ``knowledge_gap_rate`` returning 1.0 / 0.0 on SODA sessions.
+
+Two root causes were fixed:
+
+* **Knowledge metrics false positives**: ``_compute_with_knowledge_context()`` in both
+  ``miss_rate.py`` and ``gap_rate.py`` never checked ``sample.context_source``, so
+  synthesized context (built from transcript tool-call outputs) trivially matched every
+  finding via 1-token overlap, pushing miss_rate to 1.0 and gap_rate to 0.0 for all
+  SODA sessions.  Both methods now skip samples with ``context_source == "synthesized"``
+  and return N/A instead.
+
+* **Alcove adapter missing ``output_structured``**: ``_build_phases()`` never passed
+  ``output_structured`` to ``PhaseResult``, so ``_extract_domains()`` always saw an
+  empty dict and ground-truth matching produced zero matches.  Phase results now carry
+  ``output_structured=redact_dict(phase_meta)`` from the phases dict metadata.

--- a/src/raki/adapters/alcove.py
+++ b/src/raki/adapters/alcove.py
@@ -434,6 +434,7 @@ class AlcoveAdapter:
                     else (tokens_out if is_last else None),
                     output=output if is_last else "",
                     tool_calls=tool_calls if is_last else [],
+                    output_structured=redact_dict(phase_meta) if phase_meta else None,
                 )
             )
         return phases

--- a/src/raki/metrics/knowledge/gap_rate.py
+++ b/src/raki/metrics/knowledge/gap_rate.py
@@ -111,6 +111,9 @@ class KnowledgeGapRate:
             if sample.session.rework_cycles == 0:
                 continue
 
+            if sample.context_source == "synthesized":
+                continue  # Synthesized context matches too loosely; skip for knowledge metrics
+
             knowledge_text = extract_knowledge_context(sample)
             if not knowledge_text:
                 continue  # Skip this entire session -- don't count its findings

--- a/src/raki/metrics/knowledge/miss_rate.py
+++ b/src/raki/metrics/knowledge/miss_rate.py
@@ -113,6 +113,9 @@ class KnowledgeMissRate:
             if sample.session.rework_cycles == 0:
                 continue
 
+            if sample.context_source == "synthesized":
+                continue  # Synthesized context matches too loosely; skip for knowledge metrics
+
             knowledge_text = extract_knowledge_context(sample)
             if not knowledge_text:
                 continue  # Skip this entire session -- don't count its findings

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -2926,3 +2926,93 @@ def test_alcove_classic_fixture_orchestrator():
     assert sample.session.orchestrator == "alcove"
     assert sample.session.pipeline_phases is None
     assert sample.session.provider is None
+
+
+# --- Alcove output_structured from phases dict (fix #183) ---
+
+
+def test_alcove_phases_output_structured_populated(tmp_path):
+    """PhaseResult.output_structured must be populated from the phases dict metadata.
+
+    Without this fix, _build_phases() never passed output_structured to
+    PhaseResult, so _extract_domains() always returned {} and ground-truth
+    matching was broken for all alcove/bridge sessions.
+    """
+    phases_data = {
+        "triage": {
+            "status": "completed",
+            "cost_usd": 0.3,
+            "generation": 1,
+            "approach": "Patch the dependency version",
+            "code_area": "deps",
+        },
+        "implement": {
+            "status": "completed",
+            "cost_usd": 1.2,
+            "generation": 1,
+        },
+    }
+    source = _bridge_session(tmp_path, overrides={"phases": phases_data})
+    adapter = AlcoveAdapter()
+    sample = adapter.load(source)
+
+    triage_phases = [phase for phase in sample.phases if phase.name == "triage"]
+    assert len(triage_phases) == 1
+    triage = triage_phases[0]
+
+    # output_structured must be populated so ground-truth matching can read it
+    assert triage.output_structured is not None
+    assert triage.output_structured.get("approach") == "Patch the dependency version"
+    assert triage.output_structured.get("code_area") == "deps"
+
+
+def test_alcove_phases_empty_phase_meta_output_structured_none(tmp_path):
+    """When a phase entry in the phases dict is None (null), output_structured must be None.
+
+    A None/empty phase_meta means there is no metadata to store; passing None
+    to redact_dict() would error, so the adapter must guard with 'if phase_meta'.
+    """
+    # phases dict with a null value for triage
+    data = {
+        "id": "bridge-null-phase",
+        "task_id": "task-null",
+        "started_at": "2026-04-22T10:00:00Z",
+        "status": "completed",
+        "transcript": [
+            {"type": "system", "model": "claude-sonnet-4-6"},
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "content": [{"type": "text", "text": "done"}],
+                },
+            },
+            {"type": "result", "total_cost_usd": 0.01, "duration_ms": 1000},
+        ],
+        "phases": {"triage": None},
+    }
+    session_file = tmp_path / "null-phase.json"
+    session_file.write_text(json.dumps(data))
+    adapter = AlcoveAdapter()
+    sample = adapter.load(session_file)
+
+    triage_phases = [phase for phase in sample.phases if phase.name == "triage"]
+    assert len(triage_phases) == 1
+    # Null phase_meta → output_structured must be None (not an empty dict)
+    assert triage_phases[0].output_structured is None
+
+
+def test_alcove_no_phases_dict_output_structured_none(tmp_path):
+    """When no phases dict is present, the single 'session' phase has output_structured=None.
+
+    The single-phase fallback path in _build_phases() always had output_structured=None
+    (not affected by the fix).  This test verifies the unchanged path still works.
+    """
+    source = _bridge_session(tmp_path)  # no phases override → falls back to single phase
+    adapter = AlcoveAdapter()
+    sample = adapter.load(source)
+
+    assert len(sample.phases) == 1
+    assert sample.phases[0].name == "session"
+    assert sample.phases[0].output_structured is None

--- a/tests/test_metrics_knowledge.py
+++ b/tests/test_metrics_knowledge.py
@@ -1150,3 +1150,177 @@ class TestKnowledgeGapRateStrictDocChunks:
         # 'domain' tier → covered → not uncovered
         assert result.details["uncovered_findings"] == 0
         assert result.score == 0.0
+
+
+# --- Synthesized context: knowledge metrics must not count it (fix #183) ---
+
+
+class TestKnowledgeMissRateSynthesizedContext:
+    """KnowledgeMissRate._compute_with_knowledge_context skips synthesized samples."""
+
+    def _make_sample_with_context(
+        self,
+        session_id: str,
+        knowledge_context: str,
+        context_source: str | None,
+    ) -> EvalSample:
+        meta = SessionMeta(
+            session_id=session_id,
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=2,
+            rework_cycles=1,
+        )
+        phase = PhaseResult(
+            name="session",
+            generation=1,
+            status="completed",
+            output="done",
+            knowledge_context=knowledge_context,
+        )
+        finding = ReviewFinding(
+            reviewer="ai-review",
+            severity="critical",
+            issue="Missing authentication token validation",
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[phase],
+            findings=[finding],
+            events=[],
+        )
+        # EvalSample.context_source is a Literal field; set it directly
+        sample.context_source = context_source  # type: ignore[assignment]
+        return sample
+
+    def test_synthesized_context_returns_na(self):
+        """When context_source is 'synthesized', miss_rate returns N/A (score=None).
+
+        Synthesized context is built from tool-call outputs and is too broad;
+        it trivially matches every finding, inflating miss_rate to 1.0 falsely.
+        """
+        from raki.metrics.knowledge.miss_rate import KnowledgeMissRate
+
+        # Knowledge context covers the finding's words — without the fix this
+        # would produce score=1.0 (false positive).
+        sample = self._make_sample_with_context(
+            session_id="synth-miss",
+            knowledge_context="Authentication tokens must be validated before processing",
+            context_source="synthesized",
+        )
+        dataset = make_dataset(sample)
+        result = KnowledgeMissRate().compute(dataset, MetricConfig())
+        assert result.score is None, "Synthesized context must be skipped (N/A expected)"
+        assert result.details["total_rework_findings"] == 0
+
+    def test_explicit_context_is_still_used(self):
+        """When context_source is 'explicit', miss_rate processes the sample normally."""
+        from raki.metrics.knowledge.miss_rate import KnowledgeMissRate
+
+        sample = self._make_sample_with_context(
+            session_id="explicit-miss",
+            knowledge_context="Authentication tokens must be validated before processing",
+            context_source="explicit",
+        )
+        dataset = make_dataset(sample)
+        result = KnowledgeMissRate().compute(dataset, MetricConfig())
+        # Finding overlaps with knowledge_context → covered → score=1.0
+        assert result.score == 1.0
+        assert result.details["covered_findings"] == 1
+
+    def test_none_context_source_is_still_used(self):
+        """When context_source is None (legacy), miss_rate processes the sample normally."""
+        from raki.metrics.knowledge.miss_rate import KnowledgeMissRate
+
+        sample = self._make_sample_with_context(
+            session_id="none-source-miss",
+            knowledge_context="Authentication tokens must be validated before processing",
+            context_source=None,
+        )
+        dataset = make_dataset(sample)
+        result = KnowledgeMissRate().compute(dataset, MetricConfig())
+        assert result.score == 1.0
+        assert result.details["covered_findings"] == 1
+
+
+class TestKnowledgeGapRateSynthesizedContext:
+    """KnowledgeGapRate._compute_with_knowledge_context skips synthesized samples."""
+
+    def _make_sample_with_context(
+        self,
+        session_id: str,
+        knowledge_context: str,
+        context_source: str | None,
+    ) -> EvalSample:
+        meta = SessionMeta(
+            session_id=session_id,
+            started_at=datetime(2026, 4, 10, tzinfo=timezone.utc),
+            total_phases=2,
+            rework_cycles=1,
+        )
+        phase = PhaseResult(
+            name="session",
+            generation=1,
+            status="completed",
+            output="done",
+            knowledge_context=knowledge_context,
+        )
+        finding = ReviewFinding(
+            reviewer="ai-review",
+            severity="critical",
+            issue="Missing authentication token validation",
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[phase],
+            findings=[finding],
+            events=[],
+        )
+        sample.context_source = context_source  # type: ignore[assignment]
+        return sample
+
+    def test_synthesized_context_returns_na(self):
+        """When context_source is 'synthesized', gap_rate returns N/A (score=None).
+
+        Synthesized context matches too broadly; it covers every finding and
+        pushes gap_rate toward 0.0 (a false negative — appearing gap-free).
+        """
+        from raki.metrics.knowledge.gap_rate import KnowledgeGapRate
+
+        sample = self._make_sample_with_context(
+            session_id="synth-gap",
+            knowledge_context="Authentication tokens must be validated before processing",
+            context_source="synthesized",
+        )
+        dataset = make_dataset(sample)
+        result = KnowledgeGapRate().compute(dataset, MetricConfig())
+        assert result.score is None, "Synthesized context must be skipped (N/A expected)"
+        assert result.details["total_rework_findings"] == 0
+
+    def test_explicit_context_is_still_used(self):
+        """When context_source is 'explicit', gap_rate processes the sample normally."""
+        from raki.metrics.knowledge.gap_rate import KnowledgeGapRate
+
+        sample = self._make_sample_with_context(
+            session_id="explicit-gap",
+            knowledge_context="Authentication tokens must be validated before processing",
+            context_source="explicit",
+        )
+        dataset = make_dataset(sample)
+        result = KnowledgeGapRate().compute(dataset, MetricConfig())
+        # Finding overlaps with knowledge_context → covered → uncovered_findings=0, score=0.0
+        assert result.score == 0.0
+        assert result.details["uncovered_findings"] == 0
+
+    def test_none_context_source_is_still_used(self):
+        """When context_source is None (legacy), gap_rate processes the sample normally."""
+        from raki.metrics.knowledge.gap_rate import KnowledgeGapRate
+
+        sample = self._make_sample_with_context(
+            session_id="none-source-gap",
+            knowledge_context="Authentication tokens must be validated before processing",
+            context_source=None,
+        )
+        dataset = make_dataset(sample)
+        result = KnowledgeGapRate().compute(dataset, MetricConfig())
+        assert result.score == 0.0
+        assert result.details["uncovered_findings"] == 0


### PR DESCRIPTION
## Summary

Two fixes for knowledge metrics on SODA/Alcove sessions:

1. **Skip synthesized context in knowledge metrics** — `miss_rate` and `gap_rate` now return `None` (instead of false 1.0) when `knowledge_context` was synthesized by the adapter rather than explicitly provided. The synthesized context contains the session's own domain terms, making word-overlap matching trivially easy and producing misleading scores.

2. **Populate `output_structured` in Alcove adapter** — `_build_phases()` now passes `output_structured` from the phase's JSON content to `PhaseResult`, enabling ground truth matching via `_extract_domains()` for Alcove/bridge sessions.

## Test plan

- [x] `uv run pytest tests/ -v -m "not slow"` — 1273 passed
- [x] 6 new tests for synthesized-context skip behavior
- [x] 3 new tests for `output_structured` population in Alcove adapter
- [x] Knowledge metrics return `None` with synthesized context, work correctly with explicit context

Refs #183

🤖 Generated with [SODA](https://github.com/soda-ai/soda) + [Claude Code](https://claude.com/claude-code)