### PR TITLE
docs: correct GoogleEmbeddings use_vertex guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,7 @@ Use the `/orchestrate` skill in Claude Code to coordinate milestone-level develo
 ## Gotchas
 
 1. **ty is strict** -- Protocol attributes must be satisfied by class variables, not instance attributes.
-2. **Ragas 0.4 + Anthropic** -- `llm_factory()` must receive `provider="anthropic"` explicitly (defaults to `"openai"`). Must pop `top_p` from `llm.model_args` after creation — Anthropic rejects `temperature` + `top_p` together. GoogleEmbeddings ignores pre-configured clients (known bug, #106).
+2. **Ragas 0.4 + Anthropic** -- `llm_factory()` must receive `provider="anthropic"` explicitly (defaults to `"openai"`). Must pop `top_p` from `llm.model_args` after creation — Anthropic rejects `temperature` + `top_p` together. `GoogleEmbeddings` must **not** use `use_vertex=True` — that flag selects the old `google-cloud-aiplatform` SDK path. Use `genai.Client(vertexai=True)` without the flag; Ragas detects the new SDK automatically.
 3. **Large session files** -- some session formats can be 50MB+; `detect()` must read only the first 32KB.
 4. **ReviewFinding.severity** -- `Literal["critical", "major", "minor"]`, not bare `str`.
 5. **Operational metrics** -- return raw values (cost in $, cycles as count), not 0-1 normalized.
@@ -251,7 +251,7 @@ Use the `/orchestrate` skill in Claude Code to coordinate milestone-level develo
 26. **Manifest symlink path escape** -- manifest session paths cannot be symlinks to external directories. The real path is resolved and checked against project root. Copy sessions into the manifest directory instead of symlinking.
 27. **`soda-system-prompt-*.md` stray files** -- SODA sometimes leaves temporary prompt files in the repo root. These are in `.gitignore` and should never be committed.
 28. **`--docs-path` must match the project being worked on** -- when evaluating SODA sessions that implement raki code, point `--docs-path` to raki's docs, not SODA's. When evaluating Alcove sessions working on pulp-service, point to pulp-service docs. Wrong docs → knowledge_gap_rate=1.00 because findings reference source files the docs don't cover.
-29. **`vertex-anthropic` is the reliable judge provider** -- `anthropic` needs `ANTHROPIC_API_KEY` (not set by default). `google` has an async/sync client mismatch (#233). `answer_relevancy` requires either `GOOGLE_CLOUD_PROJECT` or `VERTEXAI_PROJECT`; `create_ragas_embeddings` normalises `GOOGLE_CLOUD_PROJECT` from `VERTEXAI_PROJECT` so `GoogleEmbeddings` can find the project internally (#231). Default to `--judge-provider vertex-anthropic --judge-model claude-sonnet-4-6`.
+29. **`vertex-anthropic` is the reliable judge provider** -- `anthropic` needs `ANTHROPIC_API_KEY` (not set by default). `google` async fix landed in v0.12.0 (#233). `answer_relevancy` requires either `GOOGLE_CLOUD_PROJECT` or `VERTEXAI_PROJECT`; `create_ragas_embeddings` normalises `GOOGLE_CLOUD_PROJECT` from `VERTEXAI_PROJECT` so `GoogleEmbeddings` can find the project internally (#231). Default to `--judge-provider vertex-anthropic --judge-model claude-sonnet-4-6`.
 
 ## Things agents often get wrong here
 

--- a/src/raki/metrics/ragas/llm_setup.py
+++ b/src/raki/metrics/ragas/llm_setup.py
@@ -172,11 +172,10 @@ def create_ragas_embeddings(config: MetricConfig):
     Dispatches on ``config.llm_provider``:
 
     - ``vertex-anthropic``, ``anthropic``, ``google`` -- uses ``GoogleEmbeddings``
-      constructed directly with ``use_vertex=True`` and a pre-configured
-      ``genai.Client`` for Vertex AI.  This bypasses ``embedding_factory()``
-      which does not forward ``use_vertex`` to the constructor, causing
-      ``_resolve_client()`` to take the Gemini path and discard the
-      pre-configured client (see #106).
+      with a ``genai.Client(vertexai=True)`` for Vertex AI.  The Ragas
+      ``use_vertex`` flag is *not* set -- that flag selects the old
+      ``google-cloud-aiplatform`` SDK path.  Our ``genai.Client`` handles
+      Vertex routing internally and Ragas detects it as the new SDK.
 
     - ``litellm`` -- uses Ragas's built-in ``LiteLLMEmbeddings`` with model
       ``text-embedding-3-small`` (OpenAI-compatible, routed via LiteLLM).
@@ -214,12 +213,11 @@ def create_ragas_embeddings(config: MetricConfig):
         client=client,
         model="text-embedding-005",
     )
-    # Ragas's _resolve_client() detects our genai.Client as new SDK and sets
-    # _use_new_sdk=True, routing embed calls through client.models.embed_content()
-    # instead of the deprecated vertexai._model_garden path.  We intentionally
-    # omit use_vertex=True because that flag forces the old TextEmbeddingModel
-    # path regardless of _use_new_sdk — the genai.Client(vertexai=True) already
-    # handles Vertex AI routing internally.
+    # use_vertex=True is intentionally omitted.  In Ragas, use_vertex selects
+    # the old google-cloud-aiplatform SDK path (TextEmbeddingModel); without it,
+    # Ragas detects our genai.Client as the new SDK and routes through
+    # client.models.embed_content().  Vertex AI routing is handled by
+    # genai.Client(vertexai=True) above — the Ragas flag is not needed.
     return embeddings
 
 


### PR DESCRIPTION
## Summary

- Fix misleading comments in `llm_setup.py` that described correct Ragas usage as a bug workaround
- Update AGENTS.md gotcha #2 (GoogleEmbeddings: don't use `use_vertex=True`) and #29 (Google async fix landed)


🐘 Generated with Crush