### PR TITLE
fix(ragas): drop use_vertex from GoogleEmbeddings to fix deprecated SDK path

### DIFF
--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -210,11 +210,17 @@ def create_ragas_embeddings(config: MetricConfig):
 
     client = genai.Client(vertexai=True, project=project, location=location)
 
-    return GoogleEmbeddings(
+    embeddings = GoogleEmbeddings(
         client=client,
         model="text-embedding-005",
-        use_vertex=True,
     )
+    # Ragas's _resolve_client() detects our genai.Client as new SDK and sets
+    # _use_new_sdk=True, routing embed calls through client.models.embed_content()
+    # instead of the deprecated vertexai._model_garden path.  We intentionally
+    # omit use_vertex=True because that flag forces the old TextEmbeddingModel
+    # path regardless of _use_new_sdk — the genai.Client(vertexai=True) already
+    # handles Vertex AI routing internally.
+    return embeddings
 
 
 def _validate_judge_log_path(log_path: Path, project_root: Path | None = None) -> Path:

--- a/tests/test_metrics_ragas.py
+++ b/tests/test_metrics_ragas.py
@@ -1372,8 +1372,8 @@ class TestCreateRagasEmbeddings:
             "create_fn": raki.metrics.ragas.llm_setup.create_ragas_embeddings,
         }
 
-    def test_embeddings_use_vertex_true(self, monkeypatch: pytest.MonkeyPatch):
-        """GoogleEmbeddings must be constructed with use_vertex=True, client, and model."""
+    def test_embeddings_constructed_without_use_vertex(self, monkeypatch: pytest.MonkeyPatch):
+        """GoogleEmbeddings must be constructed without use_vertex (genai.Client handles routing)."""
         monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "vertex-project")
         monkeypatch.setenv("VERTEXAI_LOCATION", "us-east1")
 
@@ -1384,7 +1384,6 @@ class TestCreateRagasEmbeddings:
         mocks["embeddings_class"].assert_called_once_with(
             client=mocks["genai_client"],
             model="text-embedding-005",
-            use_vertex=True,
         )
         assert result is mocks["embeddings_instance"]
 
@@ -1404,7 +1403,7 @@ class TestCreateRagasEmbeddings:
 
         call_kwargs = mocks["embeddings_class"].call_args.kwargs
         assert call_kwargs["client"] is mocks["genai_client"]
-        assert call_kwargs["use_vertex"] is True
+        assert "use_vertex" not in call_kwargs
 
     def test_passes_vertex_project_to_genai_client(self, monkeypatch: pytest.MonkeyPatch):
         """Verify genai.Client is created with vertexai=True and project from env."""


### PR DESCRIPTION
## Summary

- `GoogleEmbeddings(use_vertex=True)` forces the deprecated `vertexai._model_garden.TextEmbeddingModel.from_pretrained()` path regardless of `_use_new_sdk`, causing `answer_relevancy` to fail with `501 Received http2 header with status: 404`
- Dropping `use_vertex=True` lets Ragas detect the `genai.Client` as the new SDK and route through `client.models.embed_content()` which works correctly
- `genai.Client(vertexai=True)` already handles Vertex AI routing internally — the `GoogleEmbeddings` flag was redundant

Follow-up to #234 (SDK migration).

## Test plan

- [x] `create_ragas_embeddings()` returns embeddings with `_use_new_sdk=True`
- [x] `embed_text('test')` returns 768-dimension vector without deprecation warnings
- [x] `answer_relevancy` scores 0.87 on real Alcove sessions (was 0.00 / error before)
- [x] Full suite: 1507 passed


🐘 Generated with Crush