### PR TITLE
chore(#234): migrate from vertexai._model_garden to google.genai SDK

### DIFF
--- a/changes/234.misc
+++ b/changes/234.misc
@@ -1,0 +1,5 @@
+Remove ``langchain-google-vertexai`` from the ``ragas`` optional-dependencies.
+The LLM setup code uses the ``google.genai`` SDK directly (``InstructorLLM`` +
+``GoogleEmbeddings``) and has no LangChain Vertex AI integration. Dropping this
+dependency removes 28 transitive packages from the lock file (including
+``google-cloud-aiplatform``, ``grpcio``, ``pyarrow``, and ``protobuf``).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ ragas = [
     "instructor>=1.0",
     "google-auth>=2.0",
     "google-genai>=1.0",
-    "langchain-google-vertexai>=2.0",
 ]
 litellm = [
     "litellm>=1.0",

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -52,3 +52,23 @@ class TestRagasExtraDependencies:
         assert version_tuple >= (1, 0), (
             f"instructor {installed_version} is too old — instructor.from_anthropic requires >= 1.0"
         )
+
+    def test_langchain_google_vertexai_removed_from_ragas_extra(self):
+        """langchain-google-vertexai must NOT appear in the ragas extra.
+
+        The LLM setup code uses google.genai SDK directly via InstructorLLM and
+        GoogleEmbeddings — no LangChain Vertex AI integration is needed.
+        langchain-google-vertexai pulls in heavy transitive deps (google-cloud-aiplatform,
+        google-cloud-storage, pyarrow, bottleneck) that are unused and slow to install.
+        See: https://github.com/<org>/raki/issues/234
+        """
+        pyproject = _load_pyproject()
+        ragas_deps = pyproject["project"]["optional-dependencies"]["ragas"]
+        langchain_vertex_entries = [
+            dep for dep in ragas_deps if "langchain-google-vertexai" in dep.lower()
+        ]
+        assert not langchain_vertex_entries, (
+            "langchain-google-vertexai is listed in the ragas extra but is no longer used — "
+            "the code uses google.genai SDK directly via InstructorLLM / GoogleEmbeddings. "
+            f"Remove these entries: {langchain_vertex_entries}"
+        )


### PR DESCRIPTION
## Summary

Remove `langchain-google-vertexai` from the `ragas` optional-dependencies in `pyproject.toml`.

The LLM setup code (`llm_setup.py`) had already been migrated to use the `google.genai` SDK directly via `InstructorLLM` + `GoogleEmbeddings`. The `langchain-google-vertexai>=2.0` entry was a leftover holdover from an earlier integration path and is no longer needed.

Removing this dependency strips **28 transitive packages** from the lock file, including `google-cloud-aiplatform`, `grpcio`, `protobuf`, `proto-plus`, and `pyarrow`.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `pyproject.toml` | Modified | Removed `langchain-google-vertexai>=2.0` from `ragas` optional-dependencies |
| `tests/test_dependencies.py` | Modified | Added test asserting the package is absent from the extra |
| `changes/234.misc` | Created | Towncrier changelog fragment |

## Test Plan

- TDD: failing test committed first (`ff131c4`), fix in second commit (`5d4e08c`)
- All 1439 tests pass (177 ragas unit tests + 1262 others)
- `--judge-provider vertex-anthropic` tests unaffected (uses `anthropic` package directly via `AsyncAnthropicVertex`)
- Ruff linting passes
- `uv lock --check` resolves cleanly (121 packages)

## Acceptance Criteria

- [x] No `vertexai._model_garden` deprecation warnings in `src/` or `tests/`
- [x] `--judge-provider vertex-anthropic` continues to work (8 vertex-anthropic tests pass)
- [x] Ragas metrics produce the same results (no functional code changed)
- [x] `langchain-google-vertexai` removed from `ragas` extra in `pyproject.toml`