### PR TITLE
feat: add raki import-history command for backfilling evaluation history

### DIFF
--- a/changes/221.feature
+++ b/changes/221.feature
@@ -1,0 +1,17 @@
+Add ``raki import-history`` command to backfill ``history.jsonl`` from existing session directories.
+
+The new command discovers sessions under one or more input paths using the adapter registry (session-schema and alcove formats are both supported), computes all operational metrics without making any LLM calls, and appends one ``HistoryEntry`` per session to the JSONL history file.  Sessions already present in the history are automatically skipped so repeated imports are idempotent.
+
+Key options:
+
+- ``--history-path`` — override the default ``.raki/history.jsonl`` destination
+- ``--adapter`` — force a specific adapter instead of auto-detecting
+- ``--dry-run`` — preview what would be imported without writing anything
+- ``-q / --quiet`` — suppress per-session output lines
+
+Two new public helpers are also available in ``raki.report.history``:
+
+- ``load_run_ids(history_path)`` — return the set of ``run_id`` values already in the history file (O(1) deduplication)
+- ``import_history_entry(entry, history_path, existing_ids)`` — append a ``HistoryEntry`` when its ``run_id`` is not already present, updating the caller-owned ``existing_ids`` set in-place
+
+A new internal module ``raki.adapters.discovery`` provides ``discover_sessions(paths, registry)`` which walks input paths recursively and returns all detected session paths, respecting symlink safety and deduplication.

