### PR TITLE
fix(231): normalise GOOGLE_CLOUD_PROJECT from VERTEXAI_PROJECT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,7 +251,7 @@ Use the `/orchestrate` skill in Claude Code to coordinate milestone-level develo
 26. **Manifest symlink path escape** -- manifest session paths cannot be symlinks to external directories. The real path is resolved and checked against project root. Copy sessions into the manifest directory instead of symlinking.
 27. **`soda-system-prompt-*.md` stray files** -- SODA sometimes leaves temporary prompt files in the repo root. These are in `.gitignore` and should never be committed.
 28. **`--docs-path` must match the project being worked on** -- when evaluating SODA sessions that implement raki code, point `--docs-path` to raki's docs, not SODA's. When evaluating Alcove sessions working on pulp-service, point to pulp-service docs. Wrong docs → knowledge_gap_rate=1.00 because findings reference source files the docs don't cover.
-29. **`vertex-anthropic` is the reliable judge provider** -- `anthropic` needs `ANTHROPIC_API_KEY` (not set by default). `google` has an async/sync client mismatch (#233). `answer_relevancy` always fails because it uses Vertex AI embeddings which need `GOOGLE_CLOUD_PROJECT` in addition to `VERTEXAI_PROJECT` (#231). Default to `--judge-provider vertex-anthropic --judge-model claude-sonnet-4-6`.
+29. **`vertex-anthropic` is the reliable judge provider** -- `anthropic` needs `ANTHROPIC_API_KEY` (not set by default). `google` has an async/sync client mismatch (#233). `answer_relevancy` requires either `GOOGLE_CLOUD_PROJECT` or `VERTEXAI_PROJECT`; `create_ragas_embeddings` normalises `GOOGLE_CLOUD_PROJECT` from `VERTEXAI_PROJECT` so `GoogleEmbeddings` can find the project internally (#231). Default to `--judge-provider vertex-anthropic --judge-model claude-sonnet-4-6`.
 
 ## Things agents often get wrong here
 

--- a/changes/231.fix
+++ b/changes/231.fix
@@ -1,0 +1,5 @@
+``answer_relevancy`` no longer fails when only ``VERTEXAI_PROJECT`` is set.
+``create_ragas_embeddings`` now normalises ``GOOGLE_CLOUD_PROJECT`` from
+``VERTEXAI_PROJECT`` so that ``GoogleEmbeddings`` can find the project during
+embedding calls (it reads ``GOOGLE_CLOUD_PROJECT`` internally, not
+``VERTEXAI_PROJECT``).

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -198,6 +198,11 @@ def create_ragas_embeddings(config: MetricConfig):
         )
     location = os.environ.get("VERTEXAI_LOCATION", "us-central1")
 
+    # Normalise GOOGLE_CLOUD_PROJECT so that GoogleEmbeddings can find the project during
+    # embedding calls (it reads GOOGLE_CLOUD_PROJECT internally, not VERTEXAI_PROJECT).
+    # setdefault leaves an already-configured GOOGLE_CLOUD_PROJECT untouched (see #231).
+    os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project)
+
     client = genai.Client(vertexai=True, project=project, location=location)
 
     return GoogleEmbeddings(

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -1390,6 +1390,7 @@ class TestCreateRagasEmbeddings:
 
     def test_embeddings_passes_client_through(self, monkeypatch: pytest.MonkeyPatch):
         """The pre-configured genai.Client must not be discarded; it must reach GoogleEmbeddings."""
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
         monkeypatch.setenv("VERTEXAI_PROJECT", "client-project")
         monkeypatch.setenv("VERTEXAI_LOCATION", "europe-west4")
 
@@ -1407,6 +1408,7 @@ class TestCreateRagasEmbeddings:
 
     def test_passes_vertex_project_to_genai_client(self, monkeypatch: pytest.MonkeyPatch):
         """Verify genai.Client is created with vertexai=True and project from env."""
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
         monkeypatch.setenv("VERTEXAI_PROJECT", "my-project")
         monkeypatch.setenv("VERTEXAI_LOCATION", "europe-west1")
 
@@ -1445,6 +1447,43 @@ class TestCreateRagasEmbeddings:
         mocks["genai"].Client.assert_called_once_with(
             vertexai=True, project="fallback-project", location="us-central1"
         )
+
+    def test_vertexai_project_sets_google_cloud_project_env(self, monkeypatch: pytest.MonkeyPatch):
+        """When only VERTEXAI_PROJECT is set, GOOGLE_CLOUD_PROJECT must be populated in os.environ.
+
+        GoogleEmbeddings reads GOOGLE_CLOUD_PROJECT internally during embedding calls, not just at
+        construction time. Without this normalisation, answer_relevancy fails even when a valid
+        pre-configured genai.Client is passed (see #231).
+        """
+        import os
+
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.setenv("VERTEXAI_PROJECT", "fallback-project")
+        monkeypatch.setenv("VERTEXAI_LOCATION", "us-central1")
+
+        mocks = self._setup_embeddings_mocks(monkeypatch)
+        config = MetricConfig(llm_provider="vertex-anthropic")
+        mocks["create_fn"](config)
+
+        assert os.environ.get("GOOGLE_CLOUD_PROJECT") == "fallback-project"
+
+    def test_existing_google_cloud_project_not_overwritten(self, monkeypatch: pytest.MonkeyPatch):
+        """When GOOGLE_CLOUD_PROJECT is already set, it must not be overwritten by VERTEXAI_PROJECT.
+
+        os.environ.setdefault() must be used so that a user-configured GOOGLE_CLOUD_PROJECT is
+        never silently replaced (see #231).
+        """
+        import os
+
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "primary-project")
+        monkeypatch.setenv("VERTEXAI_PROJECT", "other-project")
+        monkeypatch.setenv("VERTEXAI_LOCATION", "us-central1")
+
+        mocks = self._setup_embeddings_mocks(monkeypatch)
+        config = MetricConfig(llm_provider="vertex-anthropic")
+        mocks["create_fn"](config)
+
+        assert os.environ.get("GOOGLE_CLOUD_PROJECT") == "primary-project"
 
     def test_missing_project_raises_valueerror(self, monkeypatch: pytest.MonkeyPatch):
         """When neither GOOGLE_CLOUD_PROJECT nor VERTEXAI_PROJECT is set, raise ValueError."""


### PR DESCRIPTION
## Summary

- Normalize `GOOGLE_CLOUD_PROJECT` from `VERTEXAI_PROJECT` in `create_ragas_embeddings()` using `os.environ.setdefault`
- Fixes `answer_relevancy` scoring 0.00 when only `VERTEXAI_PROJECT` is set
- Preserves existing `GOOGLE_CLOUD_PROJECT` when already configured (backward compat)

Closes #231

## Test plan

- [x] Env with only `VERTEXAI_PROJECT` → embeddings resolve project correctly
- [x] Env with `GOOGLE_CLOUD_PROJECT` set → takes precedence (backward compat)
- [x] Env with neither set → appropriate error behavior
- [x] Full test suite: 1439 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)