### PR TITLE
fix(deps): add google-cloud-aiplatform to ragas extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ ragas = [
     "instructor>=1.0",
     "google-auth>=2.0",
     "google-genai>=1.0",
+    "google-cloud-aiplatform>=1.50",
 ]
 litellm = [
     "litellm>=1.0",


### PR DESCRIPTION
## Summary

- Add `google-cloud-aiplatform>=1.50` to the `ragas` optional dependency group
- Required by `answer_relevancy` metric — `GoogleEmbeddings` needs the Vertex AI SDK
- Previously required manual `uv pip install google-cloud-aiplatform`

## Test plan

- [x] `uv sync --all-extras` resolves successfully
- [x] 1504 passed, 3 skipped


🐘 Generated with Crush