### PR TITLE
[#230] feat: manifest-level judge configuration

### DIFF
--- a/changes/230.feature
+++ b/changes/230.feature
@@ -1,0 +1,1 @@
+Add manifest-level ``judge:`` configuration block with ``provider`` and ``model`` fields. CLI flags override manifest values; env vars ``RAKI_JUDGE_PROVIDER`` and ``RAKI_JUDGE_MODEL`` serve as intermediate fallbacks.

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -294,6 +294,39 @@ jobs:
 See [docs/soda-pipeline-gate.md](soda-pipeline-gate.md) for the full per-milestone workflow,
 baseline threshold table, and interpretation guide.
 
+## Judge configuration
+
+### Manifest-level judge config
+
+Persist your judge provider and model in the manifest so CI jobs don't need
+to repeat CLI flags:
+
+```yaml
+judge:
+  provider: vertex-anthropic
+  model: claude-sonnet-4-6
+```
+
+The `--judge` flag is still required to enable analytical metrics — the manifest
+only persists *which* provider/model to use.
+
+### Environment variables
+
+You can also configure the judge via environment variables, useful for CI
+where secrets and config vary per environment:
+
+- `RAKI_JUDGE_PROVIDER` — sets the judge provider (e.g. `anthropic`, `vertex-anthropic`)
+- `RAKI_JUDGE_MODEL` — sets the judge model (e.g. `claude-sonnet-4-6`)
+
+### Resolution order
+
+RAKI resolves judge provider and model using a 4-tier priority chain:
+
+1. **CLI flags** (`--judge-provider`, `--judge-model`) — highest priority
+2. **Manifest** (`judge.provider`, `judge.model`)
+3. **Environment variables** (`RAKI_JUDGE_PROVIDER`, `RAKI_JUDGE_MODEL`)
+4. **Built-in defaults** (`vertex-anthropic`, `claude-sonnet-4-6`)
+
 ## Tips
 
 - **Start with operational gates only.** They run fast, need no API keys, and catch the most common issues. Add analytical gates after you have stable baselines.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,6 +136,32 @@ uv pip install raki[litellm]
 
 See [Analytical Metrics Reference](metrics/analytical.md) for details.
 
+### Persisting judge config in your manifest
+
+Instead of passing `--judge-provider` and `--judge-model` on every run, you can
+save them in your manifest:
+
+```yaml
+judge:
+  provider: vertex-anthropic
+  model: claude-sonnet-4-6
+```
+
+The `--judge` flag is still required to enable analytical metrics — the manifest
+just persists *which* provider and model to use.
+
+### Judge config resolution order
+
+RAKI resolves judge provider and model using a 4-tier priority chain:
+
+1. **CLI flags** (`--judge-provider`, `--judge-model`) — highest priority
+2. **Manifest** (`judge.provider`, `judge.model`)
+3. **Environment variables** (`RAKI_JUDGE_PROVIDER`, `RAKI_JUDGE_MODEL`)
+4. **Built-in defaults** (`vertex-anthropic`, `claude-sonnet-4-6`)
+
+This means you can set defaults in your manifest, override per-environment via
+env vars, and still override everything on the command line.
+
 ## Validate before running
 
 Check your manifest and session data without running metrics:

--- a/examples/raki-full.yaml
+++ b/examples/raki-full.yaml
@@ -17,6 +17,10 @@ sources:                   # Reference documents used during retrieval
       - api
       - auth
 
+judge:
+  provider: vertex-anthropic  # LLM provider: vertex-anthropic, anthropic, google, litellm
+  model: claude-sonnet-4-6    # Model name for judge metrics
+
 synthetic:
   enabled: false           # Whether to generate synthetic test cases via Ragas
   output: synthetic-out/   # Directory for generated synthetic test data

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -11,6 +11,7 @@ import click
 from rich.console import Console
 
 from raki.adapters.redact import redact_sensitive
+from raki.metrics.protocol import DEFAULT_JUDGE_MODEL, DEFAULT_JUDGE_PROVIDER
 from raki.report.rerender import is_session_data_stripped, metric_stubs_from_metadata
 
 if TYPE_CHECKING:
@@ -183,14 +184,14 @@ def main():
     "--judge-model",
     "judge_model",
     default=None,
-    help="LLM model for judge metrics (default: claude-sonnet-4-6)",
+    help=f"LLM model for judge metrics (default: {DEFAULT_JUDGE_MODEL})",
 )
 @click.option(
     "--judge-provider",
     "judge_provider",
     type=click.Choice(["vertex-anthropic", "anthropic", "google", "litellm"]),
     default=None,
-    help="LLM provider for judge metrics (default: vertex-anthropic)",
+    help=f"LLM provider for judge metrics (default: {DEFAULT_JUDGE_PROVIDER}),",
 )
 @click.option(
     "--include-sessions",
@@ -308,38 +309,48 @@ def run(
         out.print(f"[red]Error loading manifest: {redact_sensitive(str(exc))}[/red]")
         raise SystemExit(2) from exc
 
+    # Validate manifest judge.provider against allowed providers early,
+    # before it reaches MetricConfig where it would raise a raw Pydantic error.
+    if manifest.judge is not None and manifest.judge.provider is not None:
+        from typing import get_args
+
+        from raki.metrics.protocol import LLMProvider
+
+        allowed_providers = get_args(LLMProvider)
+        if manifest.judge.provider not in allowed_providers:
+            raise click.UsageError(
+                f"Invalid judge.provider in manifest: '{manifest.judge.provider}'. "
+                f"Valid providers: {', '.join(allowed_providers)}"
+            )
+
     # 4-tier judge provider/model resolution:
     #   1. CLI flag (--judge-provider / --judge-model)  — highest priority
     #   2. Manifest (judge.provider / judge.model)
     #   3. Env var (RAKI_JUDGE_PROVIDER / RAKI_JUDGE_MODEL)
     #   4. Built-in default                             — lowest priority
-    _DEFAULT_JUDGE_PROVIDER = "vertex-anthropic"
-    _DEFAULT_JUDGE_MODEL = "claude-sonnet-4-6"
-
     effective_judge_provider: str
     effective_judge_model: str
     judge_source: str
 
     if provider_from_cli or model_from_cli:
-        # At least one flag was explicitly set on the CLI
         effective_judge_provider = (
-            judge_provider if judge_provider is not None else _DEFAULT_JUDGE_PROVIDER
+            judge_provider if judge_provider is not None else DEFAULT_JUDGE_PROVIDER
         )
-        effective_judge_model = judge_model if judge_model is not None else _DEFAULT_JUDGE_MODEL
+        effective_judge_model = judge_model if judge_model is not None else DEFAULT_JUDGE_MODEL
         judge_source = "cli"
     elif manifest.judge is not None and (
         manifest.judge.provider is not None or manifest.judge.model is not None
     ):
-        effective_judge_provider = manifest.judge.provider or _DEFAULT_JUDGE_PROVIDER
-        effective_judge_model = manifest.judge.model or _DEFAULT_JUDGE_MODEL
+        effective_judge_provider = manifest.judge.provider or DEFAULT_JUDGE_PROVIDER
+        effective_judge_model = manifest.judge.model or DEFAULT_JUDGE_MODEL
         judge_source = "manifest"
     elif os.environ.get("RAKI_JUDGE_PROVIDER") or os.environ.get("RAKI_JUDGE_MODEL"):
-        effective_judge_provider = os.environ.get("RAKI_JUDGE_PROVIDER") or _DEFAULT_JUDGE_PROVIDER
-        effective_judge_model = os.environ.get("RAKI_JUDGE_MODEL") or _DEFAULT_JUDGE_MODEL
+        effective_judge_provider = os.environ.get("RAKI_JUDGE_PROVIDER") or DEFAULT_JUDGE_PROVIDER
+        effective_judge_model = os.environ.get("RAKI_JUDGE_MODEL") or DEFAULT_JUDGE_MODEL
         judge_source = "env"
     else:
-        effective_judge_provider = _DEFAULT_JUDGE_PROVIDER
-        effective_judge_model = _DEFAULT_JUDGE_MODEL
+        effective_judge_provider = DEFAULT_JUDGE_PROVIDER
+        effective_judge_model = DEFAULT_JUDGE_MODEL
         judge_source = "default"
 
     from raki.adapters import DatasetLoader

--- a/src/raki/cli.py
+++ b/src/raki/cli.py
@@ -33,10 +33,11 @@ def _build_report_config(
     manifest: "EvalManifest",
     dataset: "EvalDataset",
     effective_docs_path: Path | None,
+    judge_source: str = "default",
 ) -> None:
     """Inject project identity and evaluation context into ``report.config``.
 
-    Merges three new keys into the existing config dict produced by the
+    Merges new keys into the existing config dict produced by the
     MetricsEngine so downstream consumers (HTML renderer, JSON) can surface
     project identity without any breaking schema changes.
 
@@ -45,8 +46,11 @@ def _build_report_config(
         manifest: The loaded EvalManifest (source of project name).
         dataset: The EvalDataset used for evaluation (source of adapter formats).
         effective_docs_path: Resolved docs path used during evaluation, or None.
+        judge_source: Where the judge provider/model config came from.
+            One of "cli", "manifest", "env", or "default".
     """
     report.config["project_name"] = manifest.name
+    report.config["judge_source"] = judge_source
 
     if effective_docs_path is not None:
         report.config["docs_path"] = str(effective_docs_path)
@@ -140,6 +144,7 @@ def main():
 
 
 @main.command()
+@click.pass_context
 @click.option("-m", "--manifest", "manifest_path", default=None, help="Path to manifest file")
 @click.option("-o", "--output", "output_dir", default="./results", help="Output directory")
 @click.option("--judge", is_flag=True, default=False, help="Enable LLM-judged analytical metrics")
@@ -177,14 +182,14 @@ def main():
 @click.option(
     "--judge-model",
     "judge_model",
-    default="claude-sonnet-4-6",
+    default=None,
     help="LLM model for judge metrics (default: claude-sonnet-4-6)",
 )
 @click.option(
     "--judge-provider",
     "judge_provider",
     type=click.Choice(["vertex-anthropic", "anthropic", "google", "litellm"]),
-    default="vertex-anthropic",
+    default=None,
     help="LLM provider for judge metrics (default: vertex-anthropic)",
 )
 @click.option(
@@ -222,6 +227,7 @@ def main():
     help="Exit non-zero when metric health errors are detected",
 )
 def run(
+    ctx: click.Context,
     manifest_path: str | None,
     output_dir: str,
     judge: bool,
@@ -232,8 +238,8 @@ def run(
     adapter_format: str | None,
     metric_names: str | None,
     parallel_count: int,
-    judge_model: str,
-    judge_provider: str,
+    judge_model: str | None,
+    judge_provider: str | None,
     docs_path: str | None,
     include_sessions: bool,
     json_stdout: bool,
@@ -243,10 +249,21 @@ def run(
     strict_warnings: bool,
 ) -> None:
     """Run evaluation against sessions."""
+    import os
+
     if no_history and history_path_arg is not None:
         raise click.UsageError("--no-history and --history-path cannot be used together.")
 
     skip_judge = not judge
+
+    # Detect whether --judge-provider / --judge-model were explicitly set on
+    # the command line (vs. falling through to the default).
+    provider_from_cli = (
+        ctx.get_parameter_source("judge_provider") == click.core.ParameterSource.COMMANDLINE
+    )
+    model_from_cli = (
+        ctx.get_parameter_source("judge_model") == click.core.ParameterSource.COMMANDLINE
+    )
 
     out = _stderr_console() if json_stdout else console
 
@@ -290,6 +307,40 @@ def run(
     except Exception as exc:
         out.print(f"[red]Error loading manifest: {redact_sensitive(str(exc))}[/red]")
         raise SystemExit(2) from exc
+
+    # 4-tier judge provider/model resolution:
+    #   1. CLI flag (--judge-provider / --judge-model)  — highest priority
+    #   2. Manifest (judge.provider / judge.model)
+    #   3. Env var (RAKI_JUDGE_PROVIDER / RAKI_JUDGE_MODEL)
+    #   4. Built-in default                             — lowest priority
+    _DEFAULT_JUDGE_PROVIDER = "vertex-anthropic"
+    _DEFAULT_JUDGE_MODEL = "claude-sonnet-4-6"
+
+    effective_judge_provider: str
+    effective_judge_model: str
+    judge_source: str
+
+    if provider_from_cli or model_from_cli:
+        # At least one flag was explicitly set on the CLI
+        effective_judge_provider = (
+            judge_provider if judge_provider is not None else _DEFAULT_JUDGE_PROVIDER
+        )
+        effective_judge_model = judge_model if judge_model is not None else _DEFAULT_JUDGE_MODEL
+        judge_source = "cli"
+    elif manifest.judge is not None and (
+        manifest.judge.provider is not None or manifest.judge.model is not None
+    ):
+        effective_judge_provider = manifest.judge.provider or _DEFAULT_JUDGE_PROVIDER
+        effective_judge_model = manifest.judge.model or _DEFAULT_JUDGE_MODEL
+        judge_source = "manifest"
+    elif os.environ.get("RAKI_JUDGE_PROVIDER") or os.environ.get("RAKI_JUDGE_MODEL"):
+        effective_judge_provider = os.environ.get("RAKI_JUDGE_PROVIDER") or _DEFAULT_JUDGE_PROVIDER
+        effective_judge_model = os.environ.get("RAKI_JUDGE_MODEL") or _DEFAULT_JUDGE_MODEL
+        judge_source = "env"
+    else:
+        effective_judge_provider = _DEFAULT_JUDGE_PROVIDER
+        effective_judge_model = _DEFAULT_JUDGE_MODEL
+        judge_source = "default"
 
     from raki.adapters import DatasetLoader
 
@@ -390,8 +441,8 @@ def run(
     from raki.metrics.protocol import LLMProvider, Metric, MetricConfig
 
     config = MetricConfig(
-        llm_provider=cast(LLMProvider, judge_provider),
-        llm_model=judge_model,
+        llm_provider=cast(LLMProvider, effective_judge_provider),
+        llm_model=effective_judge_model,
         batch_size=parallel_count,
         project_root=manifest_file.parent.resolve(),
         doc_chunks=doc_chunks,
@@ -433,7 +484,7 @@ def run(
     engine = MetricsEngine(all_metrics, config=config)
     report = engine.run(dataset, skip_judge=skip_judge)
 
-    _build_report_config(report, manifest, dataset, effective_docs_path)
+    _build_report_config(report, manifest, dataset, effective_docs_path, judge_source=judge_source)
 
     if not quiet:
         from raki.report.cli_summary import print_summary

--- a/src/raki/ground_truth/manifest.py
+++ b/src/raki/ground_truth/manifest.py
@@ -57,6 +57,18 @@ class SyntheticConfig(BaseModel):
     seed: int = 42
 
 
+class JudgeConfig(BaseModel):
+    """Configuration for the LLM judge used in analytical metrics.
+
+    Uses plain ``str`` (not ``LLMProvider``) to avoid importing from the
+    metrics layer.  Validation against the allowed provider list happens at
+    ``MetricConfig`` construction time in the CLI.
+    """
+
+    provider: str | None = None
+    model: str | None = None
+
+
 class EvalManifest(BaseModel):
     """Top-level evaluation manifest model.
 
@@ -71,6 +83,7 @@ class EvalManifest(BaseModel):
     docs: DocsConfig | None = None
     synthetic: SyntheticConfig = Field(default_factory=SyntheticConfig)
     thresholds: list[str] = Field(default_factory=list)
+    judge: JudgeConfig | None = None
 
 
 def _resolve_and_guard(

--- a/src/raki/metrics/protocol.py
+++ b/src/raki/metrics/protocol.py
@@ -11,6 +11,9 @@ from raki.model.report import MetricResult
 
 LLMProvider = Literal["vertex-anthropic", "anthropic", "google", "litellm"]
 
+DEFAULT_JUDGE_PROVIDER: LLMProvider = "vertex-anthropic"
+DEFAULT_JUDGE_MODEL = "claude-sonnet-4-6"
+
 
 @dataclass
 class TokenAccumulator:
@@ -24,8 +27,8 @@ class TokenAccumulator:
 class MetricConfig(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
 
-    llm_provider: LLMProvider = "vertex-anthropic"
-    llm_model: str = "claude-sonnet-4-6"
+    llm_provider: LLMProvider = DEFAULT_JUDGE_PROVIDER
+    llm_model: str = DEFAULT_JUDGE_MODEL
     temperature: float = 0.0
     max_tokens: int | None = None
     batch_size: int = 4

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3495,3 +3495,147 @@ class TestBuildReportConfig:
         assert json_files
         data = json.loads(json_files[0].read_text())
         assert data["config"]["project_name"] == "test-project"
+
+    def test_injects_judge_source_default(self) -> None:
+        """judge_source defaults to 'default' when not explicitly provided."""
+        from raki.cli import _build_report_config
+
+        report = self._make_minimal_report()
+        manifest = self._make_manifest()
+        dataset = self._make_dataset([])
+        _build_report_config(report, manifest, dataset, None)
+        assert report.config["judge_source"] == "default"
+
+    def test_injects_judge_source_cli(self) -> None:
+        """judge_source='cli' is correctly injected into report.config."""
+        from raki.cli import _build_report_config
+
+        report = self._make_minimal_report()
+        manifest = self._make_manifest()
+        dataset = self._make_dataset([])
+        _build_report_config(report, manifest, dataset, None, judge_source="cli")
+        assert report.config["judge_source"] == "cli"
+
+    def test_injects_judge_source_manifest(self) -> None:
+        """judge_source='manifest' is correctly injected into report.config."""
+        from raki.cli import _build_report_config
+
+        report = self._make_minimal_report()
+        manifest = self._make_manifest()
+        dataset = self._make_dataset([])
+        _build_report_config(report, manifest, dataset, None, judge_source="manifest")
+        assert report.config["judge_source"] == "manifest"
+
+    def test_injects_judge_source_env(self) -> None:
+        """judge_source='env' is correctly injected into report.config."""
+        from raki.cli import _build_report_config
+
+        report = self._make_minimal_report()
+        manifest = self._make_manifest()
+        dataset = self._make_dataset([])
+        _build_report_config(report, manifest, dataset, None, judge_source="env")
+        assert report.config["judge_source"] == "env"
+
+
+class TestJudgePriorityChain:
+    """Tests for the 4-tier judge provider/model resolution in 'raki run'.
+
+    Priority (highest to lowest):
+      1. CLI flag (--judge-provider / --judge-model)
+      2. Manifest judge: block
+      3. Env var (RAKI_JUDGE_PROVIDER / RAKI_JUDGE_MODEL)
+      4. Built-in defaults (vertex-anthropic / claude-sonnet-4-6)
+
+    Each test verifies the correct judge_source value in report.config.
+    """
+
+    def _run_json(
+        self, runner: CliRunner, manifest_path: Path, extra_args: list[str] | None = None
+    ) -> dict:
+        """Invoke 'raki run --json -q --no-history' and return parsed report config."""
+        args = ["run", "-m", str(manifest_path), "--json", "-q", "--no-history"]
+        if extra_args:
+            args.extend(extra_args)
+        result = runner.invoke(main, args)
+        assert result.exit_code == 0, (
+            f"Expected exit code 0, got {result.exit_code}:\n{result.output}"
+        )
+        data = json.loads(result.output)
+        return data["config"]
+
+    def test_default_uses_builtin_values(self, empty_manifest: Path) -> None:
+        """No CLI flags, no manifest judge block, no env vars -> judge_source='default'."""
+        runner = CliRunner()
+        config = self._run_json(runner, empty_manifest)
+        assert config["judge_source"] == "default"
+
+    def test_env_var_overrides_default(
+        self, empty_manifest: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """RAKI_JUDGE_PROVIDER env var overrides built-in default -> judge_source='env'."""
+        monkeypatch.setenv("RAKI_JUDGE_PROVIDER", "anthropic")
+        runner = CliRunner()
+        config = self._run_json(runner, empty_manifest)
+        assert config["judge_source"] == "env"
+
+    def test_env_var_model_overrides_default(
+        self, empty_manifest: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """RAKI_JUDGE_MODEL env var overrides built-in default -> judge_source='env'."""
+        monkeypatch.setenv("RAKI_JUDGE_MODEL", "custom-model")
+        runner = CliRunner()
+        config = self._run_json(runner, empty_manifest)
+        assert config["judge_source"] == "env"
+
+    def test_manifest_overrides_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Manifest judge: block takes priority over env vars -> judge_source='manifest'."""
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest_file = tmp_path / "raki.yaml"
+        manifest_file.write_text(
+            f"sessions:\n  path: {sessions}\njudge:\n  provider: litellm\n  model: manifest-model\n"
+        )
+        monkeypatch.setenv("RAKI_JUDGE_PROVIDER", "anthropic")
+        runner = CliRunner()
+        config = self._run_json(runner, manifest_file)
+        assert config["judge_source"] == "manifest"
+
+    def test_cli_flag_overrides_manifest(self, tmp_path: Path) -> None:
+        """CLI --judge-provider takes priority over manifest judge: block -> judge_source='cli'."""
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest_file = tmp_path / "raki.yaml"
+        manifest_file.write_text(
+            f"sessions:\n  path: {sessions}\n"
+            "judge:\n  provider: anthropic\n  model: manifest-model\n"
+        )
+        runner = CliRunner()
+        config = self._run_json(runner, manifest_file, ["--judge-provider", "litellm"])
+        assert config["judge_source"] == "cli"
+
+    def test_cli_flag_overrides_env_var(
+        self, empty_manifest: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CLI --judge-provider takes priority over RAKI_JUDGE_PROVIDER env var -> judge_source='cli'."""
+        monkeypatch.setenv("RAKI_JUDGE_PROVIDER", "anthropic")
+        runner = CliRunner()
+        config = self._run_json(runner, empty_manifest, ["--judge-provider", "litellm"])
+        assert config["judge_source"] == "cli"
+
+    def test_partial_manifest_judge_uses_defaults_for_missing(self, tmp_path: Path) -> None:
+        """Manifest with only provider (no model field) -> judge_source='manifest'."""
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest_file = tmp_path / "raki.yaml"
+        manifest_file.write_text(f"sessions:\n  path: {sessions}\njudge:\n  provider: anthropic\n")
+        runner = CliRunner()
+        config = self._run_json(runner, manifest_file)
+        assert config["judge_source"] == "manifest"
+
+    def test_partial_cli_flag_uses_defaults_for_missing(self, empty_manifest: Path) -> None:
+        """Passing only --judge-model (not --judge-provider) -> judge_source='cli'."""
+        runner = CliRunner()
+        config = self._run_json(runner, empty_manifest, ["--judge-model", "custom-model"])
+        assert config["judge_source"] == "cli"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3639,3 +3639,15 @@ class TestJudgePriorityChain:
         runner = CliRunner()
         config = self._run_json(runner, empty_manifest, ["--judge-model", "custom-model"])
         assert config["judge_source"] == "cli"
+
+    def test_invalid_manifest_judge_provider_gives_usage_error(self, tmp_path: Path) -> None:
+        """Invalid judge.provider in manifest should produce a UsageError, not a raw traceback."""
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest_file = tmp_path / "raki.yaml"
+        manifest_file.write_text(f"sessions:\n  path: {sessions}\njudge:\n  provider: openai\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "-m", str(manifest_file), "-q", "--no-history"])
+        assert result.exit_code != 0
+        assert "Invalid judge.provider in manifest" in result.output
+        assert "openai" in result.output

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -420,6 +420,32 @@ class TestJudgeConfig:
         manifest = load_manifest(manifest_file)
         assert manifest.judge is None
 
+    def test_manifest_judge_empty_block_creates_judge_config(self, tmp_path: Path) -> None:
+        """YAML with ``judge: {}`` should create a JudgeConfig with None fields."""
+        from raki.ground_truth.manifest import load_manifest
+
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest_file = tmp_path / "raki.yaml"
+        manifest_file.write_text(f"sessions:\n  path: {sessions}\njudge: {{}}\n")
+        manifest = load_manifest(manifest_file)
+        assert manifest.judge is not None
+        assert manifest.judge.provider is None
+        assert manifest.judge.model is None
+
+    def test_manifest_judge_partial_provider_only(self, tmp_path: Path) -> None:
+        """YAML with only judge.provider should leave model as None."""
+        from raki.ground_truth.manifest import load_manifest
+
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest_file = tmp_path / "raki.yaml"
+        manifest_file.write_text(f"sessions:\n  path: {sessions}\njudge:\n  provider: anthropic\n")
+        manifest = load_manifest(manifest_file)
+        assert manifest.judge is not None
+        assert manifest.judge.provider == "anthropic"
+        assert manifest.judge.model is None
+
 
 class TestDiscoverManifest:
     """Tests for discover_manifest() function."""

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -360,6 +360,67 @@ class TestDocsConfig:
             load_manifest(manifest_file)
 
 
+class TestJudgeConfig:
+    """Tests for JudgeConfig model and manifest-level judge configuration."""
+
+    def test_judge_config_defaults_to_none(self) -> None:
+        """JudgeConfig fields default to None when not specified."""
+        from raki.ground_truth.manifest import JudgeConfig
+
+        config = JudgeConfig()
+        assert config.provider is None
+        assert config.model is None
+
+    def test_judge_config_construction(self) -> None:
+        """JudgeConfig can be constructed with provider and model."""
+        from raki.ground_truth.manifest import JudgeConfig
+
+        config = JudgeConfig(provider="anthropic", model="claude-opus-4-5")
+        assert config.provider == "anthropic"
+        assert config.model == "claude-opus-4-5"
+
+    def test_judge_config_has_no_docs_path_field(self) -> None:
+        """JudgeConfig must not have a docs_path field."""
+        from raki.ground_truth.manifest import JudgeConfig
+
+        config = JudgeConfig(provider="anthropic", model="claude-opus-4-5")
+        assert not hasattr(config, "docs_path")
+
+    def test_manifest_judge_defaults_to_none(self) -> None:
+        """EvalManifest.judge should default to None (backward compat)."""
+        from raki.ground_truth.manifest import EvalManifest, SessionsConfig
+
+        manifest = EvalManifest(sessions=SessionsConfig(path=Path("/tmp/sessions")))
+        assert manifest.judge is None
+
+    def test_manifest_judge_loaded_from_yaml(self, tmp_path: Path) -> None:
+        """YAML with judge block should deserialize into JudgeConfig."""
+        from raki.ground_truth.manifest import load_manifest
+
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest_file = tmp_path / "raki.yaml"
+        manifest_file.write_text(
+            f"sessions:\n  path: {sessions}\n"
+            "judge:\n  provider: anthropic\n  model: claude-opus-4-5\n"
+        )
+        manifest = load_manifest(manifest_file)
+        assert manifest.judge is not None
+        assert manifest.judge.provider == "anthropic"
+        assert manifest.judge.model == "claude-opus-4-5"
+
+    def test_manifest_judge_absent_from_yaml_is_none(self, tmp_path: Path) -> None:
+        """Manifests without a judge block should have judge=None (backward compat)."""
+        from raki.ground_truth.manifest import load_manifest
+
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        manifest_file = tmp_path / "raki.yaml"
+        manifest_file.write_text(f"sessions:\n  path: {sessions}\n")
+        manifest = load_manifest(manifest_file)
+        assert manifest.judge is None
+
+
 class TestDiscoverManifest:
     """Tests for discover_manifest() function."""
 


### PR DESCRIPTION
## Summary

Implements manifest-level judge configuration (ticket #230), allowing users to specify judge provider and model directly in their eval manifest YAML, with a 4-tier priority chain: CLI flags > manifest > env vars > defaults.

## Changes

### New:  model and  field on 
- Added  Pydantic model with  and  nullable string fields
- Added optional  to 
- No `docs_path` field on `JudgeConfig` (only `provider` and `model`)

### 4-tier judge priority chain in CLI
- **Tier 1**: CLI flags (`--judge`, `--judge-model`) — detected via `get_parameter_source()`
- **Tier 2**: Manifest `judge:` block
- **Tier 3**: Environment variables (`RAKI_JUDGE_PROVIDER`, `RAKI_JUDGE_MODEL`)
- **Tier 4**: Existing defaults

### Report config
- `EvalReport.config` includes `judge_source` key indicating which tier resolved the judge
- Uses `_build_report_config()` helper (from #236) with new `judge_source` parameter

### Backward compatibility
- All existing manifests without a `judge:` block continue to work unchanged
- `--judge` flag remains required to enable judging (no implicit activation from manifest)

## Test Plan

- All 1,298 existing tests pass, 20 skipped
- New tests in `TestJudgePriorityChain` cover all 4 priority tiers
- `test_judge_config_has_no_docs_path_field` asserts schema constraints
- End-to-end backward compatibility verified

## Acceptance Criteria

- [x] Manifest supports `judge.provider`/`judge.model`
- [x] `judge:` block has no `docs_path` field
- [x] CLI flags override manifest values via `get_parameter_source()`
- [x] Env vars as intermediate fallback (`RAKI_JUDGE_PROVIDER`/`RAKI_JUDGE_MODEL`)
- [x] `--judge` flag still required to enable judging
- [x] Backward compatible (no `judge:` block)
- [x] Effective config captured in `EvalReport.config` with `judge_source` key
- [x] Uses `_build_report_config()` from #236