### PR TITLE
fix: increase Alcove adapter DETECT_READ_SIZE to 32KB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,7 @@ Use the `/orchestrate` skill in Claude Code to coordinate milestone-level develo
 
 1. **ty is strict** -- Protocol attributes must be satisfied by class variables, not instance attributes.
 2. **Ragas 0.4 + Anthropic** -- `llm_factory()` must receive `provider="anthropic"` explicitly (defaults to `"openai"`). Must pop `top_p` from `llm.model_args` after creation — Anthropic rejects `temperature` + `top_p` together. GoogleEmbeddings ignores pre-configured clients (known bug, #106).
-3. **Large session files** -- some session formats can be 50MB+; `detect()` must read only the first 4KB.
+3. **Large session files** -- some session formats can be 50MB+; `detect()` must read only the first 32KB.
 4. **ReviewFinding.severity** -- `Literal["critical", "major", "minor"]`, not bare `str`.
 5. **Operational metrics** -- return raw values (cost in $, cycles as count), not 0-1 normalized.
 6. **No blended score** -- operational and retrieval metrics are separate categories; never combine them.

--- a/changes/218.fix
+++ b/changes/218.fix
@@ -1,0 +1,1 @@
+``AlcoveAdapter.detect()`` now reads the first 32 KB of a file (up from 4 KB) when detecting the Alcove/bridge format. Sessions whose ``"transcript"`` key was pushed past the 4 KB boundary by a long system prompt were previously silently skipped; they are now correctly detected and loaded.

--- a/src/raki/adapters/alcove.py
+++ b/src/raki/adapters/alcove.py
@@ -6,7 +6,7 @@ from raki.adapters.redact import redact_dict, redact_sensitive
 from raki.model import EvalSample, PhaseResult, ReviewFinding, SessionMeta, ToolCall
 
 MAX_ALCOVE_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
-DETECT_READ_SIZE = 4096  # Only read first 4KB for format detection
+DETECT_READ_SIZE = 32768  # Only read first 32KB for format detection
 MAX_SYNTHESIZED_CONTEXT_CHARS = 50_000
 
 # Bash commands whose output is informational for retrieval context (whitelist).
@@ -224,7 +224,7 @@ class AlcoveAdapter:
     detection_hint: str = "*.json file containing (session_id or id) + transcript"
 
     def detect(self, source: Path) -> bool:
-        """Detect Alcove/bridge format via substring search of first 4KB."""
+        """Detect Alcove/bridge format via substring search of first 32KB."""
         if source.is_symlink():
             return False
         if not source.is_file() or source.suffix != ".json":

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -223,6 +223,35 @@ def test_alcove_adapter_loads_id_only_session():
     assert sample.phases[0].name == "session"
 
 
+def test_alcove_adapter_detects_transcript_beyond_4kb(tmp_path):
+    """detect() must find 'transcript' when it falls beyond the first 4KB.
+
+    Sessions with long system prompts push the 'transcript' key past byte 4096.
+    Previously DETECT_READ_SIZE was 4096, so these sessions were silently skipped.
+    """
+    # Build a JSON where "transcript" falls well past the 4KB boundary.
+    # The large "prompt" value pushes "transcript" beyond byte 4096.
+    large_prompt = "A" * 11_000
+    transcript_data = {
+        "id": "large-prompt-session-id",
+        "prompt": large_prompt,
+        "transcript": [],
+    }
+    fixture = tmp_path / "large-prompt.json"
+    fixture.write_text(json.dumps(transcript_data))
+
+    # Sanity-check: "transcript" must NOT appear in the first 4096 bytes,
+    # otherwise this test is not actually exercising the boundary condition.
+    header_4kb = fixture.read_bytes()[:4096].decode("utf-8", errors="replace")
+    assert '"transcript"' not in header_4kb, (
+        "Test precondition failed: 'transcript' appeared in first 4096 bytes; "
+        "increase the prompt padding."
+    )
+
+    adapter = AlcoveAdapter()
+    assert adapter.detect(fixture)
+
+
 # --- Synthesized findings tests ---
 
 


### PR DESCRIPTION
## Summary
Increase `DETECT_READ_SIZE` from 4KB to 32KB so sessions with long prompts are not silently skipped by the Alcove adapter. Updates AGENTS.md gotcha #3 to reflect the new detection window.

## Test plan
- [ ] Test with session where `"transcript"` appears past 4KB boundary
- [ ] Existing detection of normal sessions still works
- [ ] `uv run pytest tests/ -v -m "not slow"` — all pass

Refs #218

🤖 Generated with [Claude Code](https://claude.com/claude-code) via SODA pipeline