### PR TITLE
feat: wire LiteLLM provider into CLI and embeddings (#208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ uv run raki run --manifest raki.yaml --docs-path ./docs
 
 # Add analytical metrics (requires LLM credentials)
 uv run raki run --manifest raki.yaml --judge --judge-provider anthropic
+
+# Add analytical metrics via LiteLLM (e.g. OpenAI)
+uv run raki run --manifest raki.yaml --judge --judge-provider litellm --judge-model gpt-4o
 ```
 
 ## Usage
@@ -50,6 +53,9 @@ uv run raki run --manifest raki.yaml --docs-path ./docs --judge
 
 # Run with direct Anthropic API
 uv run raki run --manifest raki.yaml --judge --judge-provider anthropic
+
+# Run with LiteLLM (any LiteLLM-supported model)
+uv run raki run --manifest raki.yaml --judge --judge-provider litellm --judge-model gpt-4o
 
 # Run specific metrics only
 uv run raki run --manifest raki.yaml --metrics cost_efficiency,rework_cycles

--- a/changes/208.feature
+++ b/changes/208.feature
@@ -1,0 +1,1 @@
+Wire ``litellm`` as a fully supported ``--judge-provider`` option. When selected, the CLI routes judge LLM calls through LiteLLM and serves answer-relevancy embeddings via ``LiteLLMEmbeddings``, removing the Google Cloud dependency for that metric path.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,6 +114,10 @@ uv run raki run --manifest raki.yaml --judge --judge-provider anthropic
 
 # Google AI
 uv run raki run --manifest raki.yaml --judge --judge-provider google
+
+# LiteLLM (any model via the LiteLLM proxy, e.g. OpenAI)
+uv run raki run --manifest raki.yaml --judge \
+  --judge-provider litellm --judge-model gpt-4o
 ```
 
 This adds four Ragas-backed metrics:
@@ -124,6 +128,11 @@ This adds four Ragas-backed metrics:
 - **Context recall** -- was all needed context retrieved? (requires ground truth)
 
 Set `ANTHROPIC_API_KEY` for direct Anthropic API, or configure Google Cloud credentials for Vertex AI.
+For LiteLLM, set the appropriate provider credentials (e.g. `OPENAI_API_KEY`) and install the extra:
+
+```bash
+uv pip install raki[litellm]
+```
 
 See [Analytical Metrics Reference](metrics/analytical.md) for details.
 

--- a/docs/metrics/analytical.md
+++ b/docs/metrics/analytical.md
@@ -15,19 +15,33 @@ uv run raki run --manifest raki.yaml --judge --judge-provider anthropic
 
 # Using Google AI
 uv run raki run --manifest raki.yaml --judge --judge-provider google
+
+# Using LiteLLM (any supported model, e.g. OpenAI)
+uv run raki run --manifest raki.yaml --judge \
+  --judge-provider litellm --judge-model gpt-4o
 ```
 
 Provider options for `--judge-provider`:
 - `vertex-anthropic` (default) -- Claude via Vertex AI
 - `anthropic` -- direct Anthropic API (requires `ANTHROPIC_API_KEY`)
 - `google` -- Google AI
+- `litellm` -- any model via [LiteLLM](https://docs.litellm.ai/) (requires `raki[litellm]` and the appropriate provider credentials, e.g. `OPENAI_API_KEY`)
 
 The default judge model is `claude-sonnet-4-6`. Override with `--judge-model`.
+
+When using `litellm`, embeddings are served by `text-embedding-3-small` (OpenAI) via LiteLLM.
+Set `OPENAI_API_KEY` or configure the LiteLLM proxy for a different embedding provider.
 
 Install with all extras to get Ragas dependencies:
 
 ```bash
 uv sync --python 3.12 --all-extras
+```
+
+Or install only what you need:
+
+```bash
+uv pip install raki[ragas,litellm]
 ```
 
 > **Note:** The `ragas` extra pulls `scikit-network`, which requires a C++ compiler (`g++`).

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -148,7 +148,7 @@ def main():
 @click.option(
     "--judge-provider",
     "judge_provider",
-    type=click.Choice(["vertex-anthropic", "anthropic", "google"]),
+    type=click.Choice(["vertex-anthropic", "anthropic", "google", "litellm"]),
     default="vertex-anthropic",
     help="LLM provider for judge metrics (default: vertex-anthropic)",
 )

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -161,20 +161,31 @@ def create_ragas_llm(config: MetricConfig):
     return llm
 
 
-def create_ragas_embeddings():
+def create_ragas_embeddings(config: MetricConfig):
     """Create embeddings for answer_relevancy metric.
 
-    Constructs ``GoogleEmbeddings`` directly with ``use_vertex=True`` and a
-    pre-configured ``genai.Client`` for Vertex AI.  This bypasses
-    ``embedding_factory()`` which does not forward ``use_vertex`` to the
-    constructor, causing ``_resolve_client()`` to take the Gemini path and
-    discard the pre-configured client (see #106).
+    Dispatches on ``config.llm_provider``:
+
+    - ``vertex-anthropic``, ``anthropic``, ``google`` -- uses ``GoogleEmbeddings``
+      constructed directly with ``use_vertex=True`` and a pre-configured
+      ``genai.Client`` for Vertex AI.  This bypasses ``embedding_factory()``
+      which does not forward ``use_vertex`` to the constructor, causing
+      ``_resolve_client()`` to take the Gemini path and discard the
+      pre-configured client (see #106).
+
+    - ``litellm`` -- uses Ragas's built-in ``LiteLLMEmbeddings`` with model
+      ``text-embedding-3-small`` (OpenAI-compatible, routed via LiteLLM).
 
     Resolves project/location from GOOGLE_CLOUD_PROJECT (or VERTEXAI_PROJECT)
-    and VERTEXAI_LOCATION environment variables.
+    and VERTEXAI_LOCATION environment variables (Google providers only).
 
     Defers imports so this module can be imported without dependencies installed.
     """
+    if config.llm_provider == "litellm":
+        from ragas.embeddings import LiteLLMEmbeddings  # ty: ignore[unresolved-import]
+
+        return LiteLLMEmbeddings(model="text-embedding-3-small")
+
     import os
 
     from google import genai  # ty: ignore[unresolved-import]

--- a/src/raki/metrics/ragas/relevancy.py
+++ b/src/raki/metrics/ragas/relevancy.py
@@ -77,7 +77,7 @@ class AnswerRelevancyMetric:
         )
 
         llm = create_ragas_llm(config)
-        embeddings = create_ragas_embeddings()
+        embeddings = create_ragas_embeddings(config)
         ragas_metric = RagasAnswerRelevancy(llm=llm, embeddings=embeddings)
 
         judge_logger: JudgeLogger | None = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -680,6 +680,35 @@ class TestCliJudgeProvider:
         )
         assert result.exit_code == 0
 
+    def test_judge_provider_litellm_accepted(self, empty_manifest):
+        """litellm provider must be accepted by --judge-provider."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--judge-provider",
+                "litellm",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_judge_provider_google_accepted(self, empty_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--judge-provider",
+                "google",
+            ],
+        )
+        assert result.exit_code == 0
+
     def test_judge_provider_invalid_rejected(self, empty_manifest):
         runner = CliRunner()
         result = runner.invoke(
@@ -693,6 +722,23 @@ class TestCliJudgeProvider:
             ],
         )
         assert result.exit_code == 2
+
+    def test_judge_provider_litellm_rejected_when_not_in_choices_regression(self, empty_manifest):
+        """Regression: 'litellm' must NOT be rejected as an invalid choice (it was missing before #208)."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "-m",
+                str(empty_manifest),
+                "--judge-provider",
+                "litellm",
+            ],
+        )
+        # Must succeed — exit code 2 would mean Click rejected it
+        assert result.exit_code == 0
+        assert "Invalid value" not in result.output
 
     def test_judge_provider_default(self, empty_manifest):
         """Default judge provider (vertex-anthropic) should be accepted without errors."""

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -1378,7 +1378,8 @@ class TestCreateRagasEmbeddings:
         monkeypatch.setenv("VERTEXAI_LOCATION", "us-east1")
 
         mocks = self._setup_embeddings_mocks(monkeypatch)
-        result = mocks["create_fn"]()
+        config = MetricConfig(llm_provider="vertex-anthropic")
+        result = mocks["create_fn"](config)
 
         mocks["embeddings_class"].assert_called_once_with(
             client=mocks["genai_client"],
@@ -1393,7 +1394,8 @@ class TestCreateRagasEmbeddings:
         monkeypatch.setenv("VERTEXAI_LOCATION", "europe-west4")
 
         mocks = self._setup_embeddings_mocks(monkeypatch)
-        mocks["create_fn"]()
+        config = MetricConfig(llm_provider="vertex-anthropic")
+        mocks["create_fn"](config)
 
         mocks["genai"].Client.assert_called_once_with(
             vertexai=True, project="client-project", location="europe-west4"
@@ -1409,7 +1411,8 @@ class TestCreateRagasEmbeddings:
         monkeypatch.setenv("VERTEXAI_LOCATION", "europe-west1")
 
         mocks = self._setup_embeddings_mocks(monkeypatch)
-        mocks["create_fn"]()
+        config = MetricConfig(llm_provider="vertex-anthropic")
+        mocks["create_fn"](config)
 
         mocks["genai"].Client.assert_called_once_with(
             vertexai=True, project="my-project", location="europe-west1"
@@ -1422,7 +1425,8 @@ class TestCreateRagasEmbeddings:
         monkeypatch.setenv("VERTEXAI_LOCATION", "us-central1")
 
         mocks = self._setup_embeddings_mocks(monkeypatch)
-        mocks["create_fn"]()
+        config = MetricConfig(llm_provider="vertex-anthropic")
+        mocks["create_fn"](config)
 
         mocks["genai"].Client.assert_called_once_with(
             vertexai=True, project="primary-project", location="us-central1"
@@ -1435,7 +1439,8 @@ class TestCreateRagasEmbeddings:
         monkeypatch.setenv("VERTEXAI_LOCATION", "us-central1")
 
         mocks = self._setup_embeddings_mocks(monkeypatch)
-        mocks["create_fn"]()
+        config = MetricConfig(llm_provider="vertex-anthropic")
+        mocks["create_fn"](config)
 
         mocks["genai"].Client.assert_called_once_with(
             vertexai=True, project="fallback-project", location="us-central1"
@@ -1447,9 +1452,98 @@ class TestCreateRagasEmbeddings:
         monkeypatch.delenv("VERTEXAI_PROJECT", raising=False)
 
         mocks = self._setup_embeddings_mocks(monkeypatch)
+        config = MetricConfig(llm_provider="vertex-anthropic")
 
         with pytest.raises(ValueError, match="GOOGLE_CLOUD_PROJECT or VERTEXAI_PROJECT"):
-            mocks["create_fn"]()
+            mocks["create_fn"](config)
+
+    def test_google_provider_also_uses_google_embeddings(self, monkeypatch: pytest.MonkeyPatch):
+        """google provider must also route to GoogleEmbeddings (not LiteLLMEmbeddings)."""
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-project")
+        monkeypatch.setenv("VERTEXAI_LOCATION", "us-central1")
+
+        mocks = self._setup_embeddings_mocks(monkeypatch)
+        config = MetricConfig(llm_provider="google")
+        result = mocks["create_fn"](config)
+
+        mocks["embeddings_class"].assert_called_once()
+        assert result is mocks["embeddings_instance"]
+
+    def test_anthropic_provider_also_uses_google_embeddings(self, monkeypatch: pytest.MonkeyPatch):
+        """anthropic provider must also route to GoogleEmbeddings (not LiteLLMEmbeddings)."""
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-project")
+        monkeypatch.setenv("VERTEXAI_LOCATION", "us-central1")
+
+        mocks = self._setup_embeddings_mocks(monkeypatch)
+        config = MetricConfig(llm_provider="anthropic")
+        result = mocks["create_fn"](config)
+
+        mocks["embeddings_class"].assert_called_once()
+        assert result is mocks["embeddings_instance"]
+
+
+class TestLiteLLMEmbeddings:
+    """Tests for LiteLLMEmbeddings dispatch in create_ragas_embeddings()."""
+
+    def _setup_litellm_embeddings_mocks(self, monkeypatch: pytest.MonkeyPatch) -> dict:
+        """Set up common mocks for litellm embeddings tests."""
+        import importlib
+        import sys
+
+        mock_litellm_embeddings_instance = MagicMock()
+        mock_litellm_embeddings_class = MagicMock(return_value=mock_litellm_embeddings_instance)
+        mock_ragas_embeddings = MagicMock()
+        mock_ragas_embeddings.LiteLLMEmbeddings = mock_litellm_embeddings_class
+
+        monkeypatch.setitem(sys.modules, "ragas", MagicMock())
+        monkeypatch.setitem(sys.modules, "ragas.embeddings", mock_ragas_embeddings)
+
+        import raki.metrics.ragas.llm_setup
+
+        importlib.reload(raki.metrics.ragas.llm_setup)
+
+        return {
+            "embeddings_class": mock_litellm_embeddings_class,
+            "embeddings_instance": mock_litellm_embeddings_instance,
+            "create_fn": raki.metrics.ragas.llm_setup.create_ragas_embeddings,
+        }
+
+    def test_litellm_provider_uses_litellm_embeddings(self, monkeypatch: pytest.MonkeyPatch):
+        """litellm provider must use LiteLLMEmbeddings, not GoogleEmbeddings."""
+        mocks = self._setup_litellm_embeddings_mocks(monkeypatch)
+        config = MetricConfig(llm_provider="litellm")
+        result = mocks["create_fn"](config)
+
+        mocks["embeddings_class"].assert_called_once_with(model="text-embedding-3-small")
+        assert result is mocks["embeddings_instance"]
+
+    def test_litellm_embeddings_default_model(self, monkeypatch: pytest.MonkeyPatch):
+        """litellm embeddings default model must be text-embedding-3-small."""
+        mocks = self._setup_litellm_embeddings_mocks(monkeypatch)
+        config = MetricConfig(llm_provider="litellm")
+        mocks["create_fn"](config)
+
+        call_kwargs = mocks["embeddings_class"].call_args
+        assert call_kwargs[1]["model"] == "text-embedding-3-small"
+
+    def test_litellm_embeddings_does_not_need_google_env(self, monkeypatch: pytest.MonkeyPatch):
+        """litellm embeddings must not require GOOGLE_CLOUD_PROJECT env var."""
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("VERTEXAI_PROJECT", raising=False)
+
+        mocks = self._setup_litellm_embeddings_mocks(monkeypatch)
+        config = MetricConfig(llm_provider="litellm")
+        # Must not raise a ValueError about missing project
+        result = mocks["create_fn"](config)
+        assert result is mocks["embeddings_instance"]
+
+    def test_litellm_embeddings_returns_instance(self, monkeypatch: pytest.MonkeyPatch):
+        """create_ragas_embeddings with litellm must return the LiteLLMEmbeddings instance."""
+        mocks = self._setup_litellm_embeddings_mocks(monkeypatch)
+        config = MetricConfig(llm_provider="litellm")
+        result = mocks["create_fn"](config)
+
+        assert result is mocks["embeddings_instance"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `litellm` to `--judge-provider` CLI choices
- `create_ragas_embeddings()` is now provider-aware: uses Google VertexAI embeddings for vertex-anthropic, LiteLLM embeddings for litellm provider
- Passes config to `create_ragas_embeddings()` in relevancy metric
- Docs updated: README, getting-started.md, analytical.md with per-provider examples
- 152 lines of new tests (CLI integration + embeddings dispatch)

## Usage

```bash
raki run --judge --judge-provider litellm --judge-model gpt-4o
raki run --judge --judge-provider litellm --judge-model vertex_ai/gemini-2.5-pro
```

## Test plan

- [x] `uv run pytest tests/ -v -m "not slow"` — 1322 passed
- [x] CLI accepts `litellm` as judge-provider
- [x] Embeddings dispatch routes correctly per provider
- [x] Existing anthropic/vertex-anthropic paths unchanged

Refs #208

🤖 Generated with [SODA](https://github.com/soda-ai/soda) + [Claude Code](https://claude.com/claude-code)