### PR TITLE
fix(tests): pass MetricConfig to create_ragas_embeddings() in integration test

### DIFF
--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -2480,7 +2480,8 @@ class TestLlmSetupIntegration:
         pytest.importorskip("ragas.embeddings.google_provider")
         from raki.metrics.ragas.llm_setup import create_ragas_embeddings
 
-        embeddings = create_ragas_embeddings()
+        config = MetricConfig(temperature=0.0)
+        embeddings = create_ragas_embeddings(config)
         assert embeddings is not None
 
 


### PR DESCRIPTION
## Summary

- Fix stale integration test broken by #234 (SDK migration): `create_ragas_embeddings()` now requires a `config` argument but `TestLlmSetupIntegration` still called it without one, causing a `TypeError`.

## Test plan

- [x] `uv run pytest tests/test_metrics_ragas.py -k test_create_ragas_embeddings -v` passes (no longer TypeError)
- [x] Full suite: 1460 passed


🐘 Generated with Crush