### PR TITLE
docs(metrics): expand operational and analytical metrics references

### DIFF
--- a/docs/metrics/analytical.md
+++ b/docs/metrics/analytical.md
@@ -2,6 +2,8 @@
 
 Analytical metrics use an LLM judge (via Ragas) to evaluate retrieval quality. They require the `--judge` flag and LLM provider credentials.
 
+> **See also:** [Rationale and Interpretation Guide](rationale-and-interpretation.md) — detailed design rationale, interpretation tables, and combined metric patterns.
+
 ## Prerequisites
 
 Enable analytical metrics with `--judge`:
@@ -22,15 +24,39 @@ uv run raki run --manifest raki.yaml --judge \
 ```
 
 Provider options for `--judge-provider`:
-- `vertex-anthropic` (default) -- Claude via Vertex AI
-- `anthropic` -- direct Anthropic API (requires `ANTHROPIC_API_KEY`)
-- `google` -- Google AI
-- `litellm` -- any model via [LiteLLM](https://docs.litellm.ai/) (requires `raki[litellm]` and the appropriate provider credentials, e.g. `OPENAI_API_KEY`)
+- `vertex-anthropic` (default) — Claude via Vertex AI
+- `anthropic` — direct Anthropic API (requires `ANTHROPIC_API_KEY`)
+- `google` — Google AI (⚠ see [silent-zero bug](#known-issue-google-provider-silent-zero-bug) below)
+- `litellm` — any model via [LiteLLM](https://docs.litellm.ai/) (requires `raki[litellm]` and the appropriate provider credentials, e.g. `OPENAI_API_KEY`)
 
 The default judge model is `claude-sonnet-4-6`. Override with `--judge-model`.
 
-When using `litellm`, embeddings are served by `text-embedding-3-small` (OpenAI) via LiteLLM.
-Set `OPENAI_API_KEY` or configure the LiteLLM proxy for a different embedding provider.
+### Manifest configuration
+
+Judge settings can also be persisted in your manifest (shipped in v0.12.0):
+
+```yaml
+judge:
+  provider: vertex-anthropic
+  model: claude-sonnet-4-6
+```
+
+**Priority order** (highest wins): CLI flags > manifest `judge.*` > environment variables (`RAKI_JUDGE_PROVIDER`, `RAKI_JUDGE_MODEL`) > built-in defaults.
+
+### Embeddings
+
+`answer_relevancy` requires embeddings in addition to the LLM judge. The embedding provider depends on your `--judge-provider`:
+
+| Judge provider | Embedding source | Required env vars |
+|---|---|---|
+| `vertex-anthropic` | Google `text-embedding-004` via Vertex AI | `GOOGLE_CLOUD_PROJECT` or `VERTEXAI_PROJECT` |
+| `anthropic` | Google `text-embedding-004` via Vertex AI | `GOOGLE_CLOUD_PROJECT` or `VERTEXAI_PROJECT` |
+| `google` | Google `text-embedding-004` via Vertex AI | `GOOGLE_CLOUD_PROJECT` or `VERTEXAI_PROJECT` |
+| `litellm` | `text-embedding-3-small` (OpenAI) via LiteLLM | `OPENAI_API_KEY` |
+
+If the required env vars are not set, `answer_relevancy` will fail with an error.
+
+### Installation
 
 Install with all extras to get Ragas dependencies:
 
@@ -46,35 +72,107 @@ uv pip install raki[ragas,litellm]
 
 > **Note:** The `ragas` extra pulls `scikit-network`, which requires a C++ compiler (`g++`).
 
-## Context synthesis
+---
 
-RAKI synthesizes context for Ragas evaluation from session phase data. The agent's tool calls, retrieved documents, and phase outputs are assembled into `retrieved_contexts` and `response` fields that Ragas evaluates.
+## How context synthesis works
 
-When the context source is inferred from phase data rather than explicit retrieval logs, metric names may appear with an `(inferred)` suffix in the report to indicate that context was reconstructed rather than directly captured.
+Ragas metrics require three inputs per session: `user_input` (the question), `retrieved_contexts` (what the agent had available), and `response` (what the agent produced). RAKI synthesizes these from session phase data:
 
-## faithfulness -- Faithfulness (experimental)
+### Field mapping
 
-**What it measures:** Whether the agent's output is grounded in the retrieved context -- i.e., the agent is not hallucinating beyond what the sources provide.
+| Ragas field | Source | Details |
+|---|---|---|
+| `user_input` | 1. Ground truth question, 2. Triage approach/summary, 3. Ticket ID | First available value is used |
+| `retrieved_contexts` | `implement.knowledge_context` | Split on `\n---\n` delimiters, each chunk truncated to 1000 chars, max 10 chunks |
+| `response` | Structured phase data or raw implement output | Prefers triage approach + plan tasks + implement commits over raw output; truncated to 2000 chars |
+| `reference` | 1. Ground truth `reference_answer`, 2. Top-K doc chunks by keyword overlap | Only used by `context_precision` and `context_recall` |
+
+### Sessions that get skipped
+
+A session is **excluded from Ragas scoring** when:
+- No `implement` or `session` phase exists
+- The implement phase has no `knowledge_context` field (i.e., no retrieval context was injected)
+- After splitting `knowledge_context` on `\n---\n`, all chunks are empty
+
+This means you may have 50 sessions but only 10 get scored if the other 40 lack `knowledge_context`. This is common with Alcove pipeline sessions and SODA sessions where the implement phase didn't receive knowledge injection. The report shows `samples_scored` and `samples_skipped` counts in each metric's details.
+
+### Content truncation
+
+To prevent max_tokens errors during Ragas scoring, RAKI truncates content before sending it to the LLM judge:
+
+| Field | Max length | Notes |
+|---|---|---|
+| Each retrieved context chunk | 1,000 chars | Truncated at word boundary with `[truncated]` marker |
+| Response | 2,000 chars | Truncated at word boundary with `[truncated]` marker |
+| Max context chunks | 10 | Additional chunks are dropped |
+| Each reference doc chunk | 1,000 chars | For context_precision/recall only |
+| Max reference chunks | 10 | Selected by keyword overlap with user_input |
+
+**Impact on scores:** Analytical metric scores reflect the *truncated* content, not the full context the agent had available. A faithfulness metric cannot verify claims against context that was truncated away. If your sessions have very large `knowledge_context` values (common with verbose retrieval systems), scores may be lower than expected because the judge only sees the first portion of each chunk.
+
+The `[truncated]` marker appears in Ragas judge output and JSON reports, making it visible when truncation occurred.
+
+### Reference chunk selection
+
+For `context_precision` and `context_recall`, when no ground truth `reference_answer` exists, RAKI selects reference doc chunks from `--docs-path` using **keyword overlap** (bag-of-words matching) with the `user_input`. This is a simple word-overlap approach — no embeddings or semantic similarity. Chunks with more shared words rank higher. Only chunks with at least 1 shared word are included.
+
+This selection quality directly affects precision/recall scores. If the keyword overlap selects irrelevant chunks, precision scores will appear low even if the retriever is performing well.
+
+---
+
+## Known issue: Google provider silent-zero bug
+
+When using `--judge-provider google`, the [instructor#1658](https://github.com/instructor-ai/instructor/issues/1658) bug can cause Ragas to silently return `score=0.0` for all sessions. This happens when `instructor` fails to parse Google's structured output and returns a Pydantic model with default field values (`value=0.0`, `reason=None`) instead of raising a validation error.
+
+**Symptoms:**
+- All analytical metrics return exactly 0.0
+- No error messages in output
+- `details.silent_zero_sessions` count in the JSON report
+
+**How RAKI handles it:** The `is_instructor_silent_zero()` detector checks for the combination of Google provider + structured result + `value=0.0` + empty `reason`. Affected sessions are **excluded from the metric average** and logged as warnings. If all sessions are affected, the metric returns `score=None` (N/A) with `skipped: "instructor#1658: Google provider returned only silent 0.0 scores"`.
+
+**Recommendation:** Use `--judge-provider vertex-anthropic` (the default) to avoid this issue entirely.
+
+---
+
+## Known issue: max_tokens failures
+
+When session contexts are very large, the LLM judge may hit its output token limit during scoring. This produces a `max_tokens` error for that session.
+
+**How RAKI handles it:** Affected sessions are excluded from the metric average. If all sessions fail with max_tokens errors, the metric returns `score=None` (N/A) with `skipped: "max_tokens: all sessions exceeded output token limit"`. The `details.max_tokens_sessions` count shows how many sessions were affected.
+
+**Mitigation:** RAKI already truncates contexts to 1000 chars each (see [content truncation](#content-truncation)). If you still see max_tokens failures, your sessions may have exceptionally large numbers of context chunks (capped at 10) or very long `user_input` fields. Consider reducing the context injected into your agent's implement phase.
+
+---
+
+## faithfulness — Faithfulness (experimental)
+
+**What it measures:** Whether the agent's output is grounded in the retrieved context — i.e., the agent is not hallucinating beyond what the sources provide.
 
 **What it tells you:** How closely the agent sticks to facts in its source material.
 
 **What action it drives:** Inspect low-scoring sessions manually. Distinguish between genuine hallucination and legitimate multi-step reasoning before taking action.
 
-**How it's computed:** Ragas Faithfulness metric. Uses LLM-as-judge to check each claim in the response against retrieved contexts.
+**How it's computed:** Ragas Faithfulness metric. Uses LLM-as-judge to decompose the response into individual claims and check each claim against the retrieved contexts. Each claim is scored as supported or unsupported. The score is the ratio of supported claims.
 
-**N/A conditions:** Returns `score=None` when no sessions have retrieval context.
+**N/A conditions:** Returns `score=None` when:
+- No sessions have retrieval context (`knowledge_context` absent), OR
+- All sessions failed with max_tokens errors, OR
+- All sessions hit the instructor#1658 silent-zero bug (Google provider)
 
-**Experimental caveat:** This metric was designed for natural language answers, not code. Scores may be noisy for agentic code-generation sessions where the agent synthesizes across tool calls.
+**Experimental caveat:** This metric was designed for natural language answers, not code. Scores may be noisy for agentic code-generation sessions where the agent synthesizes across tool calls. The details dict includes `"experimental": True` to flag this.
+
+When the context was synthesized (inferred from phase data rather than explicit retrieval logs), the details dict includes `"context_source": "synthesized"` and metric names may appear with an `(inferred)` suffix in the report.
 
 | Zone | Range | Meaning |
 |------|-------|---------|
 | Green | >= 0.80 | Output is well-grounded in context |
-| Yellow | 0.50--0.79 | Some claims lack context support |
+| Yellow | 0.50–0.79 | Some claims lack context support |
 | Red | < 0.50 | Output frequently diverges from context |
 
 ---
 
-## answer_relevancy -- Answer relevancy (experimental)
+## answer_relevancy — Answer relevancy (experimental)
 
 **What it measures:** How relevant the agent's output is to the original user query.
 
@@ -82,57 +180,63 @@ When the context source is inferred from phase data rather than explicit retriev
 
 **What action it drives:** Low relevancy often indicates a prompt or routing issue rather than a retrieval problem. Check whether the agent is interpreting the task correctly.
 
-**How it's computed:** Ragas AnswerRelevancy metric. Uses LLM + embeddings to measure semantic similarity between the response and the question.
+**How it's computed:** Ragas AnswerRelevancy metric. Uses LLM to generate synthetic questions from the response, then compares them to the original `user_input` using embedding similarity. Requires both an LLM judge and an embedding model (see [embeddings](#embeddings)).
 
-**N/A conditions:** Returns `score=None` when no sessions have retrieval context.
+**N/A conditions:** Returns `score=None` when:
+- No sessions have retrieval context, OR
+- All sessions failed with max_tokens or silent-zero errors
 
-**Experimental caveat:** Multi-step agent workflows may address the question indirectly, lowering scores without indicating a real problem.
+**Experimental caveat:** Multi-step agent workflows may address the question indirectly, lowering scores without indicating a real problem. The details dict includes `"experimental": True`.
 
 | Zone | Range | Meaning |
 |------|-------|---------|
 | Green | >= 0.80 | Output directly addresses the question |
-| Yellow | 0.50--0.79 | Output partially addresses the question |
+| Yellow | 0.50–0.79 | Output partially addresses the question |
 | Red | < 0.50 | Output does not address the question |
 
 ---
 
-## context_precision -- Context precision (requires ground truth)
+## context_precision — Context precision (requires ground truth)
 
-**What it measures:** Precision of retrieved contexts relative to ground truth -- how much of what the retriever pulled in was actually relevant.
+**What it measures:** Precision of retrieved contexts relative to ground truth — how much of what the retriever pulled in was actually relevant.
 
 **What it tells you:** Whether the retriever is surfacing relevant content or flooding the context window with noise.
 
 **What action it drives:** Low precision means the agent wastes tokens on irrelevant context. Review your retrieval pipeline's chunking and ranking.
 
-**How it's computed:** Ragas ContextPrecisionWithReference metric. Requires ground truth entries matched to sessions via `ground_truth.path` in the manifest.
+**How it's computed:** Ragas ContextPrecisionWithReference metric. Uses LLM-as-judge to evaluate each retrieved context chunk against the reference answer. Requires ground truth entries matched to sessions via `ground_truth.path` in the manifest.
 
-**N/A conditions:** Scores 0.0 with `details.skipped: "no ground truth"` when no sessions have matched ground truth entries. Run `raki validate` to check your ground truth match rate.
+When no ground truth `reference_answer` is available but `--docs-path` is provided, RAKI uses [keyword-selected doc chunks](#reference-chunk-selection) as the reference instead.
+
+**N/A conditions:** Returns `score=None` with `details.skipped: "no ground truth"` when no sessions have matched ground truth entries or doc chunks. Run `raki validate` to check your ground truth match rate.
 
 | Zone | Range | Meaning |
 |------|-------|---------|
 | Green | >= 0.80 | Retrieved context is mostly relevant |
-| Yellow | 0.50--0.79 | Significant irrelevant context |
+| Yellow | 0.50–0.79 | Significant irrelevant context |
 | Red | < 0.50 | More noise than signal |
 
 ---
 
-## context_recall -- Context recall (requires ground truth)
+## context_recall — Context recall (requires ground truth)
 
-**What it measures:** Recall of retrieved contexts relative to ground truth -- how much of the needed information the retriever successfully found.
+**What it measures:** Recall of retrieved contexts relative to ground truth — how much of the needed information the retriever successfully found.
 
 **What it tells you:** Whether the retriever is finding all the relevant knowledge.
 
 **What action it drives:** Low recall means the agent cannot find what it needs. Check that your knowledge base contains the expected content and that search is surfacing it.
 
-**How it's computed:** Ragas ContextRecallWithReference metric. Requires ground truth entries matched to sessions.
+**How it's computed:** Ragas ContextRecall metric. Uses LLM-as-judge to check whether each piece of information in the reference answer can be found in the retrieved contexts. Requires ground truth entries matched to sessions.
 
-**N/A conditions:** Same as context_precision -- requires matched ground truth.
+**N/A conditions:** Same as context_precision — returns `score=None` when no sessions have matched ground truth or doc chunks.
 
 | Zone | Range | Meaning |
 |------|-------|---------|
 | Green | >= 0.80 | Most relevant knowledge is retrieved |
-| Yellow | 0.50--0.79 | Important context is being missed |
+| Yellow | 0.50–0.79 | Important context is being missed |
 | Red | < 0.50 | Retrieval fails to surface relevant knowledge |
+
+---
 
 ## Ground truth requirements
 
@@ -146,3 +250,26 @@ ground_truth:
 Ground truth entries are matched to sessions by `code_area` domain-token overlap from triage phases. Sessions without a triage phase will not match. Run `raki validate` to check your match rate.
 
 See [Ground Truth Curation Guide](../curation-guide.md) for writing effective ground truth entries.
+
+---
+
+## Debugging analytical metrics
+
+**All metrics return N/A despite providing `--judge`:**
+- Check that sessions have `knowledge_context` in their implement phase — sessions without it are [skipped](#sessions-that-get-skipped)
+- Run `raki validate --deep` to verify adapter and metric health
+
+**Scores are all exactly 0.0:**
+- If using `--judge-provider google`, this is likely the [silent-zero bug](#known-issue-google-provider-silent-zero-bug)
+- Switch to `--judge-provider vertex-anthropic`
+- Check `details.silent_zero_sessions` in the JSON report
+
+**Scores are unexpectedly low:**
+- Check if [content truncation](#content-truncation) is cutting off important context — look for `[truncated]` markers in the JSON report
+- For `answer_relevancy`, verify the `user_input` field is meaningful — if it falls back to ticket ID, relevancy scores will be low
+- For `context_precision`/`context_recall`, check whether the reference was keyword-selected doc chunks (may not be semantically relevant)
+
+**Some sessions scored, others skipped:**
+- Check `details.samples_scored` vs `details.samples_skipped` in the JSON report
+- Skipped sessions typically lack `knowledge_context` or had scoring errors
+- `details.max_tokens_sessions` shows how many failed from context size

--- a/docs/metrics/operational.md
+++ b/docs/metrics/operational.md
@@ -1,8 +1,10 @@
 # Operational Metrics Reference
 
-Operational metrics run with zero configuration -- no LLM, no API keys, no docs path. They are computed directly from session transcript data.
+Operational metrics run with zero configuration — no LLM, no API keys, no docs path. They are computed directly from session transcript data.
 
-## first_pass_success_rate -- First-pass success rate
+> **Note:** The zone thresholds below (green/yellow/red) are defaults derived from real SODA pipeline session data. They are reasonable starting points but may need adjustment for your agent system and task complexity. Use `--gate` to set project-specific thresholds.
+
+## first_pass_success_rate — First-pass success rate
 
 **What it measures:** Fraction of sessions that completed without any rework cycles.
 
@@ -10,19 +12,19 @@ Operational metrics run with zero configuration -- no LLM, no API keys, no docs 
 
 **What action it drives:** Low values mean the implement phase is producing defective output. Investigate common failure patterns in failing sessions and improve prompts or knowledge coverage for those domains.
 
-**How it's computed:** Count sessions where `session.rework_cycles == 0`, divided by total sessions. Returns a ratio (0.0--1.0). Returns N/A for empty datasets.
+**How it's computed:** Count sessions where `session.rework_cycles == 0`, divided by total sessions. Returns a ratio (0.0–1.0). Returns `score=None` (N/A) when the dataset is empty — a dataset with sessions that all have rework returns 0.0, not N/A.
 
-**N/A conditions:** Returns `score=None` (displayed as N/A) when the dataset is empty.
+**N/A conditions:** Returns `score=None` (displayed as N/A) when the dataset is empty (zero sessions).
 
 | Zone | Range | Meaning |
 |------|-------|---------|
 | Green | >= 0.85 | Most sessions pass on first try |
-| Yellow | 0.60--0.84 | Noticeable first-attempt failures |
+| Yellow | 0.60–0.84 | Noticeable first-attempt failures |
 | Red | < 0.60 | Majority of sessions need rework |
 
 ---
 
-## rework_cycles -- Rework cycles
+## rework_cycles — Rework cycles
 
 **What it measures:** Mean number of review-fix iterations per session.
 
@@ -30,19 +32,19 @@ Operational metrics run with zero configuration -- no LLM, no API keys, no docs 
 
 **What action it drives:** Audit review findings across sessions. Repeated rework on the same issue category means the agent lacks the knowledge to get it right the first time. Add that knowledge to the KB or improve prompts.
 
-**How it's computed:** Sum `session.rework_cycles` across all sessions, divide by session count. Returns a raw count (not 0--1 normalized).
+**How it's computed:** Sum `session.rework_cycles` across all sessions, divide by session count. Returns a raw count (not 0–1 normalized).
 
-**N/A conditions:** Never N/A -- returns 0.0 when there are no sessions.
+**N/A conditions:** Never returns `score=None` — returns `score=0.0` for empty datasets. This means a score of 0.0 can indicate either "no rework happened" or "no sessions exist." Check `details.sessions` to distinguish: if `sessions > 0`, it genuinely means zero rework.
 
 | Zone | Range | Meaning |
 |------|-------|---------|
 | Green | < 1.5 | Minor or no rework needed |
-| Yellow | 1.5--3.0 | Sessions routinely need multiple iterations |
+| Yellow | 1.5–3.0 | Sessions routinely need multiple iterations |
 | Red | > 3.0 | Excessive iteration |
 
 ---
 
-## review_severity_distribution -- Severity score
+## review_severity_distribution — Severity score
 
 **What it measures:** Weighted severity of review findings across all sessions, where 1.0 means no findings.
 
@@ -51,23 +53,31 @@ Operational metrics run with zero configuration -- no LLM, no API keys, no docs 
 **What action it drives:** Categorize findings by severity and domain. Critical findings in a specific domain point to knowledge gaps in that area.
 
 **How it's computed:**
+
 ```
 weighted = (3 * critical + 2 * major + 1 * minor) / (3 * total)
 score = 1.0 - weighted
 ```
+
+The denominator `3 * total` represents the worst case: if every finding were critical. This normalization means the score measures how far the actual severity distribution is from the worst case, not from the average case.
+
+**Pool-based aggregation:** All findings from all sessions are pooled together — a single session with 50 minor findings has more influence than a session with 1 critical finding, despite the latter being a more serious quality signal. This is by design: the metric measures the *overall* severity landscape, not per-session quality. Use `self_correction_rate` and `first_pass_success_rate` for per-session quality signals.
+
 Returns 1.0 when there are zero findings.
 
-**N/A conditions:** Never N/A -- returns 1.0 when no findings exist.
+**Practical example:** 3 critical + 0 other findings → `weighted = 9/9 = 1.0` → score = `0.0`. Contrast with 0 critical + 30 minor findings → `weighted = 30/90 ≈ 0.33` → score ≈ `0.67`. The first case correctly scores worse despite having fewer total findings.
+
+**N/A conditions:** Never N/A — returns 1.0 when no findings exist.
 
 | Zone | Range | Meaning |
 |------|-------|---------|
 | Green | >= 0.85 | Few or no significant findings |
-| Yellow | 0.60--0.84 | Moderate findings present |
+| Yellow | 0.60–0.84 | Moderate findings present |
 | Red | < 0.60 | Critical or major findings are common |
 
 ---
 
-## cost_efficiency -- Cost / session
+## cost_efficiency — Cost / session
 
 **What it measures:** Mean LLM API cost per session in USD.
 
@@ -77,31 +87,35 @@ Returns 1.0 when there are zero findings.
 
 **How it's computed:** Average `session.total_cost_usd` across sessions that have cost data. Returns raw USD value.
 
-**N/A conditions:** Returns 0.0 when no sessions have `total_cost_usd`. The report shows "N/A" when `details.sessions_with_cost` is 0.
+**N/A conditions:** Returns `score=0.0` internally when no sessions have `total_cost_usd`. The report detects this via `details.sessions_with_cost == 0` and displays "N/A" instead of the misleading $0.00. This is a display concern — the metric itself cannot distinguish "zero cost" from "no data" because it returns a numeric score, not `None`.
 
 ---
 
-## self_correction_rate -- Self-correction rate
+## self_correction_rate — Self-correction rate
 
-**What it measures:** Ratio of rework findings (critical/major) that were resolved by the agent.
+**What it measures:** Ratio of rework findings (critical/major, excluding synthesized) that were resolved by the agent.
 
 **What it tells you:** Whether the agent can fix its own mistakes after review feedback.
 
 **What action it drives:** Low self-correction with high rework cycles means the agent is churning without converging. Investigate whether review criteria are clear and whether the agent's fix-apply loop is working.
 
-**How it's computed:** For sessions with `rework_cycles > 0` and critical/major findings: if the final verify phase has `status=completed`, all findings in that session count as resolved. Score = `resolved_findings / total_rework_findings`.
+**How it's computed:** For sessions with `rework_cycles > 0`: collect all critical/major non-synthesized findings. If the session's final verify phase (highest generation) has `status=completed`, all that session's findings count as resolved. Score = `resolved_findings / total_rework_findings`.
 
-**N/A conditions:** Returns `score=None` (displayed as N/A) when no sessions have rework findings. This is normal for high-quality runs.
+Synthesized findings (inferred from tool failures in the transcript) are excluded because they are not actionable review feedback — including them would artificially inflate the denominator.
+
+**N/A conditions:** Returns `score=None` (displayed as N/A) when no sessions have rework findings. This is normal for high-quality runs where every session passes on the first attempt.
+
+**Implementation note for contributors:** This metric uses `total_rework_findings: 0` in its N/A details dict, without the `sessions_with_` prefix that other metrics use. The CLI summary N/A detection (`_has_no_data()`) still works because it checks `score=None` separately from the `sessions_with_*` key convention. New metrics should prefer the `sessions_with_*` prefix for consistency.
 
 | Zone | Range | Meaning |
 |------|-------|---------|
 | Green | >= 0.80 | Agent fixes most issues after feedback |
-| Yellow | 0.50--0.79 | Some issues persist after rework |
+| Yellow | 0.50–0.79 | Some issues persist after rework |
 | Red | < 0.50 | Agent fails to resolve most issues |
 
 ---
 
-## phase_execution_time -- Phase execution time
+## phase_execution_time — Phase execution time
 
 **What it measures:** Mean total phase execution time per session in seconds.
 
@@ -109,19 +123,19 @@ Returns 1.0 when there are zero findings.
 
 **What action it drives:** Long execution times usually come from expensive tool calls, large context processing, or retry loops within a single phase. Check which phases are slowest.
 
-**How it's computed:** For each session with duration data, sum `phase.duration_ms` across phases, convert to seconds. Average across sessions.
+**How it's computed:** For each session with duration data, sum `phase.duration_ms` across phases, convert to seconds. Average across sessions. The details dict includes min, max, p50, and p95 (nearest-rank percentile, not interpolated — for small datasets this can differ from the true 95th percentile).
 
-**N/A conditions:** Returns 0.0 when no sessions have `duration_ms` data. The report shows "N/A" when `details.sessions_with_duration` is 0.
+**N/A conditions:** Returns `score=0.0` internally when no sessions have `duration_ms` data. The report detects this via `details.sessions_with_duration == 0` and displays "N/A."
 
 | Zone | Range | Meaning |
 |------|-------|---------|
 | Green | < 60s | Phases complete quickly |
-| Yellow | 60s--300s | Noticeable execution time |
+| Yellow | 60s–300s | Noticeable execution time |
 | Red | > 300s | Phases take a long time |
 
 ---
 
-## token_efficiency -- Tokens / phase
+## token_efficiency — Tokens / phase
 
 **What it measures:** Average tokens (input + output) consumed per phase.
 
@@ -129,12 +143,14 @@ Returns 1.0 when there are zero findings.
 
 **What action it drives:** Reduce retrieved context size and tighten prompts. High token counts combined with high cost confirm that token volume is driving spend.
 
-**How it's computed:** For each session, compute the mean of `(tokens_in + tokens_out)` across phases with token data. Then average across sessions.
+**How it's computed:** For each session, compute the mean of `(tokens_in + tokens_out)` across phases with token data. Then average across sessions. This is a **two-level mean** (per-phase within session, then per-session across the dataset) — not a global mean of all phase token counts. The difference: a session with 6 phases averaging 1000 tokens/phase counts the same as a session with 2 phases, even though the former consumed 3x more total tokens. This normalization makes the metric comparable across sessions with different numbers of phases.
 
-**N/A conditions:** Returns 0.0 when no phases have token data. The report shows "N/A" when `details.sessions_with_tokens` is 0.
+Phases where both `tokens_in` and `tokens_out` are `None` are skipped. Phases with only one of the two set treat the missing value as 0.
+
+**N/A conditions:** Returns `score=0.0` internally when no phases have token data. The report detects this via `details.sessions_with_tokens == 0` and displays "N/A."
 
 | Zone | Range | Meaning |
 |------|-------|---------|
 | Green | < 2,000 | Lean and efficient |
-| Yellow | 2,000--8,000 | Moderate token usage |
+| Yellow | 2,000–8,000 | Moderate token usage |
 | Red | > 8,000 | Excessive tokens per phase |


### PR DESCRIPTION
## Summary

- Expand operational metrics doc with N/A behavior clarification, severity score denominator rationale, token_efficiency two-level mean explanation, and contributor guidance on details key conventions
- Expand analytical metrics doc with silent-zero bug documentation, max_tokens failure mode, context synthesis field mapping, content truncation limits, embeddings requirements per provider, manifest judge config, and debugging guide

## What changed

### Operational (`operational.md`)
- Clarified N/A behavior for `cost_efficiency`, `phase_execution_time`, `token_efficiency` — all return `score=0.0` internally, report shows N/A via `sessions_with_*` detection
- Documented `self_correction_rate`'s non-standard details key (`total_rework_findings` without `sessions_with_` prefix) for contributors
- Added severity score denominator rationale (worst-case normalization) and pool-based aggregation explanation
- Noted zone thresholds are SODA-derived defaults, not universal
- Clarified `token_efficiency` is a two-level mean (per-phase within session, then per-session)
- Noted p95 is nearest-rank percentile, not interpolated

### Analytical (`analytical.md`)
- Documented **silent-zero bug** (instructor#1658) for Google provider with symptoms, detection, and recommendation
- Documented **max_tokens failure mode** with mitigation guidance
- Expanded context synthesis with field mapping table, session skip conditions, and truncation limits (1000/2000 chars, 10 chunks max)
- Added embeddings requirements table per provider (which env vars are needed)
- Added manifest judge config (`judge.provider`/`judge.model`) and 4-tier priority
- Documented reference chunk selection methodology (bag-of-words, not semantic)
- Fixed `context_precision` N/A returning `None` not `0.0`
- Added debugging guide for common analytical metric issues

## Test plan

- [x] All N/A behavior claims verified against implementation code
- [x] Truncation limits verified against `adapter.py` constants
- [x] Silent-zero detection verified against `is_instructor_silent_zero()`
- [x] Embeddings requirements verified against `create_ragas_embeddings()`
- [x] Cross-references to rationale doc and curation guide still valid


🐝 Generated with Crush