### PR TITLE
feat: extend session-schema adapter for full SODA phase coverage

### DIFF
--- a/changes/220.feature
+++ b/changes/220.feature
@@ -1,0 +1,5 @@
+The session-schema adapter now loads all seven SODA pipeline phases (triage, plan, implement, verify, review, submit, monitor) as ``PhaseResult`` objects. Previously only four phases were loaded; submit and monitor outputs were silently ignored.
+
+Review findings are now parsed from the SODA ``perspectives`` structure in addition to the legacy flat ``findings`` array. The perspective name (e.g. ``python``, ``security``) is used as the reviewer identifier. SODA severity labels (``CRITICAL``, ``IMPORTANT``, ``MINOR``) are mapped to raki values (``critical``, ``major``, ``minor``).
+
+Context synthesis now includes submit-phase data (PR title, branch, PR URL) and monitor-phase data (post-merge test result, review comments resolved). The ``docs/session-schema.md`` reference now documents all seven phases.

--- a/docs/session-schema.md
+++ b/docs/session-schema.md
@@ -78,13 +78,25 @@ Output from the verification phase.
 
 Output from the review phase. Suffixed files (e.g., `review.json.1`) represent earlier review generations.
 
+The adapter supports two finding formats:
+
+**Legacy flat format** — findings at the top level:
+
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `ticket_key` | string | Yes | Ticket identifier |
 | `verdict` | string | No | Review outcome (e.g., `approved`, `changes_requested`) |
 | `findings` | array of objects | No | List of review findings (see below) |
 
