### PR TITLE
feat: synthesize review findings from Alcove transcripts (#186)

### DIFF
--- a/changes/186.feature
+++ b/changes/186.feature
@@ -1,0 +1,30 @@
+Synthesize ``ReviewFinding`` objects from Alcove/bridge transcript tool failures.
+
+When an Alcove transcript contains test or lint command failures (e.g. ``pytest``,
+``ruff``, ``cargo test``) and no explicit ``findings`` array is provided in the JSON,
+the adapter now generates ``ReviewFinding`` objects directly from the failure output.
+Each synthesized finding has:
+
+- ``finding_source="synthesized"`` — a new discriminant field on ``ReviewFinding``.
+- ``severity="major"``, ``reviewer="synthesized"``.
+- Duplicate failure texts are collapsed to one finding (e.g. repeated test runs).
+
+Explicit findings parsed from the ``findings`` JSON key are tagged
+``finding_source="review"`` so callers can always tell the two apart.
+
+**Metric impact**
+
+- ``review_severity_distribution`` — synthesized findings *do* count (real
+  code quality signal).
+- ``knowledge_gap_rate`` / ``knowledge_miss_rate`` — synthesized findings
+  *excluded* from both the ``doc_chunks`` path and the legacy
+  ``knowledge_context`` path (raw tool output matches too broadly).
+- ``self_correction_rate`` — synthesized findings *excluded* from the
+  denominator (they are not actionable reviewer feedback).
+
+**CLI & HTML**
+
+- Summary sentence notes synthesized findings: e.g.
+  *"Reviewers found 2 major issues (3 synthesized from test failures)"*.
+- HTML drill-down badges synthesized findings with a grey *"synthesized"* label
+  and shows an explanatory footnote.

--- a/src/raki/adapters/alcove.py
+++ b/src/raki/adapters/alcove.py
@@ -327,6 +327,13 @@ class AlcoveAdapter:
         # Explicit values in the JSON take priority; transcript analysis is the fallback.
         tool_sequence = _extract_tool_sequence(transcript)
 
+        # Synthesize findings from test/lint failures when no explicit findings provided.
+        # Synthesized findings are marked with finding_source="synthesized" so that
+        # knowledge metrics and self-correction rate can exclude them.
+        if not findings:
+            synthesized = self._synthesize_findings(tool_sequence)
+            findings = synthesized
+
         if "rework_cycles" in raw:
             rework_cycles = raw["rework_cycles"]
         else:
@@ -444,6 +451,7 @@ class AlcoveAdapter:
 
         Skips malformed entries (missing required ``issue`` key or invalid
         severity).  Applies ``redact_sensitive()`` to free-text fields.
+        Sets ``finding_source="review"`` to mark these as human review findings.
         """
         findings: list[ReviewFinding] = []
         for finding_raw in raw_findings:
@@ -460,10 +468,56 @@ class AlcoveAdapter:
                         suggestion=redact_sensitive(suggestion)
                         if (suggestion := finding_raw.get("suggestion")) is not None
                         else None,
+                        finding_source="review",
                     )
                 )
             except (KeyError, ValueError):
                 continue
+        return findings
+
+    def _synthesize_findings(self, tool_sequence: list[dict]) -> list[ReviewFinding]:
+        """Create ``ReviewFinding`` objects from test/lint failures in the transcript.
+
+        Iterates the tool sequence (produced by ``_extract_tool_sequence``) and
+        collects the result text from every testing-phase tool call that ended in
+        a failure.  Duplicate failure texts are collapsed to a single finding so
+        that repeated test runs of the same broken test don't inflate counts.
+
+        Each synthesized finding has:
+        - ``reviewer="synthesized"``
+        - ``severity="major"`` (tool failures are actionable but not necessarily critical)
+        - ``finding_source="synthesized"``
+
+        Returns an empty list when no testing failures are present.
+        """
+        seen_issues: set[str] = set()
+        findings: list[ReviewFinding] = []
+
+        for record in tool_sequence:
+            if not record["is_failure"]:
+                continue
+            result_content = record["result_content"]
+            if not result_content:
+                continue
+            # Truncate to avoid very long issue strings; the first 500 chars
+            # capture the useful failure summary (e.g. pytest short test ID).
+            issue_text = redact_sensitive(result_content[:500].strip())
+            if issue_text in seen_issues:
+                continue
+            seen_issues.add(issue_text)
+
+            tool_input = record.get("tool_input") or {}
+            command = tool_input.get("command", "").strip() if isinstance(tool_input, dict) else ""
+            findings.append(
+                ReviewFinding(
+                    reviewer="synthesized",
+                    severity="major",
+                    issue=issue_text,
+                    suggestion=f"Fix failures reported by: {command}" if command else None,
+                    finding_source="synthesized",
+                )
+            )
+
         return findings
 
     def _synthesize_context(self, transcript: list[dict]) -> str | None:

--- a/src/raki/metrics/knowledge/gap_rate.py
+++ b/src/raki/metrics/knowledge/gap_rate.py
@@ -76,6 +76,10 @@ class KnowledgeGapRate:
             for finding in sample.findings:
                 if finding.severity not in ("critical", "major"):
                     continue
+                # Synthesized findings come from raw tool output; they match too
+                # broadly against doc chunks and would inflate gap rate artificially.
+                if finding.finding_source == "synthesized":
+                    continue
                 total_rework_findings += 1
 
                 if not is_finding_covered_by_chunks(finding, config.doc_chunks):

--- a/src/raki/metrics/knowledge/miss_rate.py
+++ b/src/raki/metrics/knowledge/miss_rate.py
@@ -78,6 +78,10 @@ class KnowledgeMissRate:
             for finding in sample.findings:
                 if finding.severity not in ("critical", "major"):
                     continue
+                # Synthesized findings come from raw tool output; they match too
+                # broadly against doc chunks and would inflate miss rate artificially.
+                if finding.finding_source == "synthesized":
+                    continue
                 total_rework_findings += 1
 
                 if is_finding_covered_by_chunks(finding, config.doc_chunks):

--- a/src/raki/metrics/operational/self_correction.py
+++ b/src/raki/metrics/operational/self_correction.py
@@ -53,7 +53,13 @@ class SelfCorrectionRate:
                 continue
 
             session_findings = [
-                finding for finding in sample.findings if finding.severity in ("critical", "major")
+                finding
+                for finding in sample.findings
+                if finding.severity in ("critical", "major")
+                # Synthesized findings are not actionable review feedback; exclude
+                # them from self-correction rate so repeated test failures don't
+                # artificially inflate the denominator.
+                and finding.finding_source != "synthesized"
             ]
             session_findings_count = len(session_findings)
             if session_findings_count == 0:

--- a/src/raki/model/phases.py
+++ b/src/raki/model/phases.py
@@ -34,3 +34,4 @@ class ReviewFinding(BaseModel):
     line: int | None = None
     issue: str
     suggestion: str | None = None
+    finding_source: Literal["review", "synthesized"] | None = None

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -167,13 +167,17 @@ def generate_summary_sentence(report: EvalReport, session_count: int) -> str:
     if rework is not None:
         parts.append(f"with an average of {rework:.1f} rework cycles")
 
-    # Count findings from sample_results
+    # Count findings from sample_results, separating review from synthesized
     severity_counter: Counter[str] = Counter()
+    synthesized_count = 0
     for sample_result in report.sample_results:
         for finding in sample_result.sample.findings:
-            severity_counter[finding.severity] += 1
+            if finding.finding_source == "synthesized":
+                synthesized_count += 1
+            else:
+                severity_counter[finding.severity] += 1
 
-    if severity_counter:
+    if severity_counter or synthesized_count:
         finding_parts: list[str] = []
         for severity_level in ("critical", "major", "minor"):
             count = severity_counter.get(severity_level, 0)
@@ -181,7 +185,16 @@ def generate_summary_sentence(report: EvalReport, session_count: int) -> str:
                 finding_parts.append(f"{count} {severity_level}")
         if finding_parts:
             finding_text = ", ".join(finding_parts)
-            parts.append(f"Reviewers found {finding_text} issues across all sessions")
+            verb = "found"
+            note = (
+                f" ({synthesized_count} synthesized from test failures)"
+                if synthesized_count > 0
+                else ""
+            )
+            parts.append(f"Reviewers {verb} {finding_text} issues across all sessions{note}")
+        elif synthesized_count > 0:
+            # Only synthesized findings — no explicit review findings
+            parts.append(f"{synthesized_count} issue(s) synthesized from test/lint failures")
 
     cost = scores.get("cost_efficiency")
     if cost is not None:

--- a/src/raki/report/templates/report.html.j2
+++ b/src/raki/report/templates/report.html.j2
@@ -1010,18 +1010,22 @@
 
       {# Findings #}
       {% if sample.findings %}
+      {% set has_synthesized = sample.findings | selectattr("finding_source", "equalto", "synthesized") | list | length > 0 %}
       <h3>Findings</h3>
       <div class="findings-list">
         {% for finding in sample.findings %}
         <div class="finding-item finding-{{ finding.severity }}">
           <div class="finding-header">
             <span class="severity-badge severity-{{ finding.severity }}">{{ finding.severity }}</span>
+            {% if finding.finding_source == "synthesized" %}
+            <span class="severity-badge" style="background: rgba(100,100,100,0.2); color: var(--text-muted); font-size: 0.7rem;">synthesized</span>
+            {% endif %}
             <span class="finding-issue">{{ finding.issue }}</span>
           </div>
           {% if finding.file %}
           <div class="finding-location">{{ finding.file }}{% if finding.line %}:{{ finding.line }}{% endif %}</div>
           {% endif %}
-          {% if finding.reviewer %}
+          {% if finding.reviewer and finding.finding_source != "synthesized" %}
           <div class="finding-reviewer">Reviewer: {{ finding.reviewer }}</div>
           {% endif %}
           {% if finding.suggestion %}
@@ -1030,6 +1034,12 @@
         </div>
         {% endfor %}
       </div>
+      {% if has_synthesized %}
+      <p style="font-size: 0.8rem; color: var(--text-muted); margin-top: 0.5rem;">
+        † Synthesized findings are inferred from test/lint tool failures in the transcript.
+        They count toward severity score but are excluded from knowledge gap/miss rate and self-correction rate.
+      </p>
+      {% endif %}
       {% else %}
       <p class="empty-state">No review findings in this session</p>
       {% endif %}

--- a/tests/fixtures/sessions/alcove-with-failures.json
+++ b/tests/fixtures/sessions/alcove-with-failures.json
@@ -1,0 +1,91 @@
+{
+    "session_id": "f9b8a7c6-d5e4-3f2a-1b0c-9d8e7f6a5b4c",
+    "transcript": [
+        {
+            "type": "system",
+            "model": "claude-sonnet-4-20250514",
+            "tools": ["Bash", "Edit", "Read"],
+            "subtype": "init",
+            "session_id": "f9b8a7c6-d5e4-3f2a-1b0c-9d8e7f6a5b4c"
+        },
+        {
+            "type": "assistant",
+            "uuid": "aaa111",
+            "message": {
+                "id": "msg_01",
+                "role": "assistant",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+                "content": [
+                    {"id": "toolu_edit1", "name": "Edit", "type": "tool_use", "input": {"file_path": "src/mymodule.py", "old_string": "x = 1", "new_string": "x = 2"}}
+                ]
+            }
+        },
+        {
+            "type": "user",
+            "uuid": "bbb222",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "content": "File edited", "is_error": false, "tool_use_id": "toolu_edit1"}
+                ]
+            },
+            "timestamp": "2026-04-20T10:00:00.000Z"
+        },
+        {
+            "type": "assistant",
+            "uuid": "ccc333",
+            "message": {
+                "id": "msg_02",
+                "role": "assistant",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {"input_tokens": 80, "output_tokens": 30},
+                "content": [
+                    {"id": "toolu_test1", "name": "Bash", "type": "tool_use", "input": {"command": "pytest tests/ -v"}}
+                ]
+            }
+        },
+        {
+            "type": "user",
+            "uuid": "ddd444",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "content": "FAILED tests/test_mymodule.py::test_value - AssertionError: assert 2 == 1\n1 failed, 5 passed", "is_error": false, "tool_use_id": "toolu_test1"}
+                ]
+            }
+        },
+        {
+            "type": "assistant",
+            "uuid": "eee555",
+            "message": {
+                "id": "msg_03",
+                "role": "assistant",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {"input_tokens": 90, "output_tokens": 40},
+                "content": [
+                    {"id": "toolu_lint1", "name": "Bash", "type": "tool_use", "input": {"command": "uv run ruff check src/"}}
+                ]
+            }
+        },
+        {
+            "type": "user",
+            "uuid": "fff666",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "content": "src/mymodule.py:10:5: error: E501 line too long (95 > 88 characters)\nFound 1 error.", "is_error": false, "tool_use_id": "toolu_lint1"}
+                ]
+            }
+        },
+        {
+            "type": "result",
+            "uuid": "ggg777",
+            "subtype": "success",
+            "is_error": false,
+            "total_cost_usd": 0.015,
+            "duration_ms": 5000,
+            "session_id": "f9b8a7c6-d5e4-3f2a-1b0c-9d8e7f6a5b4c"
+        }
+    ]
+}

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -14,6 +14,7 @@ from raki.adapters.session_schema import SessionSchemaAdapter
 FIXTURES = Path(__file__).parent / "fixtures" / "sessions"
 ALCOVE_FIXTURE = FIXTURES / "alcove-simple.json"
 ALCOVE_ID_ONLY_FIXTURE = FIXTURES / "alcove-id-only.json"
+ALCOVE_FAILURES_FIXTURE = FIXTURES / "alcove-with-failures.json"
 
 
 def test_session_schema_adapter_detects_valid_session(
@@ -220,6 +221,210 @@ def test_alcove_adapter_loads_id_only_session():
     assert sample.session.model_id == "claude-sonnet-4-20250514"
     assert len(sample.phases) == 1
     assert sample.phases[0].name == "session"
+
+
+# --- Synthesized findings tests ---
+
+
+def test_alcove_adapter_synthesizes_findings_from_test_failures():
+    """AlcoveAdapter creates synthesized findings when transcript has test failures."""
+    adapter = AlcoveAdapter()
+    sample = adapter.load(ALCOVE_FAILURES_FIXTURE)
+    # Should produce at least one synthesized finding (pytest failure)
+    synthesized = [f for f in sample.findings if f.finding_source == "synthesized"]
+    assert len(synthesized) >= 1
+
+
+def test_alcove_adapter_synthesized_findings_have_major_severity():
+    """Synthesized findings from test failures are rated major severity."""
+    adapter = AlcoveAdapter()
+    sample = adapter.load(ALCOVE_FAILURES_FIXTURE)
+    synthesized = [f for f in sample.findings if f.finding_source == "synthesized"]
+    for finding in synthesized:
+        assert finding.severity == "major"
+
+
+def test_alcove_adapter_synthesized_findings_have_synthesized_reviewer():
+    """Synthesized findings carry 'synthesized' as reviewer name."""
+    adapter = AlcoveAdapter()
+    sample = adapter.load(ALCOVE_FAILURES_FIXTURE)
+    synthesized = [f for f in sample.findings if f.finding_source == "synthesized"]
+    for finding in synthesized:
+        assert finding.reviewer == "synthesized"
+
+
+def test_alcove_adapter_no_synthesized_findings_when_explicit_findings_present(tmp_path):
+    """When explicit findings are provided in the JSON, no synthesis occurs."""
+    transcript_data = {
+        "session_id": "explicit-findings-test",
+        "findings": [{"issue": "Manual review issue", "severity": "minor", "source": "reviewer"}],
+        "transcript": [
+            {
+                "type": "system",
+                "model": "claude-sonnet-4-20250514",
+                "tools": ["Bash"],
+                "subtype": "init",
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_01",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "content": [
+                        {
+                            "id": "toolu_test1",
+                            "name": "Bash",
+                            "type": "tool_use",
+                            "input": {"command": "pytest tests/ -v"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "content": "FAILED tests/test_foo.py::test_bar",
+                            "is_error": False,
+                            "tool_use_id": "toolu_test1",
+                        }
+                    ],
+                },
+                "timestamp": "2026-04-20T10:00:00.000Z",
+            },
+        ],
+    }
+    fixture = tmp_path / "explicit.json"
+    fixture.write_text(json.dumps(transcript_data))
+    adapter = AlcoveAdapter()
+    sample = adapter.load(fixture)
+    # Only the explicit finding should be present (no synthesized ones)
+    assert len(sample.findings) == 1
+    assert sample.findings[0].finding_source == "review"
+    assert sample.findings[0].issue == "Manual review issue"
+
+
+def test_alcove_adapter_deduplicates_repeated_test_failures(tmp_path):
+    """The same failure text repeated across test runs produces only one finding."""
+    duplicate_failure = "FAILED tests/test_foo.py::test_bar - AssertionError"
+    transcript_data = {
+        "session_id": "dedup-test",
+        "transcript": [
+            {
+                "type": "system",
+                "model": "claude-sonnet-4-20250514",
+                "tools": ["Bash"],
+                "subtype": "init",
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_01",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "content": [
+                        {
+                            "id": "toolu_t1",
+                            "name": "Bash",
+                            "type": "tool_use",
+                            "input": {"command": "pytest tests/ -v"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "content": duplicate_failure,
+                            "is_error": False,
+                            "tool_use_id": "toolu_t1",
+                        }
+                    ],
+                },
+                "timestamp": "2026-04-20T10:00:00.000Z",
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_02",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "content": [
+                        {
+                            "id": "toolu_t2",
+                            "name": "Bash",
+                            "type": "tool_use",
+                            "input": {"command": "pytest tests/ -v"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "content": duplicate_failure,
+                            "is_error": False,
+                            "tool_use_id": "toolu_t2",
+                        }
+                    ],
+                },
+            },
+        ],
+    }
+    fixture = tmp_path / "dedup.json"
+    fixture.write_text(json.dumps(transcript_data))
+    adapter = AlcoveAdapter()
+    sample = adapter.load(fixture)
+    synthesized = [f for f in sample.findings if f.finding_source == "synthesized"]
+    # Same failure text → 1 finding, not 2
+    assert len(synthesized) == 1
+
+
+def test_alcove_adapter_no_synthesis_when_no_failures():
+    """When no test failures occur in the transcript, no findings are synthesized."""
+    adapter = AlcoveAdapter()
+    # alcove-simple.json has no test failures in the transcript
+    sample = adapter.load(ALCOVE_FIXTURE)
+    assert sample.findings == []
+
+
+def test_alcove_adapter_parsed_findings_tagged_as_review(tmp_path):
+    """Explicitly provided findings get finding_source='review'."""
+    transcript_data = {
+        "session_id": "review-tag-test",
+        "findings": [
+            {"issue": "Use context manager", "severity": "major", "source": "reviewer"},
+            {"issue": "Missing type hint", "severity": "minor"},
+        ],
+        "transcript": [
+            {
+                "type": "system",
+                "model": "claude-sonnet-4-20250514",
+                "tools": [],
+                "subtype": "init",
+            }
+        ],
+    }
+    fixture = tmp_path / "review_tagged.json"
+    fixture.write_text(json.dumps(transcript_data))
+    adapter = AlcoveAdapter()
+    sample = adapter.load(fixture)
+    assert all(f.finding_source == "review" for f in sample.findings)
 
 
 # --- Redaction tests ---

--- a/tests/test_metrics_knowledge.py
+++ b/tests/test_metrics_knowledge.py
@@ -1324,3 +1324,110 @@ class TestKnowledgeGapRateSynthesizedContext:
         result = KnowledgeGapRate().compute(dataset, MetricConfig())
         assert result.score == 0.0
         assert result.details["uncovered_findings"] == 0
+
+
+# --- Synthesized findings exclusion (ticket #186) ---
+
+
+class TestKnowledgeMetricsExcludeSynthesized:
+    """Knowledge metrics must skip findings with finding_source='synthesized'."""
+
+    def _make_dataset_with_synthesized(self, session_id: str, rework_cycles: int = 1):
+        from datetime import datetime, timezone
+
+        from raki.model import EvalDataset, EvalSample, PhaseResult, ReviewFinding, SessionMeta
+
+        meta = SessionMeta(
+            session_id=session_id,
+            started_at=datetime(2026, 4, 20, tzinfo=timezone.utc),
+            total_phases=2,
+            rework_cycles=rework_cycles,
+        )
+        phases = [PhaseResult(name="implement", generation=1, status="completed", output="done")]
+        # These synthesized findings contain words that overlap with any doc chunk
+        # and would pollute the knowledge metrics if not excluded.
+        findings = [
+            ReviewFinding(
+                reviewer="synthesized",
+                severity="major",
+                issue="FAILED tests/test_auth.py::test_token - AssertionError",
+                finding_source="synthesized",
+            ),
+            ReviewFinding(
+                reviewer="synthesized",
+                severity="major",
+                issue="error: E501 line too long (95 > 88 characters)",
+                finding_source="synthesized",
+            ),
+        ]
+        sample = EvalSample(session=meta, phases=phases, findings=findings, events=[])
+        return EvalDataset(samples=[sample])
+
+    def test_gap_rate_with_doc_chunks_skips_synthesized(self):
+        """gap_rate._compute_with_doc_chunks skips synthesized findings → N/A."""
+        from raki.docs.chunker import DocChunk
+        from raki.metrics.knowledge.gap_rate import KnowledgeGapRate
+
+        chunk = DocChunk(
+            text="Authentication token validation must be checked",
+            domain="auth",
+            source_file="docs/auth.md",
+        )
+        config = MetricConfig(doc_chunks=[chunk])
+        dataset = self._make_dataset_with_synthesized("gap-synth-1")
+        result = KnowledgeGapRate().compute(dataset, config)
+        assert result.score is None
+        assert result.details["total_rework_findings"] == 0
+
+    def test_miss_rate_with_doc_chunks_skips_synthesized(self):
+        """miss_rate._compute_with_doc_chunks skips synthesized findings → N/A."""
+        from raki.docs.chunker import DocChunk
+        from raki.metrics.knowledge.miss_rate import KnowledgeMissRate
+
+        chunk = DocChunk(
+            text="Authentication token validation must be checked",
+            domain="auth",
+            source_file="docs/auth.md",
+        )
+        config = MetricConfig(doc_chunks=[chunk])
+        dataset = self._make_dataset_with_synthesized("miss-synth-1")
+        result = KnowledgeMissRate().compute(dataset, config)
+        assert result.score is None
+        assert result.details["total_rework_findings"] == 0
+
+    def test_gap_rate_review_findings_still_counted_with_doc_chunks(self):
+        """gap_rate still counts review findings with finding_source='review' normally."""
+        from datetime import datetime, timezone
+
+        from raki.docs.chunker import DocChunk
+        from raki.metrics.knowledge.gap_rate import KnowledgeGapRate
+        from raki.model import EvalDataset, EvalSample, PhaseResult, ReviewFinding, SessionMeta
+
+        meta = SessionMeta(
+            session_id="gap-review-1",
+            started_at=datetime(2026, 4, 20, tzinfo=timezone.utc),
+            total_phases=2,
+            rework_cycles=1,
+        )
+        phases = [PhaseResult(name="implement", generation=1, status="completed", output="done")]
+        findings = [
+            ReviewFinding(
+                reviewer="reviewer",
+                severity="major",
+                issue="Missing input validation on the API endpoint",
+                finding_source="review",
+            )
+        ]
+        sample = EvalSample(session=meta, phases=phases, findings=findings, events=[])
+        dataset = EvalDataset(samples=[sample])
+
+        # chunk covers "validation" but not "api endpoint" → uncovered
+        chunk = DocChunk(
+            text="Authentication token checking required",
+            domain="auth",
+            source_file="docs/auth.md",
+        )
+        config = MetricConfig(doc_chunks=[chunk])
+        result = KnowledgeGapRate().compute(dataset, config)
+        assert result.score is not None
+        assert result.details["total_rework_findings"] == 1

--- a/tests/test_metrics_operational.py
+++ b/tests/test_metrics_operational.py
@@ -788,3 +788,92 @@ class TestOperationalMetricRationale:
         from raki.metrics.protocol import Metric
 
         assert hasattr(Metric, "rationale")
+
+
+# --- Synthesized findings exclusion (ticket #186) ---
+
+
+class TestSelfCorrectionRateExcludesSynthesized:
+    """SelfCorrectionRate must not count synthesized findings from transcript failures."""
+
+    def _make_rework_sample(
+        self,
+        session_id: str,
+        *,
+        review_findings: int = 0,
+        synthesized_findings: int = 0,
+        verify_status: str = "completed",
+    ):
+        from raki.model import EvalSample, PhaseResult, ReviewFinding, SessionMeta
+
+        from datetime import datetime, timezone
+
+        findings = []
+        for i in range(review_findings):
+            findings.append(
+                ReviewFinding(
+                    reviewer="reviewer",
+                    severity="major",
+                    issue=f"Review issue {i}",
+                    finding_source="review",
+                )
+            )
+        for i in range(synthesized_findings):
+            findings.append(
+                ReviewFinding(
+                    reviewer="synthesized",
+                    severity="major",
+                    issue=f"FAILED tests/test_x.py::test_{i}",
+                    finding_source="synthesized",
+                )
+            )
+        meta = SessionMeta(
+            session_id=session_id,
+            started_at=datetime(2026, 4, 20, tzinfo=timezone.utc),
+            total_phases=3,
+            rework_cycles=1,
+        )
+        phases = [
+            PhaseResult(name="implement", generation=1, status="completed", output="done"),
+            PhaseResult(
+                name="verify",
+                generation=2,
+                status=verify_status,
+                output="PASS" if verify_status == "completed" else "FAIL",
+            ),
+        ]
+        return EvalSample(session=meta, phases=phases, findings=findings, events=[])
+
+    def test_synthesized_only_returns_na(self):
+        """Session with only synthesized findings → N/A (no rework findings counted)."""
+        from raki.metrics.operational.self_correction import SelfCorrectionRate
+        from raki.model import EvalDataset
+
+        sample = self._make_rework_sample("s1", synthesized_findings=3)
+        dataset = EvalDataset(samples=[sample])
+        result = SelfCorrectionRate().compute(dataset, MetricConfig())
+        assert result.score is None
+
+    def test_review_findings_still_counted(self):
+        """Review findings (finding_source='review') are still counted normally."""
+        from raki.metrics.operational.self_correction import SelfCorrectionRate
+        from raki.model import EvalDataset
+
+        sample = self._make_rework_sample("s2", review_findings=2, verify_status="completed")
+        dataset = EvalDataset(samples=[sample])
+        result = SelfCorrectionRate().compute(dataset, MetricConfig())
+        assert result.score == 1.0
+        assert result.details["total_rework_findings"] == 2
+
+    def test_mixed_only_review_findings_counted(self):
+        """When session has both review and synthesized findings, only review are counted."""
+        from raki.metrics.operational.self_correction import SelfCorrectionRate
+        from raki.model import EvalDataset
+
+        sample = self._make_rework_sample(
+            "s3", review_findings=1, synthesized_findings=5, verify_status="completed"
+        )
+        dataset = EvalDataset(samples=[sample])
+        result = SelfCorrectionRate().compute(dataset, MetricConfig())
+        assert result.score == 1.0
+        assert result.details["total_rework_findings"] == 1

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -108,6 +108,67 @@ def test_review_finding():
     assert finding.severity == "critical"
 
 
+def test_review_finding_source_defaults_to_none():
+    """finding_source defaults to None for backward compatibility."""
+    finding = ReviewFinding(reviewer="bot", severity="minor", issue="nit")
+    assert finding.finding_source is None
+
+
+def test_review_finding_source_review():
+    """finding_source='review' accepted for human review findings."""
+    finding = ReviewFinding(
+        reviewer="go-specialist",
+        severity="major",
+        issue="Race condition",
+        finding_source="review",
+    )
+    assert finding.finding_source == "review"
+
+
+def test_review_finding_source_synthesized():
+    """finding_source='synthesized' accepted for findings inferred from test failures."""
+    finding = ReviewFinding(
+        reviewer="synthesized",
+        severity="major",
+        issue="pytest: FAILED test_foo.py::test_bar",
+        finding_source="synthesized",
+    )
+    assert finding.finding_source == "synthesized"
+
+
+def test_review_finding_source_rejects_invalid():
+    """finding_source rejects values outside the Literal union."""
+    with pytest.raises(ValidationError):
+        ReviewFinding(
+            reviewer="bot",
+            severity="minor",
+            issue="nit",
+            finding_source="human",  # type: ignore[arg-type]
+        )
+
+
+def test_review_finding_source_serialization_roundtrip():
+    """finding_source survives model_dump / model_validate roundtrip."""
+    original = ReviewFinding(
+        reviewer="synthesized",
+        severity="major",
+        issue="FAILED tests/test_x.py::test_y",
+        finding_source="synthesized",
+    )
+    dumped = original.model_dump()
+    restored = ReviewFinding.model_validate(dumped)
+    assert restored.finding_source == "synthesized"
+
+
+def test_review_finding_source_none_roundtrip():
+    """finding_source=None survives model_dump / model_validate (old data compat)."""
+    original = ReviewFinding(reviewer="bot", severity="minor", issue="nit")
+    dumped = original.model_dump()
+    assert dumped["finding_source"] is None
+    restored = ReviewFinding.model_validate(dumped)
+    assert restored.finding_source is None
+
+
 def test_session_event():
     event = SessionEvent(
         timestamp=datetime(2026, 4, 16, 8, 29, tzinfo=timezone.utc),

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -737,6 +737,66 @@ class TestGenerateSummarySentence:
         sentence = generate_summary_sentence(report, session_count=0)
         assert isinstance(sentence, str)
 
+    def test_synthesized_findings_noted_in_sentence(self) -> None:
+        """Summary sentence notes synthesized findings alongside review ones."""
+        review_finding = ReviewFinding(
+            reviewer="go-specialist",
+            severity="major",
+            issue="Race condition",
+            finding_source="review",
+        )
+        synthesized_finding = ReviewFinding(
+            reviewer="synthesized",
+            severity="major",
+            issue="FAILED tests/test_x.py::test_y",
+            finding_source="synthesized",
+        )
+        sample = make_sample("s1", findings=[review_finding, synthesized_finding])
+        report = EvalReport(
+            run_id="summary-synth",
+            aggregate_scores={"first_pass_success_rate": 0.80},
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+        sentence = generate_summary_sentence(report, session_count=1)
+        # Review finding appears in count; synthesized noted in parenthetical
+        assert "1 major" in sentence
+        assert "synthesized" in sentence
+
+    def test_synthesized_only_findings_separate_message(self) -> None:
+        """When only synthesized findings exist, uses a distinct message."""
+        synthesized_finding = ReviewFinding(
+            reviewer="synthesized",
+            severity="major",
+            issue="FAILED tests/test_x.py::test_y",
+            finding_source="synthesized",
+        )
+        sample = make_sample("s1", findings=[synthesized_finding])
+        report = EvalReport(
+            run_id="summary-synth-only",
+            aggregate_scores={},
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+        sentence = generate_summary_sentence(report, session_count=1)
+        assert "synthesized" in sentence
+
+    def test_no_synthesized_note_when_only_review_findings(self) -> None:
+        """When all findings are review, the sentence does not mention 'synthesized'."""
+        review_finding = ReviewFinding(
+            reviewer="go-specialist",
+            severity="major",
+            issue="Race condition",
+            finding_source="review",
+        )
+        sample = make_sample("s1", findings=[review_finding])
+        report = EvalReport(
+            run_id="summary-review-only",
+            aggregate_scores={"first_pass_success_rate": 0.80},
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+        sentence = generate_summary_sentence(report, session_count=1)
+        assert "synthesized" not in sentence
+        assert "1 major" in sentence
+
 
 # --- No-data metric display tests ---
 


### PR DESCRIPTION
## Summary

- Extracts `ReviewFinding` objects from Alcove/bridge session transcripts (test failures, lint errors)
- Adds `finding_source: Literal["review", "synthesized"] | None` field to `ReviewFinding` model
- Knowledge metrics and `self_correction_rate` exclude synthesized findings (different quality signal)
- CLI summary and HTML report distinguish synthesized vs real findings
- New test fixture `alcove-with-failures.json` for end-to-end testing
- 741 new lines across 14 files

## Test plan

- [x] `uv run pytest tests/ -v -m "not slow"` — 1164 passed
- [x] Synthesized findings extracted from transcript failures
- [x] `finding_source` field correctly set on all findings
- [x] Knowledge metrics skip synthesized findings
- [x] `self_correction_rate` only counts real review findings
- [x] CLI/HTML distinguish finding sources

Refs #186

🤖 Generated with [SODA](https://github.com/soda-ai/soda) + [Claude Code](https://claude.com/claude-code)