### PR TITLE
docs: add gotchas #28-#29 for docs-path and judge provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,8 @@ Use the `/orchestrate` skill in Claude Code to coordinate milestone-level develo
 25. **Towncrier fragment types** -- only `.breaking`, `.feature`, and `.fix` are configured. Using `.change` or other suffixes gets silently ignored by `towncrier build`.
 26. **Manifest symlink path escape** -- manifest session paths cannot be symlinks to external directories. The real path is resolved and checked against project root. Copy sessions into the manifest directory instead of symlinking.
 27. **`soda-system-prompt-*.md` stray files** -- SODA sometimes leaves temporary prompt files in the repo root. These are in `.gitignore` and should never be committed.
+28. **`--docs-path` must match the project being worked on** -- when evaluating SODA sessions that implement raki code, point `--docs-path` to raki's docs, not SODA's. When evaluating Alcove sessions working on pulp-service, point to pulp-service docs. Wrong docs → knowledge_gap_rate=1.00 because findings reference source files the docs don't cover.
+29. **`vertex-anthropic` is the reliable judge provider** -- `anthropic` needs `ANTHROPIC_API_KEY` (not set by default). `google` has an async/sync client mismatch (#233). `answer_relevancy` always fails because it uses Vertex AI embeddings which need `GOOGLE_CLOUD_PROJECT` in addition to `VERTEXAI_PROJECT` (#231). Default to `--judge-provider vertex-anthropic --judge-model claude-sonnet-4-6`.
 
 ## Things agents often get wrong here
 


### PR DESCRIPTION
## Summary
Add two new gotchas from v0.11.0 verification learnings:
- **#28**: `--docs-path` must point to the project being worked on, not the pipeline tool
- **#29**: `vertex-anthropic` is the reliable judge provider; documents known issues with others

## Related
- #231 (answer_relevancy VERTEXAI_PROJECT bug)
- #233 (Google async client mismatch)