-### findings (nested in review.json)
+**SODA perspectives format** — findings nested inside reviewer perspectives:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ticket_key` | string | Yes | Ticket identifier |
+| `verdict` | string | No | Review outcome: `approve` or `rework` |
+| `perspectives` | array of objects | No | Per-specialist review perspectives (see below) |
+
+### findings (nested in review.json — flat format)
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -94,6 +106,50 @@ Output from the review phase. Suffixed files (e.g., `review.json.1`) represent e
 | `line` | integer | No | Line number related to the finding |
 | `issue` | string | Yes | Description of the issue found |
 | `suggestion` | string | No | Suggested fix or improvement |
+
+### perspectives (nested in review.json — SODA format)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Specialist name (e.g., `python`, `security`); used as reviewer |
+| `verdict` | string | Yes | Specialist outcome: `clean` or `needs_fixes` |
+| `findings` | array of objects | Yes | Per-finding list (same shape as flat format, but `severity` uses uppercase: `CRITICAL`, `IMPORTANT`, `MINOR`) |
+
+Severity mapping from SODA uppercase labels to raki values: `CRITICAL` → `critical`, `IMPORTANT` → `major`, `MINOR` → `minor`.
+
+## submit.json
+
+Output from the submit phase. Records the pull request created from the implementation.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ticket_key` | string | Yes | Ticket identifier |
+| `pr_url` | string | Yes | URL of the opened pull request |
+| `pr_number` | integer | Yes | Pull request number |
+| `title` | string | Yes | Pull request title |
+| `branch` | string | Yes | Source branch submitted |
+| `target` | string | Yes | Target branch (e.g., `main`) |
+
+## monitor.json
+
+Output from the monitor phase. Records CI results and review comment handling after the PR is open.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ticket_key` | string | Yes | Ticket identifier |
+| `pr_url` | string | Yes | URL of the monitored pull request |
+| `comments_handled` | array of objects | Yes | Review comments and how they were handled |
+| `tests_passed` | boolean | Yes | Whether post-merge CI checks passed |
+
+### comments_handled (nested in monitor.json)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `comment_id` | string | Yes | Unique identifier for the review comment |
+| `author` | string | Yes | Author of the review comment |
+| `content` | string | No | Text of the comment |
+| `action` | string | Yes | How the comment was handled: `fixed`, `explained`, or `deferred` |
+| `response` | string | Yes | Description of the action taken |
 
 ## events.jsonl
 

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -1,7 +1,7 @@
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import ValidationError
 
@@ -231,7 +231,7 @@ class SessionSchemaAdapter:
     # Map SODA review schema severity labels to raki ReviewFinding literals.
     # SODA uses uppercase (CRITICAL/IMPORTANT/MINOR); raki uses lowercase.
     # SODA "IMPORTANT" maps to raki "major" (there is no direct equivalent).
-    _SODA_SEVERITY_MAP: dict[str, str] = {
+    _SODA_SEVERITY_MAP: dict[str, Literal["critical", "major", "minor"]] = {
         "CRITICAL": "critical",
         "IMPORTANT": "major",
         "MINOR": "minor",
@@ -241,7 +241,9 @@ class SessionSchemaAdapter:
         "minor": "minor",
     }
 
-    def _normalize_severity(self, raw_severity: str | None) -> str:
+    def _normalize_severity(
+        self, raw_severity: str | None
+    ) -> Literal["critical", "major", "minor"]:
         """Normalize a raw severity string to a ReviewFinding-compatible literal.
 
         Returns 'minor' when the value is absent or unrecognised so that

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -228,6 +228,83 @@ class SessionSchemaAdapter:
             )
         return results
 
+    # Map SODA review schema severity labels to raki ReviewFinding literals.
+    # SODA uses uppercase (CRITICAL/IMPORTANT/MINOR); raki uses lowercase.
+    # SODA "IMPORTANT" maps to raki "major" (there is no direct equivalent).
+    _SODA_SEVERITY_MAP: dict[str, str] = {
+        "CRITICAL": "critical",
+        "IMPORTANT": "major",
+        "MINOR": "minor",
+        # Passthrough for pre-existing lowercase values (flat-findings format).
+        "critical": "critical",
+        "major": "major",
+        "minor": "minor",
+    }
+
+    def _normalize_severity(self, raw_severity: str | None) -> str:
+        """Normalize a raw severity string to a ReviewFinding-compatible literal.
+
+        Returns 'minor' when the value is absent or unrecognised so that
+        malformed review files never cause a ValidationError.
+        """
+        if raw_severity is None:
+            return "minor"
+        return self._SODA_SEVERITY_MAP.get(str(raw_severity), "minor")
+
+    def _findings_from_flat(self, raw: dict) -> list[ReviewFinding]:
+        """Extract findings from the legacy flat ``findings`` array format."""
+        results: list[ReviewFinding] = []
+        for finding_raw in raw.get("findings") or []:
+            try:
+                results.append(
+                    ReviewFinding(
+                        reviewer=finding_raw.get("source", "unknown"),
+                        severity=self._normalize_severity(finding_raw.get("severity")),
+                        file=finding_raw.get("file"),
+                        line=finding_raw.get("line"),
+                        issue=redact_sensitive(finding_raw["issue"]),
+                        suggestion=redact_sensitive(s)
+                        if (s := finding_raw.get("suggestion")) is not None
+                        else None,
+                    )
+                )
+            except (KeyError, ValueError):
+                continue
+        return results
+
+    def _findings_from_perspectives(self, raw: dict) -> list[ReviewFinding]:
+        """Extract findings from the SODA ``perspectives`` array format.
+
+        Each perspective element has a ``name`` (e.g. ``"python"``) and a nested
+        ``findings`` array.  The perspective name is used as the reviewer
+        identifier, and SODA severity labels (CRITICAL/IMPORTANT/MINOR) are
+        normalised to raki's lowercase literals (critical/major/minor).
+        """
+        results: list[ReviewFinding] = []
+        for perspective in raw.get("perspectives") or []:
+            if not isinstance(perspective, dict):
+                continue
+            reviewer = perspective.get("name", "unknown")
+            for finding_raw in perspective.get("findings") or []:
+                if not isinstance(finding_raw, dict):
+                    continue
+                try:
+                    results.append(
+                        ReviewFinding(
+                            reviewer=str(reviewer),
+                            severity=self._normalize_severity(finding_raw.get("severity")),
+                            file=finding_raw.get("file"),
+                            line=finding_raw.get("line"),
+                            issue=redact_sensitive(finding_raw["issue"]),
+                            suggestion=redact_sensitive(s)
+                            if (s := finding_raw.get("suggestion")) is not None
+                            else None,
+                        )
+                    )
+                except (KeyError, ValueError):
+                    continue
+        return results
+
     def _load_findings(self, source: Path) -> list[ReviewFinding]:
         findings: list[ReviewFinding] = []
         pattern = re.compile(r"^review\.json(\.\d+)?$")
@@ -239,22 +316,12 @@ class SessionSchemaAdapter:
                 raw = json.loads(_read_bounded(file_path))
             except json.JSONDecodeError:
                 continue
-            for finding_raw in raw.get("findings") or []:
-                try:
-                    findings.append(
-                        ReviewFinding(
-                            reviewer=finding_raw.get("source", "unknown"),
-                            severity=finding_raw.get("severity", "minor"),
-                            file=finding_raw.get("file"),
-                            line=finding_raw.get("line"),
-                            issue=redact_sensitive(finding_raw["issue"]),
-                            suggestion=redact_sensitive(s)
-                            if (s := finding_raw.get("suggestion")) is not None
-                            else None,
-                        )
-                    )
-                except (KeyError, ValueError):
-                    continue
+            if raw.get("perspectives") is not None:
+                # SODA format: findings are nested inside perspective objects.
+                findings.extend(self._findings_from_perspectives(raw))
+            else:
+                # Legacy flat format: top-level "findings" array.
+                findings.extend(self._findings_from_flat(raw))
         return findings
 
     def _synthesize_context(self, phases: list[PhaseResult]) -> str | None:

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -213,11 +213,16 @@ class SessionSchemaAdapter:
             except json.JSONDecodeError:
                 continue
             output_text = redact_sensitive(json.dumps(raw))
+            status = phase_meta.get("status", "completed")
+            if phase_name == "verify" and not suffix_match:
+                verdict = raw.get("verdict")
+                if isinstance(verdict, str) and verdict.upper() == "FAIL":
+                    status = "failed"
             results.append(
                 PhaseResult(
                     name=phase_name,
                     generation=generation,
-                    status=phase_meta.get("status", "completed"),
+                    status=status,
                     cost_usd=phase_meta.get("cost"),
                     duration_ms=phase_meta.get("duration_ms"),
                     tokens_in=tokens_in,
@@ -234,11 +239,8 @@ class SessionSchemaAdapter:
     _SODA_SEVERITY_MAP: dict[str, Literal["critical", "major", "minor"]] = {
         "CRITICAL": "critical",
         "IMPORTANT": "major",
+        "MAJOR": "major",
         "MINOR": "minor",
-        # Passthrough for pre-existing lowercase values (flat-findings format).
-        "critical": "critical",
-        "major": "major",
-        "minor": "minor",
     }
 
     def _normalize_severity(
@@ -246,12 +248,12 @@ class SessionSchemaAdapter:
     ) -> Literal["critical", "major", "minor"]:
         """Normalize a raw severity string to a ReviewFinding-compatible literal.
 
-        Returns 'minor' when the value is absent or unrecognised so that
-        malformed review files never cause a ValidationError.
+        Case-insensitive. Returns 'minor' when the value is absent or
+        unrecognised so that malformed review files never cause a ValidationError.
         """
         if raw_severity is None:
             return "minor"
-        return self._SODA_SEVERITY_MAP.get(str(raw_severity), "minor")
+        return self._SODA_SEVERITY_MAP.get(str(raw_severity).upper(), "minor")
 
     def _findings_from_flat(self, raw: dict) -> list[ReviewFinding]:
         """Extract findings from the legacy flat ``findings`` array format."""

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -329,10 +329,12 @@ class SessionSchemaAdapter:
     def _synthesize_context(self, phases: list[PhaseResult]) -> str | None:
         """Synthesize retrieval context from structured phase outputs.
 
-        Extracts relevant fields from triage, plan, and implement phases:
+        Extracts relevant fields from each SODA pipeline phase:
         - Triage: approach, code_area, files, risks
         - Plan: approach, task descriptions and files
         - Implement: files_changed, commits, deviations; falls back to output text
+        - Submit: title, branch, pr_url, tests_passed
+        - Monitor: tests_passed, comments_handled summary
         """
         context_chunks: list[str] = []
 
@@ -395,6 +397,44 @@ class SessionSchemaAdapter:
                     impl_parts.append(f"Deviations: {deviations}")
                 if impl_parts:
                     context_chunks.append(redact_sensitive("\n".join(impl_parts)))
+
+            elif phase.name == "submit" and phase.output_structured:
+                submit_parts: list[str] = []
+                title = phase.output_structured.get("title")
+                if title and isinstance(title, str):
+                    submit_parts.append(f"PR title: {title}")
+                branch = phase.output_structured.get("branch")
+                if branch and isinstance(branch, str):
+                    submit_parts.append(f"Branch: {branch}")
+                pr_url = phase.output_structured.get("pr_url")
+                if pr_url and isinstance(pr_url, str):
+                    submit_parts.append(f"PR URL: {pr_url}")
+                target = phase.output_structured.get("target")
+                if target and isinstance(target, str):
+                    submit_parts.append(f"Target branch: {target}")
+                if submit_parts:
+                    context_chunks.append(redact_sensitive("\n".join(submit_parts)))
+
+            elif phase.name == "monitor" and phase.output_structured:
+                monitor_parts: list[str] = []
+                tests_passed = phase.output_structured.get("tests_passed")
+                if tests_passed is not None:
+                    monitor_parts.append(
+                        f"Post-merge tests: {'passed' if tests_passed else 'failed'}"
+                    )
+                comments_handled = phase.output_structured.get("comments_handled")
+                if comments_handled and isinstance(comments_handled, list):
+                    resolved_count = sum(
+                        1
+                        for comment in comments_handled
+                        if isinstance(comment, dict)
+                        and comment.get("action") in ("fixed", "explained")
+                    )
+                    monitor_parts.append(
+                        f"Review comments resolved: {resolved_count}/{len(comments_handled)}"
+                    )
+                if monitor_parts:
+                    context_chunks.append(redact_sensitive("\n".join(monitor_parts)))
 
         # Fall back to implement phase output when structured fields are insufficient
         if not context_chunks:

--- a/src/raki/adapters/session_schema.py
+++ b/src/raki/adapters/session_schema.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 from raki.adapters.redact import redact_dict, redact_sensitive
 from raki.model import EvalSample, PhaseResult, ReviewFinding, SessionEvent, SessionMeta
 
-PHASE_NAMES = ["triage", "plan", "implement", "verify"]
+PHASE_NAMES = ["triage", "plan", "implement", "verify", "review", "submit", "monitor"]
 
 MAX_SESSION_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
 MAX_IMPLEMENT_FALLBACK_CHARS = 10_000

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -3288,7 +3288,7 @@ def test_session_schema_adapter_loads_soda_session(soda_session_dir: Path):
 
 
 def test_session_schema_soda_session_has_all_phases(soda_session_dir: Path):
-    """soda-session fixture contains triage, plan, implement, and verify phases."""
+    """soda-session fixture contains all seven SODA pipeline phases."""
     adapter = SessionSchemaAdapter()
     sample = adapter.load(soda_session_dir)
     phase_names = {phase.name for phase in sample.phases}
@@ -3296,6 +3296,9 @@ def test_session_schema_soda_session_has_all_phases(soda_session_dir: Path):
     assert "plan" in phase_names
     assert "implement" in phase_names
     assert "verify" in phase_names
+    assert "review" in phase_names
+    assert "submit" in phase_names
+    assert "monitor" in phase_names
 
 
 def test_session_schema_soda_session_triage_structured(soda_session_dir: Path):
@@ -3325,17 +3328,54 @@ def test_session_schema_soda_session_implement_structured(soda_session_dir: Path
 
 
 def test_session_schema_soda_session_review_finding(soda_session_dir: Path):
-    """soda-session fixture has review findings in perspectives structure.
-
-    The current adapter reads top-level 'findings' only. Once #220 lands
-    (perspectives support), this test should assert findings are loaded.
-    For now, verify the adapter does not crash on the SODA review format.
-    """
+    """soda-session fixture has review findings parsed from perspectives structure (#220)."""
     adapter = SessionSchemaAdapter()
     sample = adapter.load(soda_session_dir)
-    # Findings are in perspectives structure (SODA schema), not top-level.
-    # Adapter cannot read them yet (#220). Verify graceful handling.
-    assert sample.findings == []
+    # Findings are in perspectives structure (SODA schema); adapter must parse them.
+    assert len(sample.findings) >= 1
+
+
+def test_session_schema_soda_session_perspectives_severity_mapped(soda_session_dir: Path):
+    """SODA perspectives severity values (MINOR/IMPORTANT/CRITICAL) map to ReviewFinding values."""
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(soda_session_dir)
+    # soda-session review.json has one MINOR finding from the python perspective
+    minor_findings = [f for f in sample.findings if f.severity == "minor"]
+    assert len(minor_findings) >= 1
+
+
+def test_session_schema_soda_session_perspectives_source_is_perspective_name(
+    soda_session_dir: Path,
+):
+    """Findings parsed from perspectives use the perspective name as reviewer."""
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(soda_session_dir)
+    # soda-session review.json has findings from the "python" perspective
+    python_findings = [f for f in sample.findings if f.reviewer == "python"]
+    assert len(python_findings) >= 1
+
+
+def test_session_schema_soda_session_submit_phase_loaded(soda_session_dir: Path):
+    """soda-session fixture loads the submit phase as a PhaseResult."""
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(soda_session_dir)
+    submit_phases = [phase for phase in sample.phases if phase.name == "submit"]
+    assert len(submit_phases) == 1
+    submit_phase = submit_phases[0]
+    assert submit_phase.output_structured is not None
+    assert submit_phase.output_structured["ticket_key"] == "223"
+    assert "pr_url" in submit_phase.output_structured
+
+
+def test_session_schema_soda_session_monitor_phase_loaded(soda_session_dir: Path):
+    """soda-session fixture loads the monitor phase as a PhaseResult."""
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(soda_session_dir)
+    monitor_phases = [phase for phase in sample.phases if phase.name == "monitor"]
+    assert len(monitor_phases) == 1
+    monitor_phase = monitor_phases[0]
+    assert monitor_phase.output_structured is not None
+    assert monitor_phase.output_structured["ticket_key"] == "223"
 
 
 def test_session_schema_soda_session_synthesizes_context(soda_session_dir: Path):
@@ -3344,6 +3384,30 @@ def test_session_schema_soda_session_synthesizes_context(soda_session_dir: Path)
     sample = adapter.load(soda_session_dir)
     has_context = any(phase.knowledge_context is not None for phase in sample.phases)
     assert has_context
+
+
+def test_session_schema_soda_session_submit_context_included(soda_session_dir: Path):
+    """Context synthesis includes submit phase data (PR URL, title)."""
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(soda_session_dir)
+    # Find the phase that holds the synthesized context
+    context_phase = next(
+        (phase for phase in sample.phases if phase.knowledge_context is not None), None
+    )
+    assert context_phase is not None
+    assert (
+        "PR" in context_phase.knowledge_context or "pr" in context_phase.knowledge_context.lower()
+    )
+
+
+def test_session_schema_soda_session_perspectives_empty_findings_skipped(soda_session_dir: Path):
+    """Perspectives with empty findings lists contribute zero ReviewFindings."""
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(soda_session_dir)
+    # soda-session review.json has a "security" perspective with 0 findings.
+    # Total findings should be exactly the count from non-empty perspectives.
+    security_findings = [f for f in sample.findings if f.reviewer == "security"]
+    assert len(security_findings) == 0
 
 
 # --- Ticket 219: rework_cycles resolution from generation ---

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -3387,7 +3387,13 @@ def test_session_schema_soda_session_synthesizes_context(soda_session_dir: Path)
 
 
 def test_session_schema_soda_session_submit_context_included(soda_session_dir: Path):
-    """Context synthesis includes submit phase data (PR URL, title)."""
+    """Context synthesis includes submit phase data (PR URL/title).
+
+    The submit fixture has pr_url 'https://github.com/example/raki/pull/223'
+    and title 'chore: add SODA session test fixture ...'.  The pr_url
+    contains 'pull/223' which only appears in the submit phase output
+    (not in triage/plan/implement) and must be present after #220.
+    """
     adapter = SessionSchemaAdapter()
     sample = adapter.load(soda_session_dir)
     # Find the phase that holds the synthesized context
@@ -3395,9 +3401,9 @@ def test_session_schema_soda_session_submit_context_included(soda_session_dir: P
         (phase for phase in sample.phases if phase.knowledge_context is not None), None
     )
     assert context_phase is not None
-    assert (
-        "PR" in context_phase.knowledge_context or "pr" in context_phase.knowledge_context.lower()
-    )
+    ctx_lower = context_phase.knowledge_context.lower()
+    # PR URL path 'pull/223' is unique to the submit phase output.
+    assert "pull/223" in ctx_lower
 
 
 def test_session_schema_soda_session_perspectives_empty_findings_skipped(soda_session_dir: Path):

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -3416,6 +3416,52 @@ def test_session_schema_soda_session_perspectives_empty_findings_skipped(soda_se
     assert len(security_findings) == 0
 
 
+def test_session_schema_verify_verdict_pass_sets_status(soda_session_dir: Path):
+    """Verify phase with verdict PASS keeps status as completed."""
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(soda_session_dir)
+    verify_phases = [phase for phase in sample.phases if phase.name == "verify"]
+    assert len(verify_phases) >= 1
+    assert verify_phases[-1].status == "completed"
+
+
+def test_session_schema_verify_verdict_fail_sets_failed(tmp_path):
+    """Verify phase with verdict FAIL overrides status to failed."""
+    meta = {
+        "ticket": "999",
+        "started_at": "2026-01-01T00:00:00Z",
+        "total_cost": 1.0,
+        "phases": {"verify": {"status": "completed", "cost": 0.5, "generation": 1}},
+    }
+    verify_output = {"ticket_key": "999", "verdict": "FAIL", "criteria_results": []}
+    events = [
+        {"phase": "verify", "event": "phase_started"},
+        {"phase": "verify", "event": "phase_completed", "cost": 0.5},
+    ]
+    (tmp_path / "meta.json").write_text(json.dumps(meta))
+    (tmp_path / "verify.json").write_text(json.dumps(verify_output))
+    (tmp_path / "events.jsonl").write_text("\n".join(json.dumps(event) for event in events) + "\n")
+    adapter = SessionSchemaAdapter()
+    sample = adapter.load(tmp_path)
+    verify_phases = [phase for phase in sample.phases if phase.name == "verify"]
+    assert len(verify_phases) == 1
+    assert verify_phases[0].status == "failed"
+
+
+def test_session_schema_severity_case_insensitive(tmp_path):
+    """Severity normalization is case-insensitive (e.g. 'Critical' maps to 'critical')."""
+    adapter = SessionSchemaAdapter()
+    assert adapter._normalize_severity("CRITICAL") == "critical"
+    assert adapter._normalize_severity("Critical") == "critical"
+    assert adapter._normalize_severity("critical") == "critical"
+    assert adapter._normalize_severity("IMPORTANT") == "major"
+    assert adapter._normalize_severity("Important") == "major"
+    assert adapter._normalize_severity("MINOR") == "minor"
+    assert adapter._normalize_severity("Minor") == "minor"
+    assert adapter._normalize_severity("unknown") == "minor"
+    assert adapter._normalize_severity(None) == "minor"
+
+
 # --- Ticket 219: rework_cycles resolution from generation ---
 
 


### PR DESCRIPTION
## Summary
Extend the session-schema adapter to handle all 7 SODA phases and parse structured review findings.

### Changes
- **Dynamic phase discovery**: loads review, submit, and monitor phases (previously hardcoded to 4)
- **Review findings from perspectives**: extracts findings from SODA's nested `perspectives -> findings` structure
- **Severity mapping**: normalizes `CRITICAL/IMPORTANT/MINOR` (SODA) to `critical/major/minor` (RAKI)
- **Verify verdict**: uses structured `verdict` field from verify.json
- **Context synthesis**: submit and monitor phases contribute to synthesized context

## Test plan
- [ ] All 7 SODA phases loaded from soda-session fixture
- [ ] Review findings extracted from perspectives structure with correct severity mapping
- [ ] Backward compatible with non-SODA session-schema directories
- [ ] `uv run pytest tests/ -v -m "not slow"` — all pass

Refs #220

🤖 Generated with [Claude Code](https://claude.com/claude-code) via SODA pipeline