--- a/src/raki/adapters/discovery.py
+++ b/src/raki/adapters/discovery.py
@@ -1,0 +1,108 @@
+"""Session discovery — walk input paths and detect sessions via the adapter registry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from raki.adapters.registry import AdapterRegistry
+
+
+def discover_sessions(
+    paths: list[Path],
+    registry: AdapterRegistry,
+    *,
+    recursive: bool = True,
+) -> list[Path]:
+    """Walk *paths* and return every session path detected by any registered adapter.
+
+    A session path is any file or directory for which at least one adapter's
+    ``detect()`` method returns ``True``.  When a directory is detected as a
+    session it is **not** recursed into (its children are part of the session,
+    not separate sessions).  Symlinks are always skipped.
+
+    Args:
+        paths: Input paths to scan.  May be a mix of files and directories.
+        registry: Adapter registry used for session detection.
+        recursive: When ``True`` (the default), directories that are not
+            themselves sessions are recursed into to find nested sessions.
+
+    Returns:
+        Detected session paths in discovery order (per-path, then
+        alphabetically within each directory level).  Duplicates are removed
+        while preserving first-seen order.
+    """
+    found: list[Path] = []
+    seen: set[Path] = set()
+
+    for raw_path in paths:
+        # Check is_symlink() before resolve() so the symlink itself is detected,
+        # not the eventual target (which resolve() would return).
+        if raw_path.is_symlink():
+            continue
+        path = raw_path.resolve()
+        if path.is_file():
+            _check_file(path, registry, found, seen)
+        elif path.is_dir():
+            _walk_dir(path, registry, found, seen, recursive=recursive)
+
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_session(path: Path, registry: AdapterRegistry) -> bool:
+    """Return True if *any* registered adapter detects *path* as a session."""
+    return any(adapter.detect(path) for adapter in registry.list_all())
+
+
+def _check_file(
+    path: Path,
+    registry: AdapterRegistry,
+    found: list[Path],
+    seen: set[Path],
+) -> None:
+    """Add *path* to *found* if it is detected as a session and not yet seen."""
+    resolved = path.resolve()
+    if resolved in seen:
+        return
+    if _is_session(resolved, registry):
+        seen.add(resolved)
+        found.append(resolved)
+
+
+def _walk_dir(
+    directory: Path,
+    registry: AdapterRegistry,
+    found: list[Path],
+    seen: set[Path],
+    *,
+    recursive: bool,
+) -> None:
+    """Recursively walk *directory* and collect session paths.
+
+    If *directory* itself is detected as a session it is added and recursion
+    stops.  Otherwise all non-symlink children are visited in sorted order.
+    """
+    resolved = directory.resolve()
+    if resolved in seen or resolved.is_symlink():
+        return
+    seen.add(resolved)
+
+    # If this directory is itself a session, add it and stop recursing.
+    if _is_session(resolved, registry):
+        found.append(resolved)
+        return
+
+    if not recursive:
+        return
+
+    for child in sorted(resolved.iterdir()):
+        if child.is_symlink():
+            continue
+        if child.is_file():
+            _check_file(child, registry, found, seen)
+        elif child.is_dir():
+            _walk_dir(child, registry, found, seen, recursive=recursive)

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -1370,5 +1370,163 @@ def gate_check(
         raise SystemExit(exit_code)
 
 
+@main.command("import-history")
+@click.argument("paths", nargs=-1, required=True, type=click.Path(exists=True))
+@click.option(
+    "--history-path",
+    "history_path_arg",
+    default=None,
+    help="Path to JSONL history log (default: .raki/history.jsonl)",
+)
+@click.option("--adapter", "adapter_format", default=None, help="Force adapter (default: auto)")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show what would be imported without writing to history",
+)
+@click.option("-q", "--quiet", is_flag=True, help="Suppress per-session output")
+def import_history(
+    paths: tuple[str, ...],
+    history_path_arg: str | None,
+    adapter_format: str | None,
+    dry_run: bool,
+    quiet: bool,
+) -> None:
+    """Backfill history.jsonl from existing session directories.
+
+    Discovers sessions under each PATH using the adapter registry, computes
+    operational metrics (no LLM calls), and appends one HistoryEntry per
+    session to the JSONL history file.  Sessions already present in the
+    history (matched by run_id) are skipped automatically.
+
+    Use --dry-run to preview what would be imported without writing anything.
+    """
+    from raki.adapters import DatasetLoader
+    from raki.adapters.discovery import discover_sessions
+    from raki.metrics import MetricsEngine
+    from raki.metrics.operational import ALL_OPERATIONAL
+    from raki.metrics.protocol import MetricConfig
+    from raki.model import EvalDataset
+    from raki.report.history import HistoryEntry, import_history_entry, load_run_ids
+
+    registry = _build_registry()
+
+    if adapter_format is not None and registry.get(adapter_format) is None:
+        valid_names = ", ".join(adapter.name for adapter in registry.list_all())
+        raise click.BadParameter(
+            f"Unknown adapter: '{adapter_format}'. Valid adapters: {valid_names}",
+            param_hint="'--adapter'",
+        )
+
+    history_path = (
+        Path(history_path_arg) if history_path_arg else Path.cwd() / ".raki" / "history.jsonl"
+    )
+
+    # Path traversal guard: history path must be a descendant of project root
+    resolved_history = history_path.resolve()
+    project_root = Path.cwd().resolve()
+    try:
+        resolved_history.relative_to(project_root)
+    except ValueError:
+        raise click.UsageError(f"--history-path must be within the project root ({project_root})")
+
+    input_paths = [Path(p) for p in paths]
+    session_paths = discover_sessions(input_paths, registry)
+
+    if not session_paths:
+        console.print("[yellow]No sessions found in the provided paths.[/yellow]")
+        return
+
+    if not quiet:
+        console.print(
+            f"Discovered [bold]{len(session_paths)}[/bold] session"
+            f"{'s' if len(session_paths) != 1 else ''}"
+        )
+
+    existing_ids = load_run_ids(history_path)
+
+    loader = DatasetLoader(registry)
+    config = MetricConfig()
+    engine = MetricsEngine(list(ALL_OPERATIONAL), config=config)
+
+    imported = 0
+    skipped = 0
+    errors = 0
+
+    for session_path in session_paths:
+        try:
+            sample = loader.load_session(session_path, adapter_name=adapter_format)
+        except Exception as exc:
+            errors += 1
+            if not quiet:
+                console.print(
+                    f"  [red]✗[/red] {session_path.name}: load error — {redact_sensitive(str(exc))}"
+                )
+            continue
+
+        # Build a stable run_id from the session_id so re-imports are idempotent
+        run_id = f"import-{sample.session.session_id}"
+
+        if run_id in existing_ids:
+            skipped += 1
+            if not quiet:
+                console.print(f"  [dim]—[/dim] {session_path.name}: already in history")
+            continue
+
+        try:
+            dataset = EvalDataset(samples=[sample])
+            report = engine.run(dataset, skip_judge=True)
+        except Exception as exc:
+            errors += 1
+            if not quiet:
+                console.print(
+                    f"  [red]✗[/red] {session_path.name}: "
+                    f"metrics error — {redact_sensitive(str(exc))}"
+                )
+            continue
+
+        metrics_dict = {k: v for k, v in report.aggregate_scores.items() if v is not None}
+
+        entry = HistoryEntry(
+            run_id=run_id,
+            timestamp=sample.session.started_at,
+            sessions_count=1,
+            metrics=metrics_dict,
+        )
+
+        if dry_run:
+            imported += 1
+            if not quiet:
+                metric_preview = ", ".join(
+                    f"{k}={v:.3f}" for k, v in list(metrics_dict.items())[:3]
+                )
+                console.print(
+                    f"  [dim]○[/dim] {session_path.name}: "
+                    f"would import ({metric_preview}{'...' if len(metrics_dict) > 3 else ''})"
+                )
+        else:
+            try:
+                import_history_entry(entry, history_path, existing_ids)
+                imported += 1
+                if not quiet:
+                    console.print(f"  [green]✓[/green] {session_path.name}: imported")
+            except Exception as exc:
+                errors += 1
+                if not quiet:
+                    console.print(
+                        f"  [red]✗[/red] {session_path.name}: "
+                        f"write error — {redact_sensitive(str(exc))}"
+                    )
+
+    action = "Would import" if dry_run else "Imported"
+    suffix = " (dry run)" if dry_run else ""
+    console.print(
+        f"\n{action} [bold]{imported}[/bold] session"
+        f"{'s' if imported != 1 else ''}{suffix}"
+        f" ({skipped} already present, {errors} error{'s' if errors != 1 else ''})"
+    )
+
+
 if __name__ == "__main__":
     main()

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -1526,6 +1526,8 @@ def import_history(
         f"{'s' if imported != 1 else ''}{suffix}"
         f" ({skipped} already present, {errors} error{'s' if errors != 1 else ''})"
     )
+    if errors > 0 and imported == 0:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/src/raki/report/history.py
+++ b/src/raki/report/history.py
@@ -102,6 +102,67 @@ def append_history_entry(
         history_file.write(line + "\n")
 
 
+def load_run_ids(history_path: Path) -> set[str]:
+    """Return the set of ``run_id`` values already present in *history_path*.
+
+    This is a lightweight deduplication helper for ``import-history``: callers
+    can check membership in O(1) before attempting to write a new entry.
+
+    Args:
+        history_path: Path to the JSONL history file.  A missing file is
+            treated as an empty history — an empty set is returned.
+
+    Returns:
+        Set of run_id strings found in the existing history.
+
+    Raises:
+        ValueError: If ``history_path`` is a symlink (security guard).
+    """
+    return {entry.run_id for entry in load_history(history_path)}
+
+
+def import_history_entry(
+    entry: HistoryEntry,
+    history_path: Path,
+    existing_ids: set[str],
+) -> bool:
+    """Append *entry* to the JSONL history file if its ``run_id`` is not already present.
+
+    The caller owns the *existing_ids* set and is responsible for keeping it
+    up-to-date: this function **adds** ``entry.run_id`` to *existing_ids* when
+    a write occurs, so that repeated calls within the same import session remain
+    idempotent without re-reading the file each time.
+
+    Args:
+        entry: The :class:`HistoryEntry` to append.
+        history_path: Path to the JSONL history file.  Parent directories are
+            created on first write.
+        existing_ids: Mutable set of run_ids already in the file.  Updated
+            in-place when an entry is written.
+
+    Returns:
+        ``True`` if the entry was written, ``False`` if it was a duplicate.
+
+    Raises:
+        ValueError: If ``history_path`` is a symlink (security guard).
+    """
+    if entry.run_id in existing_ids:
+        return False
+
+    if history_path.is_symlink():
+        raise ValueError(f"Refusing to write to symlink: {history_path}")
+
+    resolved = history_path.resolve()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+
+    line = json.dumps(entry.model_dump(mode="json"), default=str)
+    with resolved.open("a", encoding="utf-8") as history_file:
+        history_file.write(line + "\n")
+
+    existing_ids.add(entry.run_id)
+    return True
+
+
 def load_history(history_path: Path) -> list[HistoryEntry]:
     """Load all history entries from a JSONL file.
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,245 @@
+"""Tests for raki.adapters.discovery — discover_sessions()."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+from raki.adapters import default_registry
+from raki.adapters.discovery import discover_sessions
+from raki.adapters.registry import AdapterRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session_dir(parent: Path, name: str) -> Path:
+    """Create a minimal session-schema session directory."""
+    session = parent / name
+    session.mkdir()
+    (session / "meta.json").write_text(
+        json.dumps(
+            {
+                "ticket": name,
+                "started_at": "2026-04-10T08:00:00Z",
+                "total_cost": 1.0,
+                "rework_cycles": 0,
+                "phases": {},
+            }
+        )
+    )
+    (session / "events.jsonl").write_text("")
+    return session
+
+
+def _make_alcove_file(parent: Path, name: str = "session.json") -> Path:
+    """Create a minimal alcove-format JSON file."""
+    path = parent / name
+    path.write_text(
+        json.dumps(
+            {
+                "session_id": name.replace(".json", ""),
+                "transcript": [
+                    {
+                        "type": "user",
+                        "timestamp": "2026-04-10T08:00:00Z",
+                        "message": {"content": "hello"},
+                    }
+                ],
+            }
+        )
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Basic session detection
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverSessionsBasic:
+    def test_empty_paths_returns_empty(self, tmp_path: Path) -> None:
+        registry = default_registry()
+        result = discover_sessions([], registry)
+        assert result == []
+
+    def test_finds_single_session_schema_dir(self, tmp_path: Path) -> None:
+        session = _make_session_dir(tmp_path, "101")
+        registry = default_registry()
+        result = discover_sessions([tmp_path], registry)
+        assert session.resolve() in result
+
+    def test_finds_multiple_session_schema_dirs(self, tmp_path: Path) -> None:
+        sessions = [_make_session_dir(tmp_path, str(i)) for i in range(3)]
+        registry = default_registry()
+        result = discover_sessions([tmp_path], registry)
+        assert len(result) == 3
+        resolved = {p.resolve() for p in sessions}
+        assert set(result) == resolved
+
+    def test_finds_alcove_file_in_directory(self, tmp_path: Path) -> None:
+        alcove = _make_alcove_file(tmp_path, "session.json")
+        registry = default_registry()
+        result = discover_sessions([tmp_path], registry)
+        assert alcove.resolve() in result
+
+    def test_finds_alcove_file_given_directly(self, tmp_path: Path) -> None:
+        alcove = _make_alcove_file(tmp_path, "s.json")
+        registry = default_registry()
+        result = discover_sessions([alcove], registry)
+        assert alcove.resolve() in result
+
+    def test_non_session_directory_not_returned(self, tmp_path: Path) -> None:
+        # Just an empty directory — no adapter should detect it
+        registry = default_registry()
+        result = discover_sessions([tmp_path], registry)
+        assert result == []
+
+    def test_non_json_file_not_returned(self, tmp_path: Path) -> None:
+        txt = tmp_path / "notes.txt"
+        txt.write_text("hello")
+        registry = default_registry()
+        result = discover_sessions([tmp_path], registry)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Recursive discovery
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverSessionsRecursive:
+    def test_recursive_finds_nested_sessions(self, tmp_path: Path) -> None:
+        """Sessions in subdirectories are discovered recursively (default)."""
+        sub = tmp_path / "group-a"
+        sub.mkdir()
+        session = _make_session_dir(sub, "nested-101")
+        registry = default_registry()
+        result = discover_sessions([tmp_path], registry)
+        assert session.resolve() in result
+
+    def test_non_recursive_does_not_descend(self, tmp_path: Path) -> None:
+        """When recursive=False, subdirectories are not entered."""
+        sub = tmp_path / "subdir"
+        sub.mkdir()
+        _make_session_dir(sub, "101")
+        registry = default_registry()
+        result = discover_sessions([tmp_path], registry, recursive=False)
+        assert result == []
+
+    def test_session_dir_not_recursed_into(self, tmp_path: Path) -> None:
+        """A detected session directory is added once; its children are not checked."""
+        session = _make_session_dir(tmp_path, "parent-session")
+        # Add a nested directory that would also look like a session
+        nested = session / "sub-session"
+        nested.mkdir()
+        (nested / "meta.json").write_text(
+            json.dumps({"started_at": "2026-01-01T00:00:00Z", "phases": {}})
+        )
+        (nested / "events.jsonl").write_text("")
+        registry = default_registry()
+        result = discover_sessions([tmp_path], registry)
+        # Only the top-level session should be returned
+        assert len(result) == 1
+        assert result[0] == session.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Deduplication and ordering
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverSessionsDedup:
+    def test_no_duplicates_when_path_overlaps(self, tmp_path: Path) -> None:
+        """Passing the same path twice should not yield duplicates."""
+        _make_session_dir(tmp_path, "101")
+        registry = default_registry()
+        result = discover_sessions([tmp_path, tmp_path], registry)
+        assert len(result) == 1
+
+    def test_no_duplicates_for_same_session_different_paths(self, tmp_path: Path) -> None:
+        """A session returned by a parent path and given directly should appear once."""
+        session = _make_session_dir(tmp_path, "101")
+        registry = default_registry()
+        result = discover_sessions([tmp_path, session], registry)
+        assert len(result) == 1
+
+    def test_results_are_resolved_paths(self, tmp_path: Path) -> None:
+        """All returned paths are absolute (resolved)."""
+        _make_session_dir(tmp_path, "101")
+        registry = default_registry()
+        result = discover_sessions([tmp_path], registry)
+        assert all(p.is_absolute() for p in result)
+
+
+# ---------------------------------------------------------------------------
+# Symlink safety
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverSessionsSymlinks:
+    def test_symlinked_input_path_skipped(self, tmp_path: Path) -> None:
+        """A symlinked input path should be silently skipped."""
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        _make_session_dir(real_dir, "101")
+        link = tmp_path / "link"
+        link.symlink_to(real_dir)
+        registry = default_registry()
+        result = discover_sessions([link], registry)
+        assert result == []
+
+    def test_symlinked_child_skipped_during_walk(self, tmp_path: Path) -> None:
+        """Symlinked children inside a scanned directory are skipped."""
+        real_session = _make_session_dir(tmp_path, "real-session")
+        link = tmp_path / "link-session"
+        link.symlink_to(real_session)
+        registry = default_registry()
+        result = discover_sessions([tmp_path], registry)
+        # Only the real session should appear, not the symlink
+        assert len(result) == 1
+        assert result[0] == real_session.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Empty registry
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverSessionsEmptyRegistry:
+    def test_empty_registry_finds_nothing(self, tmp_path: Path) -> None:
+        """An empty registry has no adapters, so nothing should be detected."""
+        _make_session_dir(tmp_path, "101")
+        empty_registry = AdapterRegistry()
+        result = discover_sessions([tmp_path], empty_registry)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Fixture-based integration
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverSessionsFixtures:
+    def test_discovers_pass_simple_fixture(self, sessions_dir: Path) -> None:
+        """discover_sessions finds the pass-simple fixture session."""
+        registry = default_registry()
+        result = discover_sessions([sessions_dir], registry)
+        names = [p.name for p in result]
+        assert "pass-simple" in names
+
+    def test_discovers_rework_cycle_fixture(self, sessions_dir: Path) -> None:
+        """discover_sessions finds the rework-cycle fixture session."""
+        registry = default_registry()
+        result = discover_sessions([sessions_dir], registry)
+        names = [p.name for p in result]
+        assert "rework-cycle" in names
+
+    def test_discovers_all_fixture_sessions(self, sessions_dir: Path) -> None:
+        """discover_sessions finds all fixture sessions (at least 3)."""
+        registry = default_registry()
+        result = discover_sessions([sessions_dir], registry)
+        assert len(result) >= 3

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -9,7 +9,13 @@ from unittest.mock import patch
 import pytest
 
 from raki.model.report import EvalReport
-from raki.report.history import HistoryEntry, append_history_entry, load_history
+from raki.report.history import (
+    HistoryEntry,
+    append_history_entry,
+    import_history_entry,
+    load_history,
+    load_run_ids,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -353,3 +359,142 @@ class TestLoadHistory:
         ):
             sha = _git_sha()
         assert sha is None
+
+
+# ---------------------------------------------------------------------------
+# load_run_ids
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRunIds:
+    def test_returns_empty_set_when_file_missing(self, tmp_path: Path) -> None:
+        """load_run_ids must return an empty set when the history file does not exist."""
+        history_path = tmp_path / "history.jsonl"
+        ids = load_run_ids(history_path)
+        assert ids == set()
+
+    def test_returns_all_run_ids(self, tmp_path: Path) -> None:
+        """load_run_ids must return all run_id values from the history file."""
+        history_path = tmp_path / "history.jsonl"
+        for run_id in ("eval-a", "eval-b", "eval-c"):
+            report, count = _make_report(run_id=run_id)
+            append_history_entry(report, history_path, sessions_count=count)
+        ids = load_run_ids(history_path)
+        assert ids == {"eval-a", "eval-b", "eval-c"}
+
+    def test_returns_set_not_list(self, tmp_path: Path) -> None:
+        """load_run_ids must return a set for O(1) membership tests."""
+        history_path = tmp_path / "history.jsonl"
+        report, count = _make_report()
+        append_history_entry(report, history_path, sessions_count=count)
+        result = load_run_ids(history_path)
+        assert isinstance(result, set)
+
+    def test_rejects_symlink(self, tmp_path: Path) -> None:
+        """load_run_ids must refuse to read a symlink (delegates to load_history)."""
+        real_file = tmp_path / "real.jsonl"
+        real_file.write_text(
+            '{"run_id":"r","timestamp":"2026-01-01T00:00:00Z","sessions_count":1,"metrics":{}}\n'
+        )
+        link = tmp_path / "link.jsonl"
+        link.symlink_to(real_file)
+        with pytest.raises(ValueError, match="symlink"):
+            load_run_ids(link)
+
+
+# ---------------------------------------------------------------------------
+# import_history_entry
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(run_id: str = "import-101") -> HistoryEntry:
+    return HistoryEntry(
+        run_id=run_id,
+        timestamp=datetime(2026, 4, 10, 8, 0, 0, tzinfo=timezone.utc),
+        sessions_count=1,
+        metrics={"first_pass_success_rate": 1.0},
+    )
+
+
+class TestImportHistoryEntry:
+    def test_writes_new_entry(self, tmp_path: Path) -> None:
+        """import_history_entry must write a new entry and return True."""
+        history_path = tmp_path / "history.jsonl"
+        entry = _make_entry("import-101")
+        existing: set[str] = set()
+        result = import_history_entry(entry, history_path, existing)
+        assert result is True
+        assert history_path.exists()
+
+    def test_skips_duplicate_run_id(self, tmp_path: Path) -> None:
+        """import_history_entry must skip an entry whose run_id is already present."""
+        history_path = tmp_path / "history.jsonl"
+        entry = _make_entry("import-101")
+        existing: set[str] = {"import-101"}
+        result = import_history_entry(entry, history_path, existing)
+        assert result is False
+        assert not history_path.exists()
+
+    def test_updates_existing_ids_on_write(self, tmp_path: Path) -> None:
+        """import_history_entry must add the run_id to existing_ids after writing."""
+        history_path = tmp_path / "history.jsonl"
+        entry = _make_entry("import-101")
+        existing: set[str] = set()
+        import_history_entry(entry, history_path, existing)
+        assert "import-101" in existing
+
+    def test_does_not_update_existing_ids_on_skip(self, tmp_path: Path) -> None:
+        """existing_ids must not be modified when the entry is skipped."""
+        history_path = tmp_path / "history.jsonl"
+        entry = _make_entry("import-101")
+        existing: set[str] = {"import-101"}
+        import_history_entry(entry, history_path, existing)
+        assert existing == {"import-101"}
+
+    def test_appends_multiple_entries(self, tmp_path: Path) -> None:
+        """Multiple import_history_entry calls must produce multiple JSONL lines."""
+        history_path = tmp_path / "history.jsonl"
+        existing: set[str] = set()
+        for i in range(3):
+            entry = _make_entry(f"import-{i}")
+            import_history_entry(entry, history_path, existing)
+        lines = history_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 3
+
+    def test_written_line_is_valid_json(self, tmp_path: Path) -> None:
+        """Each written line must be valid JSON."""
+        history_path = tmp_path / "history.jsonl"
+        entry = _make_entry("import-json")
+        import_history_entry(entry, history_path, set())
+        raw = history_path.read_text(encoding="utf-8").strip()
+        parsed = json.loads(raw)
+        assert parsed["run_id"] == "import-json"
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        """import_history_entry must create missing parent directories."""
+        history_path = tmp_path / "deep" / "nested" / "history.jsonl"
+        entry = _make_entry("import-deep")
+        import_history_entry(entry, history_path, set())
+        assert history_path.exists()
+
+    def test_rejects_symlink(self, tmp_path: Path) -> None:
+        """import_history_entry must refuse to write through a symlink."""
+        real_file = tmp_path / "real.jsonl"
+        real_file.write_text("")
+        link = tmp_path / "link.jsonl"
+        link.symlink_to(real_file)
+        entry = _make_entry("import-sym")
+        with pytest.raises(ValueError, match="symlink"):
+            import_history_entry(entry, link, set())
+
+    def test_second_call_same_id_is_idempotent(self, tmp_path: Path) -> None:
+        """After a successful write, calling import_history_entry again with the
+        same run_id must be a no-op (existing_ids is updated in-place)."""
+        history_path = tmp_path / "history.jsonl"
+        entry = _make_entry("import-idem")
+        existing: set[str] = set()
+        import_history_entry(entry, history_path, existing)
+        result = import_history_entry(entry, history_path, existing)
+        assert result is False
+        lines = history_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1

--- a/tests/test_import_history.py
+++ b/tests/test_import_history.py
@@ -529,7 +529,7 @@ class TestImportHistoryErrors:
             ["import-history", str(sessions), "--history-path", str(history_path)],
             catch_exceptions=False,
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "error" in result.output.lower()
 
     def test_history_path_outside_project_root_rejected(

--- a/tests/test_import_history.py
+++ b/tests/test_import_history.py
@@ -1,0 +1,625 @@
+"""Tests for the `raki import-history` CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from raki.cli import main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session_dir(parent: Path, name: str = "101") -> Path:
+    """Create a minimal session-schema session directory."""
+    session = parent / name
+    session.mkdir()
+    (session / "meta.json").write_text(
+        json.dumps(
+            {
+                "ticket": name,
+                "started_at": "2026-04-10T08:00:00Z",
+                "total_cost": 5.0,
+                "rework_cycles": 0,
+                "phases": {
+                    "triage": {"status": "completed", "generation": 1},
+                    "implement": {"status": "completed", "generation": 1},
+                    "verify": {"status": "completed", "generation": 1},
+                },
+            }
+        )
+    )
+    (session / "events.jsonl").write_text("")
+    (session / "verify.json").write_text(json.dumps({"verdict": "PASS"}))
+    return session
+
+
+def _make_session_dir_with_rework(parent: Path, name: str = "102") -> Path:
+    """Create a session-schema directory with 1 rework cycle."""
+    session = parent / name
+    session.mkdir()
+    (session / "meta.json").write_text(
+        json.dumps(
+            {
+                "ticket": name,
+                "started_at": "2026-04-11T08:00:00Z",
+                "total_cost": 8.0,
+                "rework_cycles": 1,
+                "phases": {
+                    "implement": {"status": "completed", "generation": 2},
+                    "verify": {"status": "completed", "generation": 1},
+                },
+            }
+        )
+    )
+    (session / "events.jsonl").write_text("")
+    (session / "verify.json").write_text(json.dumps({"verdict": "PASS"}))
+    return session
+
+
+def _invoke(args: list[str], *, cwd: Path | None = None) -> object:
+    """Invoke the CLI from within *cwd* (or tmp_path via monkeypatch)."""
+    runner = CliRunner()
+    return runner.invoke(main, args, catch_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Help and registration
+# ---------------------------------------------------------------------------
+
+
+class TestImportHistoryHelp:
+    def test_import_history_in_help(self) -> None:
+        """import-history must appear in the top-level help output."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "import-history" in result.output
+
+    def test_import_history_help_text(self) -> None:
+        """import-history --help must show usage, options, and description."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["import-history", "--help"])
+        assert result.exit_code == 0
+        assert "PATHS" in result.output
+        assert "--dry-run" in result.output
+        assert "--history-path" in result.output
+        assert "--adapter" in result.output
+        assert "-q" in result.output or "--quiet" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Basic import
+# ---------------------------------------------------------------------------
+
+
+class TestImportHistoryBasic:
+    def test_imports_single_session(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """import-history must import a single detected session."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert history_path.exists()
+        lines = history_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+
+    def test_imports_multiple_sessions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """import-history must import all detected sessions in the directory."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        for name in ("101", "102", "103"):
+            _make_session_dir(sessions, name)
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        lines = history_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 3
+
+    def test_each_entry_is_valid_jsonl(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each line written to history.jsonl must be valid JSON."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        for line in history_path.read_text(encoding="utf-8").strip().splitlines():
+            parsed = json.loads(line)
+            assert isinstance(parsed, dict)
+            assert "run_id" in parsed
+            assert "timestamp" in parsed
+            assert "sessions_count" in parsed
+            assert "metrics" in parsed
+
+    def test_run_id_prefixed_with_import(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Imported entries must have run_id starting with 'import-'."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        parsed = json.loads(history_path.read_text(encoding="utf-8").strip())
+        assert parsed["run_id"].startswith("import-")
+
+    def test_timestamp_from_session_started_at(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Imported entry timestamp must come from the session's started_at field."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        parsed = json.loads(history_path.read_text(encoding="utf-8").strip())
+        assert "2026-04-10" in parsed["timestamp"]
+
+    def test_sessions_count_is_one_per_session(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each imported entry must have sessions_count == 1."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        _make_session_dir(sessions, "102")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        for line in history_path.read_text(encoding="utf-8").strip().splitlines():
+            parsed = json.loads(line)
+            assert parsed["sessions_count"] == 1
+
+    def test_metrics_are_computed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Imported entries must contain at least one operational metric."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        parsed = json.loads(history_path.read_text(encoding="utf-8").strip())
+        assert len(parsed["metrics"]) > 0
+
+    def test_output_reports_imported_count(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The output summary must report how many sessions were imported."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        _make_session_dir(sessions, "102")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        assert "2" in result.output
+        assert "import" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestImportHistoryDeduplication:
+    def test_skips_already_imported_session(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second import of the same session must be skipped."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        lines = history_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+
+    def test_new_sessions_appended_to_existing_history(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """New sessions are added while existing entries are preserved."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        _make_session_dir(sessions, "102")
+        runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        lines = history_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 2
+
+    def test_duplicate_report_shows_already_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Output on second import must mention the session is already present."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        result = runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        assert "already" in result.output.lower() or "present" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Dry run
+# ---------------------------------------------------------------------------
+
+
+class TestImportHistoryDryRun:
+    def test_dry_run_does_not_write(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--dry-run must not create or modify the history file."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            [
+                "import-history",
+                str(sessions),
+                "--history-path",
+                str(history_path),
+                "--dry-run",
+            ],
+            catch_exceptions=False,
+        )
+        assert not history_path.exists()
+
+    def test_dry_run_reports_would_import(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--dry-run output must mention 'would import'."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "import-history",
+                str(sessions),
+                "--history-path",
+                str(history_path),
+                "--dry-run",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "would import" in result.output.lower() or "dry run" in result.output.lower()
+
+    def test_dry_run_shows_session_count(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--dry-run output must include the count of sessions that would be imported."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        for name in ("101", "102"):
+            _make_session_dir(sessions, name)
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "import-history",
+                str(sessions),
+                "--history-path",
+                str(history_path),
+                "--dry-run",
+            ],
+            catch_exceptions=False,
+        )
+        assert "2" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Quiet mode
+# ---------------------------------------------------------------------------
+
+
+class TestImportHistoryQuiet:
+    def test_quiet_suppresses_per_session_output(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--quiet must suppress per-session lines but still write the history."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "import-history",
+                str(sessions),
+                "--history-path",
+                str(history_path),
+                "-q",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert history_path.exists()
+        # Per-session lines (✓ / ✗) must not appear
+        assert "✓" not in result.output
+        assert "✗" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# No sessions found
+# ---------------------------------------------------------------------------
+
+
+class TestImportHistoryNoSessions:
+    def test_empty_directory_reports_no_sessions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty directory must produce a 'no sessions' message."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "no sessions" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestImportHistoryErrors:
+    def test_invalid_adapter_exits_with_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unrecognised adapter name must produce a clear error and exit."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "import-history",
+                str(sessions),
+                "--history-path",
+                str(history_path),
+                "--adapter",
+                "nonexistent-adapter",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_malformed_session_logged_as_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A session that fails to load must be counted as an error, not cause a crash."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        # Create a malformed session (invalid JSON in meta.json)
+        malformed = sessions / "bad-session"
+        malformed.mkdir()
+        (malformed / "meta.json").write_text("NOT JSON {{{")
+        (malformed / "events.jsonl").write_text("")
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["import-history", str(sessions), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "error" in result.output.lower()
+
+    def test_history_path_outside_project_root_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A history-path outside the project root must be rejected with UsageError."""
+        monkeypatch.chdir(tmp_path)
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session_dir(sessions, "101")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "import-history",
+                str(sessions),
+                "--history-path",
+                "/tmp/outside-project-history.jsonl",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "project root" in result.output.lower() or result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Fixture-based integration
+# ---------------------------------------------------------------------------
+
+
+class TestImportHistoryFixtures:
+    def test_imports_from_fixture_sessions_dir(
+        self, sessions_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """import-history must successfully import from the test fixtures directory."""
+        monkeypatch.chdir(tmp_path)
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["import-history", str(sessions_dir), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert history_path.exists()
+        lines = history_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) >= 3
+
+    def test_imported_entries_have_valid_schema(
+        self, sessions_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All imported entries must conform to the HistoryEntry schema."""
+        from raki.report.history import HistoryEntry
+
+        monkeypatch.chdir(tmp_path)
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["import-history", str(sessions_dir), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        for line in history_path.read_text(encoding="utf-8").strip().splitlines():
+            parsed = json.loads(line)
+            entry = HistoryEntry.model_validate(parsed)
+            assert entry.sessions_count == 1
+            assert entry.run_id.startswith("import-")
+
+    def test_repeated_import_is_idempotent(
+        self, sessions_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Running import-history twice on the same path must not duplicate entries."""
+        monkeypatch.chdir(tmp_path)
+        history_path = tmp_path / ".raki" / "history.jsonl"
+
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["import-history", str(sessions_dir), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        first_count = len(history_path.read_text(encoding="utf-8").strip().splitlines())
+
+        runner.invoke(
+            main,
+            ["import-history", str(sessions_dir), "--history-path", str(history_path)],
+            catch_exceptions=False,
+        )
+        second_count = len(history_path.read_text(encoding="utf-8").strip().splitlines())
+
+        assert first_count == second_count


### PR DESCRIPTION
## Summary
Add `raki import-history` command to backfill `.raki/history.jsonl` from existing sessions in any adapter-supported format. Computes operational metrics only (no LLM calls). Uses original session timestamps, deduplicates by run ID.

### New files
- `src/raki/adapters/discovery.py` — session discovery logic (walk dirs, auto-detect adapters)
- `src/raki/report/history.py` — `load_run_ids()` and `import_history_entry()` helpers

### CLI
```bash
raki import-history .soda/                    # import SODA sessions
raki import-history ~/exports/*.json          # import Alcove exports
raki import-history .soda/ --dry-run          # preview without writing
raki import-history .soda/ --adapter alcove   # force adapter
```

## Test plan
- [ ] Auto-detects adapter format via existing registry
- [ ] Computes operational metrics only (no LLM calls)
- [ ] Uses original session timestamp, not import time
- [ ] Deduplicates: skips sessions already in history log
- [ ] `--dry-run` previews without writing
- [ ] `--adapter` forces adapter selection
- [ ] Does NOT break existing `raki trends` command
- [ ] `uv run pytest tests/ -v -m "not slow"` — all pass

Refs #221

🤖 Generated with [Claude Code](https://claude.com/claude-code) via SODA pipeline