### PR TITLE
feat: RAKI as pipeline quality gate (#184)

### DIFF
--- a/changes/184.feature
+++ b/changes/184.feature
@@ -1,0 +1,7 @@
+Add ``raki gate-check`` command for SODA pipeline quality evaluation.
+
+Run ``raki gate-check <report.json>`` to evaluate a RAKI report against
+SODA-tuned quality thresholds (``first_pass_success_rate>=0.6``,
+``rework_cycles<=0.5``). Supports ``--baseline`` for regression detection
+across milestones, ``--gate`` for custom thresholds, and ``--json`` for
+CI integration. See ``docs/soda-pipeline-gate.md`` for the full workflow.

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -228,6 +228,72 @@ nightly-judge-gate:
     when: always
 ```
 
+## SODA pipeline quality gate
+
+Use `raki gate-check` to evaluate SODA pipeline sessions on a per-milestone cadence.
+Unlike `raki run`, which evaluates sessions and computes metrics, `gate-check` operates
+on an already-generated JSON report and applies SODA-tuned thresholds in one fast step.
+
+Default SODA gates (applied automatically with no additional flags):
+- `first_pass_success_rate>=0.6` — target to improve from the v0.8.0 baseline of 0.44
+- `rework_cycles<=0.5` — target to reduce from the v0.8.0 baseline of 0.72
+
+### Quick start
+
+```bash
+# Step 1: Run evaluation on SODA sessions
+uv run raki run -m examples/soda-gate.yaml -o results/
+
+# Step 2: Check gates with SODA defaults
+uv run raki gate-check results/raki-report-*.json
+
+# Step 3: Compare against a previous milestone baseline
+uv run raki gate-check results/current.json --baseline results/previous.json
+
+# Step 4: Use custom thresholds or a manifest
+uv run raki gate-check results/current.json -m examples/soda-gate.yaml
+```
+
+### GitHub Actions snippet for milestone gate checks
+
+```yaml
+name: SODA Milestone Quality Gate
+
+on:
+  workflow_dispatch:
+
+jobs:
+  soda-gate-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+      - name: Install RAKI
+        run: uv sync --python 3.12 --all-extras
+      - name: Run SODA session evaluation
+        run: |
+          uv run raki run \
+            --manifest examples/soda-gate.yaml \
+            --output results/ \
+            --quiet
+      - name: Check SODA quality gates
+        run: |
+          uv run raki gate-check results/raki-report-*.json \
+            --manifest examples/soda-gate.yaml
+      - name: Upload evaluation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: soda-quality-report
+          path: results/
+          retention-days: 90
+```
+
+See [docs/soda-pipeline-gate.md](soda-pipeline-gate.md) for the full per-milestone workflow,
+baseline threshold table, and interpretation guide.
+
 ## Tips
 
 - **Start with operational gates only.** They run fast, need no API keys, and catch the most common issues. Add analytical gates after you have stable baselines.

--- a/docs/soda-pipeline-gate.md
+++ b/docs/soda-pipeline-gate.md
@@ -1,0 +1,236 @@
+# SODA Pipeline Quality Gate
+
+Use RAKI's `gate-check` command to evaluate SODA pipeline session quality as a feedback loop.
+Run periodic (per-milestone) evaluations on accumulated SODA sessions to surface quality trends
+and detect regressions before they compound.
+
+## Overview
+
+RAKI evaluates SODA pipeline sessions and produces actionable metrics:
+
+- **`first_pass_success_rate`** — fraction of sessions that verify on the first attempt. Low values signal prompt quality or task complexity issues.
+- **`rework_cycles`** — average rework iterations per session. High values indicate implementation accuracy problems.
+- **`review_severity_distribution`** — distribution of review finding severities. Tracks whether code quality is improving.
+- **`cost_efficiency`** — average cost per session in USD. Useful for budget planning and catching runaway sessions.
+
+The `gate-check` command applies threshold gates to an already-generated JSON report, making it fast to check quality without re-running the full evaluation.
+
+## Prerequisites
+
+- RAKI installed: `uv pip install raki`
+- SODA session transcripts available (under `.soda/` or a configured path)
+- A prior `raki run` to generate the JSON report to evaluate
+
+The history log (`#170`) and `raki trends` (`#171`) are recommended companions for cross-milestone tracking. See [CI Integration Guide](ci-integration.md) for general gating patterns.
+
+## Workflow
+
+### Step 1: Evaluate accumulated SODA sessions
+
+After a milestone's SODA sessions complete, run `raki run` to generate the evaluation report:
+
+```bash
+uv run raki run -m examples/soda-gate.yaml -o results/
+```
+
+This loads sessions from `.soda/` (or the path in your manifest), computes operational metrics, and writes `results/raki-report-<timestamp>.json`.
+
+### Step 2: Check gates with SODA defaults
+
+Run `gate-check` on the generated report to check against the built-in SODA thresholds:
+
+```bash
+uv run raki gate-check results/raki-report-*.json
+```
+
+Default thresholds (applied when no `--gate` or manifest `thresholds:` is given):
+- `first_pass_success_rate>=0.6`
+- `rework_cycles<=0.5`
+
+Exit code 0 = all pass. Exit code 1 = at least one gate failed.
+
+### Step 3: Compare against a previous milestone (optional)
+
+Check for regressions versus the previous milestone's report:
+
+```bash
+uv run raki gate-check results/current.json --baseline results/previous.json
+```
+
+If any metric regressed beyond the noise margin (2%), `gate-check` exits with code 3.
+Exit code 4 means both a threshold violation and a regression were detected.
+
+### Step 4: Detailed metric comparison
+
+For a more detailed view of what changed between milestones, use `raki report --diff`:
+
+```bash
+uv run raki report --diff results/previous.json results/current.json
+```
+
+This shows per-metric deltas, verdict transitions, and a direction indicator (▲/▼) for each metric.
+
+### Step 5: Visualize metric trajectories
+
+Use `raki trends` to see how metrics have moved over multiple milestones:
+
+```bash
+uv run raki trends --last 10
+uv run raki trends --metrics first_pass_success_rate,rework_cycles
+```
+
+## Baseline thresholds
+
+These thresholds are derived from v0.8.0 cycle data. Adjust them as your pipeline matures.
+
+| Metric | v0.8.0 Baseline | Target | Gate Expression |
+|--------|----------------|--------|----------------|
+| `first_pass_success_rate` | 0.44 | ≥ 0.6 | `first_pass_success_rate>=0.6` |
+| `rework_cycles` | 0.72 | ≤ 0.5 | `rework_cycles<=0.5` |
+| `review_severity_distribution` | 0.63 | ≥ 0.5 | `review_severity_distribution>=0.5` |
+| `cost_efficiency` | $7.28 avg | ≤ $10.0 | `cost_efficiency<=10.0` |
+
+The built-in `SODA_DEFAULT_GATES` (the two most critical gates applied when no overrides are given):
+
+```
+first_pass_success_rate>=0.6
+rework_cycles<=0.5
+```
+
+## Customizing thresholds
+
+### Via `--gate` flag
+
+Override defaults with per-invocation gates. CLI `--gate` flags replace SODA defaults entirely:
+
+```bash
+# Stricter first-pass target
+uv run raki gate-check results/current.json \
+  --gate 'first_pass_success_rate>=0.75' \
+  --gate 'rework_cycles<=0.3'
+```
+
+### Via manifest `thresholds:` block
+
+Use the provided manifest template for repeatable gate configuration:
+
+```bash
+# Use soda-gate.yaml thresholds (overrides SODA defaults)
+uv run raki gate-check results/current.json -m examples/soda-gate.yaml
+```
+
+Priority chain (highest to lowest): CLI `--gate` > manifest `thresholds:` > SODA defaults.
+
+### Manifest template
+
+`examples/soda-gate.yaml` is a ready-to-use manifest with all four SODA metrics pre-configured.
+Copy and adjust it for your team's targets:
+
+```yaml
+sessions:
+  path: .soda/
+  format: auto
+
+thresholds:
+  - "first_pass_success_rate>=0.6"
+  - "rework_cycles<=0.5"
+  - "review_severity_distribution>=0.5"
+  - "cost_efficiency<=10.0"
+```
+
+## CI integration
+
+Add a milestone gate check to your GitHub Actions workflow:
+
+```yaml
+name: SODA Milestone Quality Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      current_report:
+        description: "Path to the current milestone report JSON"
+        required: true
+      baseline_report:
+        description: "Path to the baseline (previous milestone) report JSON"
+        required: false
+
+jobs:
+  gate-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+      - name: Install RAKI
+        run: uv sync --python 3.12 --all-extras
+      - name: Run SODA sessions evaluation
+        run: |
+          uv run raki run -m examples/soda-gate.yaml -o results/
+      - name: Check quality gates
+        run: |
+          uv run raki gate-check results/raki-report-*.json \
+            -m examples/soda-gate.yaml
+      - name: Check regression vs baseline
+        if: inputs.baseline_report != ''
+        run: |
+          uv run raki gate-check results/raki-report-*.json \
+            --baseline ${{ inputs.baseline_report }} \
+            -m examples/soda-gate.yaml
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: soda-quality-report
+          path: results/
+          retention-days: 90
+```
+
+## Interpreting results
+
+### When gates fail
+
+**`first_pass_success_rate` below threshold:**
+- Review recent changes to the `implement` phase prompt — did the instruction change in a way that reduces clarity?
+- Check if ticket complexity increased (larger ticket budget, more files, more unknowns).
+- Use `raki report --diff` to see which sessions are transitioning from pass to rework.
+
+**`rework_cycles` above threshold:**
+- Examine the `verify` prompt feedback messages — are they actionable?
+- Check if the `implement` agent is ignoring verify feedback (common in short-budget sessions).
+- Look for patterns: same ticket type, same phase, same error class.
+
+**`review_severity_distribution` below threshold:**
+- More critical/major findings means review quality may be improving (catching more issues) or implementation quality dropped.
+- Correlate with `rework_cycles` — if both worsen together, implementation quality declined.
+
+**`cost_efficiency` above threshold:**
+- Check for runaway sessions (very high individual costs).
+- Look at whether LLM provider or model changed between milestones.
+
+### Using `--diff` to pinpoint regressions
+
+After detecting a regression with `gate-check`, use `raki report --diff` for per-session detail:
+
+```bash
+uv run raki report \
+  --diff results/previous.json results/current.json \
+  --fail-on-regression
+```
+
+This shows which sessions changed verdict (pass → rework, rework → pass) between milestones.
+
+### Using `raki trends` for trajectory analysis
+
+For multi-milestone trend analysis:
+
+```bash
+# Show all metric trends for the last 10 evaluations
+uv run raki trends --last 10
+
+# Focus on the two most critical SODA metrics
+uv run raki trends --metrics first_pass_success_rate,rework_cycles
+```
+
+A consistently flat or declining `first_pass_success_rate` with rising `rework_cycles` signals that prompt changes are not improving pipeline quality.

--- a/examples/soda-gate.yaml
+++ b/examples/soda-gate.yaml
@@ -1,0 +1,26 @@
+# SODA Pipeline Quality Gate — RAKI evaluation manifest
+# Use with: raki gate-check <report.json> -m examples/soda-gate.yaml
+#
+# This manifest defines SODA-tuned thresholds for pipeline quality evaluation.
+# Thresholds are based on v0.8.0 cycle baseline data.
+#
+# Workflow:
+#   1. Run evaluation on SODA sessions:
+#      uv run raki run -m examples/soda-gate.yaml -o results/
+#   2. Check gates against SODA defaults (or manifest thresholds below):
+#      uv run raki gate-check results/raki-report-*.json -m examples/soda-gate.yaml
+#   3. Compare against a previous milestone report:
+#      uv run raki gate-check results/current.json --baseline results/previous.json
+
+sessions:
+  path: .soda/          # SODA session transcripts directory
+  format: auto
+
+# SODA pipeline quality thresholds (v0.8.0 baseline)
+# These gates are used by `raki gate-check` when this manifest is provided.
+# They override the built-in SODA defaults (first_pass_success_rate>=0.6, rework_cycles<=0.5).
+thresholds:
+  - "first_pass_success_rate>=0.6"      # Target: improve from v0.8.0 baseline of 0.44
+  - "rework_cycles<=0.5"                # Target: reduce from v0.8.0 baseline of 0.72
+  - "review_severity_distribution>=0.5" # Track finding patterns; v0.8.0 baseline: 0.63
+  - "cost_efficiency<=10.0"             # Cost per session cap ($); v0.8.0 average: $7.28

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -1276,7 +1276,7 @@ def gate_check(
     )
     has_violation = any(not result.passed for result in gate_results)
 
-    if not quiet:
+    if not quiet and not json_output:
         out.print(format_threshold_results(gate_results))
 
     # --- Regression detection (optional) ---
@@ -1318,7 +1318,7 @@ def gate_check(
         regressed = [result for result in regression_results_list if result.regressed]
         regression_detected = bool(regressed)
 
-        if not quiet and regression_detected:
+        if not quiet and not json_output and regression_detected:
             out.print("\n[red]Regressions detected:[/red]")
             for result in regressed:
                 out.print(

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -1168,5 +1168,207 @@ def trends(
     render_trends_table(trend_list, console=console)
 
 
+# SODA pipeline quality gate defaults (v0.8.0 baseline data)
+SODA_DEFAULT_GATES: tuple[str, ...] = (
+    "first_pass_success_rate>=0.6",
+    "rework_cycles<=0.5",
+)
+
+
+@main.command("gate-check")
+@click.argument("report_path")
+@click.option(
+    "--gate",
+    "gate_thresholds",
+    multiple=True,
+    help="Override default gates: 'metric>=value'. Replaces SODA defaults entirely.",
+)
+@click.option(
+    "-m",
+    "--manifest",
+    "manifest_path",
+    default=None,
+    help="Path to manifest file. Uses its thresholds: block if no --gate flags given.",
+)
+@click.option(
+    "--baseline",
+    "baseline_path",
+    default=None,
+    help="Path to baseline JSON report for regression comparison.",
+)
+@click.option(
+    "--require-metric",
+    "required_metrics",
+    multiple=True,
+    help="Fail if metric is N/A instead of skipping threshold.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Print JSON result to stdout.")
+@click.option("-q", "--quiet", is_flag=True, help="Suppress non-essential output.")
+def gate_check(
+    report_path: str,
+    gate_thresholds: tuple[str, ...],
+    manifest_path: str | None,
+    baseline_path: str | None,
+    required_metrics: tuple[str, ...],
+    json_output: bool,
+    quiet: bool,
+) -> None:
+    """Evaluate a saved RAKI report against SODA pipeline quality gates.
+
+    Checks first_pass_success_rate>=0.6 and rework_cycles<=0.5 by default.
+    Override with --gate or provide a manifest with thresholds:.
+
+    Use --baseline to compare against a previous report for regression detection.
+    See docs/soda-pipeline-gate.md for the full workflow.
+    """
+    out = _stderr_console() if json_output else console
+
+    # --- Load the report ---
+    report_file = Path(report_path)
+    if not report_file.exists():
+        out.print(f"[red]Error: report file not found: {report_file}[/red]")
+        raise SystemExit(2)
+
+    try:
+        from raki.report.json_report import load_json_report
+
+        eval_report = load_json_report(report_file)
+    except Exception as exc:
+        out.print(f"[red]Error loading report: {redact_sensitive(str(exc))}[/red]")
+        raise SystemExit(2) from exc
+
+    # --- Determine effective thresholds ---
+    # Priority: CLI --gate > manifest thresholds: > SODA defaults
+    effective_thresholds: list[str] = list(gate_thresholds)
+
+    if not effective_thresholds and manifest_path is not None:
+        try:
+            manifest_file = Path(manifest_path)
+            if not manifest_file.exists():
+                out.print(f"[red]Error: manifest file not found: {manifest_file}[/red]")
+                raise SystemExit(2)
+            from raki.ground_truth.manifest import load_manifest
+
+            manifest = load_manifest(manifest_file)
+            if manifest.thresholds:
+                effective_thresholds = list(manifest.thresholds)
+        except SystemExit:
+            raise
+        except Exception as exc:
+            out.print(f"[yellow]Warning: could not load manifest thresholds: {exc}[/yellow]")
+
+    if not effective_thresholds:
+        effective_thresholds = list(SODA_DEFAULT_GATES)
+
+    # --- Parse thresholds ---
+    from raki.gates.thresholds import evaluate_all, format_threshold_results, parse_threshold
+
+    try:
+        parsed_thresholds = [parse_threshold(raw) for raw in effective_thresholds]
+    except ValueError as exc:
+        out.print(f"[red]Error: {exc}[/red]")
+        raise SystemExit(2) from exc
+
+    # --- Evaluate gates ---
+    required_set = set(required_metrics) if required_metrics else None
+    gate_results = evaluate_all(
+        parsed_thresholds, eval_report.aggregate_scores, required_metrics=required_set
+    )
+    has_violation = any(not result.passed for result in gate_results)
+
+    if not quiet:
+        out.print(format_threshold_results(gate_results))
+
+    # --- Regression detection (optional) ---
+    regression_results_list: list = []
+    regression_detected = False
+
+    if baseline_path is not None:
+        baseline_file = Path(baseline_path)
+        if not baseline_file.exists():
+            out.print(f"[red]Error: baseline file not found: {baseline_file}[/red]")
+            raise SystemExit(2)
+
+        try:
+            from raki.report.json_report import load_json_report
+
+            baseline_report = load_json_report(baseline_file)
+        except Exception as exc:
+            out.print(f"[red]Error loading baseline report: {redact_sensitive(str(exc))}[/red]")
+            raise SystemExit(2) from exc
+
+        from raki.gates.regression import Direction, detect_regressions
+        from raki.report.diff import is_higher_is_better
+
+        all_metric_names = set(baseline_report.aggregate_scores.keys()) | set(
+            eval_report.aggregate_scores.keys()
+        )
+        metric_directions: dict[str, Direction] = {
+            metric_name: "higher_is_better"
+            if is_higher_is_better(metric_name)
+            else "lower_is_better"
+            for metric_name in all_metric_names
+        }
+
+        regression_results_list = detect_regressions(
+            baseline_report.aggregate_scores,
+            eval_report.aggregate_scores,
+            metric_directions,
+        )
+        regressed = [result for result in regression_results_list if result.regressed]
+        regression_detected = bool(regressed)
+
+        if not quiet and regression_detected:
+            out.print("\n[red]Regressions detected:[/red]")
+            for result in regressed:
+                out.print(
+                    f"  {result.metric}: {result.baseline:.4f} -> "
+                    f"{result.current:.4f} ({result.direction})"
+                )
+
+    # --- JSON output ---
+    if json_output:
+        import json as json_mod
+
+        gates_output = [
+            {
+                "metric": result.threshold.metric,
+                "operator": result.threshold.operator,
+                "target": result.threshold.value,
+                "actual": result.actual,
+                "passed": result.passed,
+                "skipped": result.skipped,
+                "reason": result.reason,
+            }
+            for result in gate_results
+        ]
+        regressions_output = [
+            {
+                "metric": result.metric,
+                "baseline": result.baseline,
+                "current": result.current,
+                "direction": result.direction,
+                "regressed": result.regressed,
+            }
+            for result in regression_results_list
+        ]
+        json_result = {
+            "passed": not has_violation and not regression_detected,
+            "gates": gates_output,
+            "regressions": regressions_output,
+        }
+        click.echo(json_mod.dumps(json_result, indent=2))
+
+    # --- Exit code ---
+    from raki.gates.regression import compute_exit_code
+
+    exit_code = compute_exit_code(
+        threshold_violated=has_violation,
+        regression_detected=regression_detected,
+    )
+    if exit_code != 0:
+        raise SystemExit(exit_code)
+
+
 if __name__ == "__main__":
     main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3096,3 +3096,232 @@ class TestCliStrictWarnings:
                 ["run", "-m", str(manifest), "-o", str(output_dir), "-q"],
             )
         assert result.exit_code == 0
+
+
+class TestGateCheckCommand:
+    """Tests for the `raki gate-check` command."""
+
+    def test_help_shows_gate_check(self):
+        """raki --help should list the gate-check command."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "gate-check" in result.output
+
+    def test_gate_check_default_gates_pass(self, tmp_path):
+        """Default SODA gates pass when scores meet the thresholds."""
+        report_file = tmp_path / "report.json"
+        _write_diff_report_json(
+            report_file,
+            run_id="eval-pass",
+            aggregate_scores={"first_pass_success_rate": 0.80, "rework_cycles": 0.3},
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["gate-check", str(report_file)])
+        assert result.exit_code == 0
+        assert "PASS" in result.output
+
+    def test_gate_check_default_gates_fail(self, tmp_path):
+        """Default SODA gates fail when scores are below the thresholds."""
+        report_file = tmp_path / "report.json"
+        _write_diff_report_json(
+            report_file,
+            run_id="eval-fail",
+            aggregate_scores={"first_pass_success_rate": 0.40, "rework_cycles": 0.8},
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["gate-check", str(report_file)])
+        assert result.exit_code == 1
+        assert "FAIL" in result.output
+
+    def test_gate_check_custom_gate_overrides_defaults(self, tmp_path):
+        """--gate overrides SODA defaults entirely; only the specified gate applies."""
+        report_file = tmp_path / "report.json"
+        _write_diff_report_json(
+            report_file,
+            run_id="eval-custom",
+            # first_pass_success_rate=0.50 would fail SODA default (>=0.6)
+            # but the custom gate is >=0.40, which passes
+            aggregate_scores={"first_pass_success_rate": 0.50},
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["gate-check", str(report_file), "--gate", "first_pass_success_rate>=0.40"],
+        )
+        assert result.exit_code == 0
+
+    def test_gate_check_manifest_thresholds_override_defaults(self, tmp_path):
+        """Manifest thresholds override SODA defaults when no --gate is given."""
+        report_file = tmp_path / "report.json"
+        _write_diff_report_json(
+            report_file,
+            run_id="eval-manifest",
+            # first_pass_success_rate=0.50 would fail SODA default (>=0.6)
+            # but manifest threshold is >=0.40, which passes
+            aggregate_scores={"first_pass_success_rate": 0.50},
+        )
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        manifest_file = tmp_path / "raki.yaml"
+        manifest_file.write_text(
+            f"sessions:\n  path: {sessions_dir}\n  format: auto\n"
+            "thresholds:\n  - 'first_pass_success_rate>=0.40'\n"
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["gate-check", str(report_file), "-m", str(manifest_file)],
+        )
+        assert result.exit_code == 0
+
+    def test_gate_check_cli_gate_overrides_manifest(self, tmp_path):
+        """CLI --gate wins over manifest thresholds (manifest is strict but CLI is lenient)."""
+        report_file = tmp_path / "report.json"
+        _write_diff_report_json(
+            report_file,
+            run_id="eval-cli-wins",
+            aggregate_scores={"first_pass_success_rate": 0.50},
+        )
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        manifest_file = tmp_path / "raki.yaml"
+        manifest_file.write_text(
+            f"sessions:\n  path: {sessions_dir}\n  format: auto\n"
+            # Strict manifest threshold that would fail
+            "thresholds:\n  - 'first_pass_success_rate>=0.99'\n"
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            # CLI gate is lenient and should win over manifest
+            [
+                "gate-check",
+                str(report_file),
+                "-m",
+                str(manifest_file),
+                "--gate",
+                "first_pass_success_rate>=0.40",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_gate_check_baseline_regression_detected(self, tmp_path):
+        """Exit code 3 and regression message when scores drop vs baseline."""
+        baseline_file = tmp_path / "baseline.json"
+        current_file = tmp_path / "current.json"
+        _write_diff_report_json(
+            baseline_file,
+            run_id="eval-baseline",
+            aggregate_scores={"first_pass_success_rate": 0.90},
+        )
+        # current drops significantly — regression should be detected
+        _write_diff_report_json(
+            current_file,
+            run_id="eval-current",
+            aggregate_scores={"first_pass_success_rate": 0.60},
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "gate-check",
+                str(current_file),
+                "--baseline",
+                str(baseline_file),
+                "--gate",
+                "first_pass_success_rate>=0.50",  # gate passes; only regression triggers exit 3
+            ],
+        )
+        assert result.exit_code == 3
+        assert "Regression" in result.output or "regression" in result.output.lower()
+
+    def test_gate_check_baseline_no_regression(self, tmp_path):
+        """Exit code 0 when scores are stable or improved vs baseline."""
+        baseline_file = tmp_path / "baseline.json"
+        current_file = tmp_path / "current.json"
+        _write_diff_report_json(
+            baseline_file,
+            run_id="eval-baseline",
+            aggregate_scores={"first_pass_success_rate": 0.70},
+        )
+        # Current is same score — no regression
+        _write_diff_report_json(
+            current_file,
+            run_id="eval-current",
+            aggregate_scores={"first_pass_success_rate": 0.70},
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "gate-check",
+                str(current_file),
+                "--baseline",
+                str(baseline_file),
+                "--gate",
+                "first_pass_success_rate>=0.60",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_gate_check_json_output(self, tmp_path):
+        """--json flag produces valid JSON with passed, gates, and regressions keys."""
+        report_file = tmp_path / "report.json"
+        _write_diff_report_json(
+            report_file,
+            run_id="eval-json",
+            aggregate_scores={"first_pass_success_rate": 0.80, "rework_cycles": 0.3},
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["gate-check", str(report_file), "--json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "passed" in parsed
+        assert "gates" in parsed
+        assert "regressions" in parsed
+        assert isinstance(parsed["passed"], bool)
+        assert isinstance(parsed["gates"], list)
+        assert isinstance(parsed["regressions"], list)
+
+    def test_gate_check_quiet_mode(self, tmp_path):
+        """--quiet suppresses gate results output."""
+        report_file = tmp_path / "report.json"
+        _write_diff_report_json(
+            report_file,
+            run_id="eval-quiet",
+            aggregate_scores={"first_pass_success_rate": 0.80, "rework_cycles": 0.3},
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["gate-check", str(report_file), "-q"])
+        assert result.exit_code == 0
+        assert "Quality Gates" not in result.output
+
+    def test_gate_check_missing_report_exits_2(self, tmp_path):
+        """Exit code 2 when report file does not exist."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["gate-check", str(tmp_path / "nonexistent.json")])
+        assert result.exit_code == 2
+
+    def test_gate_check_require_metric_fails_on_na(self, tmp_path):
+        """--require-metric fails the gate when the metric is N/A."""
+        report_file = tmp_path / "report.json"
+        # faithfulness is absent from aggregate_scores — will be treated as N/A
+        _write_diff_report_json(
+            report_file,
+            run_id="eval-require",
+            aggregate_scores={"first_pass_success_rate": 0.80},
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "gate-check",
+                str(report_file),
+                "--gate",
+                "faithfulness>=0.8",
+                "--require-metric",
+                "faithfulness",
+            ],
+        )
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary

- New `raki gate-check` command for periodic SODA pipeline quality evaluation
- Runs RAKI against accumulated SODA sessions, compares with baseline, gates on thresholds
- Example manifest template `examples/soda-gate.yaml` for SODA session evaluation
- Documentation: `docs/soda-pipeline-gate.md` (workflow guide) + `docs/ci-integration.md` (CI section)
- 766 new lines across 6 files, 12 new CLI tests

## Test plan

- [x] `uv run pytest tests/ -v -m "not slow"` — 1326 passed
- [x] `gate-check` command accepts manifest, thresholds, baseline report
- [x] Exit codes: 0 (pass), 1 (threshold failure), 3 (regression vs baseline)
- [x] JSON output mode for CI integration

Refs #184

🤖 Generated with [SODA](https://github.com/soda-ai/soda) + [Claude Code](https://claude.com/claude-code)