### PR TITLE
feat(metrics): triage_calibration metric — predicted complexity vs actual cost

### DIFF
--- a/changes/251.feature
+++ b/changes/251.feature
@@ -1,0 +1,4 @@
+Add `triage_calibration` metric — measures how well the agent's triage complexity prediction
+(`small` / `medium` / `large`) matches the actual session cost. Calibration thresholds:
+small ≤ $8.00, medium ≤ $16.00, large: any cost. Returns N/A when no sessions have both a
+triage complexity estimate and a cost.

--- a/docs/metrics/operational.md
+++ b/docs/metrics/operational.md
@@ -138,3 +138,29 @@ Returns 1.0 when there are zero findings.
 | Green | < 2,000 | Lean and efficient |
 | Yellow | 2,000--8,000 | Moderate token usage |
 | Red | > 8,000 | Excessive tokens per phase |
+
+---
+
+## triage_calibration -- Triage calibration
+
+**What it measures:** Fraction of sessions where the agent's triage complexity prediction is consistent with the actual session cost.
+
+**What it tells you:** Whether the agent's upfront complexity estimate (`small`, `medium`, or `large`) accurately predicts how expensive the session will be. A well-calibrated agent labels cheap tasks as `small` and expensive tasks as `large`, enabling accurate planning and resource allocation.
+
+**What action it drives:** Low calibration in one direction (e.g., many `small` sessions that cost more than $8) suggests the agent is underestimating effort during triage. High calibration means you can trust the triage output for scheduling and cost forecasting.
+
+**How it's computed:** For each session with a triage phase containing `output_structured.complexity` and a `total_cost_usd`:
+
+- `small` → calibrated if `cost <= $8.00`
+- `medium` → calibrated if `cost <= $16.00`
+- `large` → always calibrated (no upper bound)
+
+Score = `calibrated_sessions / sessions_with_triage_and_cost`. Returns N/A when no qualifying sessions exist.
+
+**N/A conditions:** Returns `score=None` (displayed as N/A) when no sessions have both a triage complexity prediction and a cost. This is expected for sessions using adapters that do not emit a triage phase.
+
+| Zone | Range | Meaning |
+|------|-------|---------|
+| Green | >= 0.80 | Triage predictions are reliable |
+| Yellow | 0.60--0.79 | Moderate miscalibration |
+| Red | < 0.60 | Predictions are frequently wrong |

--- a/src/raki/metrics/operational/__init__.py
+++ b/src/raki/metrics/operational/__init__.py
@@ -4,6 +4,7 @@ from raki.metrics.operational.rework import ReworkCycles
 from raki.metrics.operational.self_correction import SelfCorrectionRate
 from raki.metrics.operational.severity import ReviewSeverityDistribution
 from raki.metrics.operational.token_efficiency import TokenEfficiencyMetric
+from raki.metrics.operational.triage_calibration import TriageCalibrationMetric
 from raki.metrics.operational.verify_rate import FirstPassSuccessRate
 
 ALL_OPERATIONAL = [
@@ -14,6 +15,7 @@ ALL_OPERATIONAL = [
     SelfCorrectionRate(),
     PhaseExecutionTimeMetric(),
     TokenEfficiencyMetric(),
+    TriageCalibrationMetric(),
 ]
 
 __all__ = [
@@ -25,4 +27,5 @@ __all__ = [
     "ReworkCycles",
     "SelfCorrectionRate",
     "TokenEfficiencyMetric",
+    "TriageCalibrationMetric",
 ]

--- a/src/raki/metrics/operational/triage_calibration.py
+++ b/src/raki/metrics/operational/triage_calibration.py
@@ -1,0 +1,125 @@
+"""Triage calibration metric.
+
+Measures how well the agent's triage complexity prediction aligns with the actual
+session cost. A session is "calibrated" when the predicted complexity level is
+consistent with the actual total_cost_usd.
+
+Thresholds:
+- small  → actual cost must be <= SMALL_MAX (default 8.0 USD)
+- medium → actual cost must be <= MEDIUM_MAX (default 16.0 USD)
+- large  → any cost is acceptable (no upper bound)
+
+Score = mean(calibrated sessions) over sessions with both a triage complexity
+prediction and a cost.  Returns score=None (N/A) when no sessions qualify.
+
+This is a purely operational metric -- no LLM required.
+"""
+
+from raki.metrics.protocol import MetricConfig
+from raki.model import EvalDataset
+from raki.model.report import MetricResult
+
+# Default cost thresholds (USD) -- override via MetricConfig.params if needed.
+SMALL_MAX: float = 8.0
+MEDIUM_MAX: float = 16.0
+
+
+class TriageCalibrationMetric:
+    """Fraction of sessions where triage complexity prediction matches actual cost.
+
+    Score = calibrated_sessions / sessions_with_triage_and_cost.
+    Higher is better: 1.0 means every prediction was calibrated,
+    0.0 means every prediction was wrong.
+    Returns score=None when no sessions have both a triage complexity and cost.
+    """
+
+    name: str = "triage_calibration"
+    requires_ground_truth: bool = False
+    requires_llm: bool = False
+    higher_is_better: bool = True
+    display_format: str = "percent"
+    display_name: str = "Triage calibration"
+    description: str = "Fraction of sessions where predicted complexity matches actual cost"
+    rationale: str = (
+        "Triage calibration measures whether the agent's upfront complexity estimate "
+        "predicts the actual cost of completing the session. A well-calibrated agent "
+        "labels small tasks cheaply and large tasks expensively, enabling accurate "
+        "planning and resource allocation. Miscalibration in either direction is a "
+        "signal: small-labeled sessions that cost a lot suggest the agent underestimates "
+        "effort; large-labeled sessions that cost very little suggest over-caution. "
+        "Only sessions with both a triage complexity estimate and an actual cost are "
+        "scored; sessions missing either are excluded (N/A). "
+        "Thresholds: small <= $8.00, medium <= $16.00, large: any cost. "
+        "Target: >= 80% calibrated."
+    )
+
+    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:
+        small_max = float(config.params.get("small_max", SMALL_MAX))
+        medium_max = float(config.params.get("medium_max", MEDIUM_MAX))
+
+        calibrated = 0
+        total = 0
+        sample_scores: dict[str, float] = {}
+
+        for sample in dataset.samples:
+            # Find the triage phase (take the first one found).
+            triage_phase = None
+            for phase in sample.phases:
+                if phase.name == "triage":
+                    triage_phase = phase
+                    break
+
+            if triage_phase is None:
+                continue
+
+            output = triage_phase.output_structured
+            if not isinstance(output, dict):
+                continue
+
+            complexity = output.get("complexity")
+            if complexity not in ("small", "medium", "large"):
+                continue
+
+            cost = sample.session.total_cost_usd
+            if cost is None:
+                continue
+
+            total += 1
+
+            if complexity == "small":
+                is_calibrated = cost <= small_max
+            elif complexity == "medium":
+                is_calibrated = cost <= medium_max
+            else:
+                # large: no upper bound
+                is_calibrated = True
+
+            session_score = 1.0 if is_calibrated else 0.0
+            sample_scores[sample.session.session_id] = session_score
+            if is_calibrated:
+                calibrated += 1
+
+        if total == 0:
+            return MetricResult(
+                name=self.name,
+                score=None,
+                details={
+                    "calibrated_sessions": 0,
+                    "sessions_with_triage_and_cost": 0,
+                    "small_max": small_max,
+                    "medium_max": medium_max,
+                },
+            )
+
+        score = calibrated / total
+        return MetricResult(
+            name=self.name,
+            score=score,
+            details={
+                "calibrated_sessions": calibrated,
+                "sessions_with_triage_and_cost": total,
+                "small_max": small_max,
+                "medium_max": medium_max,
+            },
+            sample_scores=sample_scores,
+        )

--- a/src/raki/metrics/operational/triage_calibration.py
+++ b/src/raki/metrics/operational/triage_calibration.py
@@ -60,6 +60,11 @@ class TriageCalibrationMetric:
         calibrated = 0
         total = 0
         sample_scores: dict[str, float] = {}
+        per_complexity: dict[str, dict[str, int]] = {
+            "small": {"total": 0, "calibrated": 0},
+            "medium": {"total": 0, "calibrated": 0},
+            "large": {"total": 0, "calibrated": 0},
+        }
 
         for sample in dataset.samples:
             # Find the triage phase (take the first one found).
@@ -85,19 +90,20 @@ class TriageCalibrationMetric:
                 continue
 
             total += 1
+            per_complexity[complexity]["total"] += 1
 
             if complexity == "small":
                 is_calibrated = cost <= small_max
             elif complexity == "medium":
                 is_calibrated = cost <= medium_max
             else:
-                # large: no upper bound
                 is_calibrated = True
 
             session_score = 1.0 if is_calibrated else 0.0
             sample_scores[sample.session.session_id] = session_score
             if is_calibrated:
                 calibrated += 1
+                per_complexity[complexity]["calibrated"] += 1
 
         if total == 0:
             return MetricResult(
@@ -108,6 +114,7 @@ class TriageCalibrationMetric:
                     "sessions_with_triage_and_cost": 0,
                     "small_max": small_max,
                     "medium_max": medium_max,
+                    "per_complexity": per_complexity,
                 },
             )
 
@@ -120,6 +127,7 @@ class TriageCalibrationMetric:
                 "sessions_with_triage_and_cost": total,
                 "small_max": small_max,
                 "medium_max": medium_max,
+                "per_complexity": per_complexity,
             },
             sample_scores=sample_scores,
         )

--- a/src/raki/metrics/operational/triage_calibration.py
+++ b/src/raki/metrics/operational/triage_calibration.py
@@ -5,8 +5,8 @@ session cost. A session is "calibrated" when the predicted complexity level is
 consistent with the actual total_cost_usd.
 
 Thresholds:
-- small  → actual cost must be <= SMALL_MAX (default 8.0 USD)
-- medium → actual cost must be <= MEDIUM_MAX (default 16.0 USD)
+- small  → actual cost must be <= SMALL_MAX (8.0 USD)
+- medium → actual cost must be <= MEDIUM_MAX (16.0 USD)
 - large  → any cost is acceptable (no upper bound)
 
 Score = mean(calibrated sessions) over sessions with both a triage complexity
@@ -19,7 +19,7 @@ from raki.metrics.protocol import MetricConfig
 from raki.model import EvalDataset
 from raki.model.report import MetricResult
 
-# Default cost thresholds (USD) -- override via MetricConfig.params if needed.
+# Cost thresholds (USD) for complexity calibration.
 SMALL_MAX: float = 8.0
 MEDIUM_MAX: float = 16.0
 
@@ -53,9 +53,9 @@ class TriageCalibrationMetric:
         "Target: >= 80% calibrated."
     )
 
-    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:
-        small_max = float(config.params.get("small_max", SMALL_MAX))
-        medium_max = float(config.params.get("medium_max", MEDIUM_MAX))
+    def compute(self, dataset: EvalDataset, config: MetricConfig) -> MetricResult:  # noqa: ARG002
+        small_max = SMALL_MAX
+        medium_max = MEDIUM_MAX
 
         calibrated = 0
         total = 0

--- a/src/raki/report/cli_summary.py
+++ b/src/raki/report/cli_summary.py
@@ -22,6 +22,7 @@ OPERATIONAL_METRICS = {
     "self_correction_rate",
     "phase_execution_time",
     "token_efficiency",
+    "triage_calibration",
 }
 
 KNOWLEDGE_METRICS = {

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -116,6 +116,16 @@ METRIC_METADATA: dict[str, dict[str, str | bool]] = {
         "threshold": "",
         "docs_anchor": "token-efficiency",
     },
+    "triage_calibration": {
+        "display_name": "Triage calibration",
+        "higher_is_better": True,
+        "display_format": "percent",
+        "description": "Fraction of sessions where predicted complexity matches actual cost",
+        "subtitle": "How well the agent's triage complexity estimate predicts actual session cost",
+        "direction": "higher is better",
+        "threshold": "Target: >= 80%",
+        "docs_anchor": "triage-calibration",
+    },
     "faithfulness": {
         "display_name": "Faithfulness",
         "higher_is_better": True,

--- a/tests/test_triage_calibration.py
+++ b/tests/test_triage_calibration.py
@@ -203,6 +203,34 @@ class TestTriageCalibrationDetails:
         assert result.details["small_max"] == SMALL_MAX
         assert result.details["medium_max"] == MEDIUM_MAX
 
+    def test_per_complexity_breakdown(self):
+        """Details dict includes per-complexity total and calibrated counts."""
+        s_cal = _make_triage_sample("s1", complexity="small", cost=5.0)
+        s_mis = _make_triage_sample("s2", complexity="small", cost=12.0)
+        m_cal = _make_triage_sample("m1", complexity="medium", cost=10.0)
+        l_cal = _make_triage_sample("l1", complexity="large", cost=25.0)
+
+        dataset = EvalDataset(samples=[s_cal, s_mis, m_cal, l_cal])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+
+        breakdown = result.details["per_complexity"]
+        assert breakdown["small"]["total"] == 2
+        assert breakdown["small"]["calibrated"] == 1
+        assert breakdown["medium"]["total"] == 1
+        assert breakdown["medium"]["calibrated"] == 1
+        assert breakdown["large"]["total"] == 1
+        assert breakdown["large"]["calibrated"] == 1
+
+    def test_per_complexity_breakdown_na(self):
+        """N/A result includes per-complexity breakdown with all zeros."""
+        dataset = EvalDataset(samples=[])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+
+        breakdown = result.details["per_complexity"]
+        for level in ("small", "medium", "large"):
+            assert breakdown[level]["total"] == 0
+            assert breakdown[level]["calibrated"] == 0
+
 
 class TestTriageCalibrationProperties:
     """Protocol attribute verification."""

--- a/tests/test_triage_calibration.py
+++ b/tests/test_triage_calibration.py
@@ -1,0 +1,220 @@
+"""Tests for TriageCalibrationMetric.
+
+All tests use a local _make_triage_sample helper to avoid polluting conftest.py
+with fixtures that are only useful for this single metric.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from raki.metrics.operational.triage_calibration import (
+    MEDIUM_MAX,
+    SMALL_MAX,
+    TriageCalibrationMetric,
+)
+from raki.metrics.protocol import MetricConfig
+from raki.model import EvalDataset, EvalSample, PhaseResult, SessionMeta
+
+
+def _make_triage_sample(
+    session_id: str,
+    complexity: str | None,
+    cost: float | None,
+) -> EvalSample:
+    """Build an EvalSample with a triage phase containing the given complexity and cost."""
+    meta = SessionMeta(
+        session_id=session_id,
+        started_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        total_phases=2,
+        rework_cycles=0,
+        total_cost_usd=cost,
+    )
+    output_structured = {"complexity": complexity} if complexity is not None else None
+    phases = [
+        PhaseResult(
+            name="triage",
+            generation=1,
+            status="completed",
+            output="triage done",
+            output_structured=output_structured,
+        ),
+        PhaseResult(
+            name="implement",
+            generation=1,
+            status="completed",
+            output="done",
+        ),
+    ]
+    return EvalSample(session=meta, phases=phases, findings=[], events=[])
+
+
+class TestTriageCalibrationSmall:
+    """Sessions predicted as 'small' complexity."""
+
+    def test_small_within_threshold_is_calibrated(self):
+        """small + cost <= SMALL_MAX → score 1.0."""
+        sample = _make_triage_sample("s1", complexity="small", cost=SMALL_MAX - 1.0)
+        dataset = EvalDataset(samples=[sample])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+        assert result.score == 1.0
+        assert result.details["calibrated_sessions"] == 1
+        assert result.details["sessions_with_triage_and_cost"] == 1
+        assert result.sample_scores["s1"] == 1.0
+
+    def test_small_exactly_at_threshold_is_calibrated(self):
+        """small + cost == SMALL_MAX → score 1.0 (inclusive boundary)."""
+        sample = _make_triage_sample("s2", complexity="small", cost=SMALL_MAX)
+        dataset = EvalDataset(samples=[sample])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+        assert result.score == 1.0
+        assert result.sample_scores["s2"] == 1.0
+
+    def test_small_over_threshold_is_miscalibrated(self):
+        """small + cost > SMALL_MAX → score 0.0."""
+        sample = _make_triage_sample("s3", complexity="small", cost=SMALL_MAX + 0.01)
+        dataset = EvalDataset(samples=[sample])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+        assert result.score == 0.0
+        assert result.sample_scores["s3"] == 0.0
+
+
+class TestTriageCalibrationMedium:
+    """Sessions predicted as 'medium' complexity."""
+
+    def test_medium_within_threshold_is_calibrated(self):
+        """medium + cost <= MEDIUM_MAX → score 1.0."""
+        sample = _make_triage_sample("m1", complexity="medium", cost=MEDIUM_MAX - 1.0)
+        dataset = EvalDataset(samples=[sample])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+        assert result.score == 1.0
+        assert result.sample_scores["m1"] == 1.0
+
+    def test_medium_over_threshold_is_miscalibrated(self):
+        """medium + cost > MEDIUM_MAX → score 0.0."""
+        sample = _make_triage_sample("m2", complexity="medium", cost=MEDIUM_MAX + 5.0)
+        dataset = EvalDataset(samples=[sample])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+        assert result.score == 0.0
+        assert result.sample_scores["m2"] == 0.0
+
+
+class TestTriageCalibrationLarge:
+    """Sessions predicted as 'large' complexity."""
+
+    def test_large_any_cost_is_calibrated(self):
+        """large sessions are always calibrated regardless of cost."""
+        sample = _make_triage_sample("l1", complexity="large", cost=999.0)
+        dataset = EvalDataset(samples=[sample])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+        assert result.score == 1.0
+        assert result.sample_scores["l1"] == 1.0
+
+
+class TestTriageCalibrationMixed:
+    """Mixed session datasets."""
+
+    def test_mixed_complexity_levels(self):
+        """Mean over calibrated/miscalibrated sessions across all complexity levels."""
+        # small calibrated
+        s_cal = _make_triage_sample("s-cal", complexity="small", cost=5.0)
+        # small miscalibrated
+        s_mis = _make_triage_sample("s-mis", complexity="small", cost=20.0)
+        # medium calibrated
+        m_cal = _make_triage_sample("m-cal", complexity="medium", cost=12.0)
+        # large always calibrated
+        l_cal = _make_triage_sample("l-cal", complexity="large", cost=100.0)
+
+        dataset = EvalDataset(samples=[s_cal, s_mis, m_cal, l_cal])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+
+        # 3 calibrated out of 4 total
+        assert result.score == pytest.approx(3 / 4)
+        assert result.details["calibrated_sessions"] == 3
+        assert result.details["sessions_with_triage_and_cost"] == 4
+        assert result.sample_scores["s-cal"] == 1.0
+        assert result.sample_scores["s-mis"] == 0.0
+        assert result.sample_scores["m-cal"] == 1.0
+        assert result.sample_scores["l-cal"] == 1.0
+
+
+class TestTriageCalibrationNA:
+    """N/A conditions: missing triage phase, missing cost, invalid complexity."""
+
+    def test_no_triage_phase_returns_na(self):
+        """Sample without a triage phase is excluded → N/A."""
+        meta = SessionMeta(
+            session_id="no-triage",
+            started_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            total_phases=1,
+            rework_cycles=0,
+            total_cost_usd=10.0,
+        )
+        sample = EvalSample(
+            session=meta,
+            phases=[
+                PhaseResult(
+                    name="implement",
+                    generation=1,
+                    status="completed",
+                    output="done",
+                )
+            ],
+            findings=[],
+            events=[],
+        )
+        dataset = EvalDataset(samples=[sample])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+        assert result.score is None
+        assert result.details["sessions_with_triage_and_cost"] == 0
+
+    def test_missing_cost_returns_na(self):
+        """Sample with triage but no cost is excluded → N/A."""
+        sample = _make_triage_sample("no-cost", complexity="small", cost=None)
+        dataset = EvalDataset(samples=[sample])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+        assert result.score is None
+        assert result.details["sessions_with_triage_and_cost"] == 0
+
+    def test_empty_dataset_returns_na(self):
+        """Empty dataset → N/A."""
+        dataset = EvalDataset(samples=[])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+        assert result.score is None
+        assert result.details["calibrated_sessions"] == 0
+        assert result.details["sessions_with_triage_and_cost"] == 0
+
+
+class TestTriageCalibrationDetails:
+    """Details dict structure."""
+
+    def test_details_include_threshold_values(self):
+        """Details must expose the threshold values used."""
+        sample = _make_triage_sample("s1", complexity="small", cost=5.0)
+        dataset = EvalDataset(samples=[sample])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+        assert result.details["small_max"] == SMALL_MAX
+        assert result.details["medium_max"] == MEDIUM_MAX
+
+    def test_na_details_include_threshold_values(self):
+        """N/A result must also expose threshold values."""
+        dataset = EvalDataset(samples=[])
+        result = TriageCalibrationMetric().compute(dataset, MetricConfig())
+        assert result.details["small_max"] == SMALL_MAX
+        assert result.details["medium_max"] == MEDIUM_MAX
+
+
+class TestTriageCalibrationProperties:
+    """Protocol attribute verification."""
+
+    def test_properties(self):
+        """All Protocol-required class attributes must be set correctly."""
+        metric = TriageCalibrationMetric()
+        assert metric.name == "triage_calibration"
+        assert metric.requires_ground_truth is False
+        assert metric.requires_llm is False
+        assert metric.higher_is_better is True
+        assert metric.display_format == "percent"
+        assert metric.display_name == "Triage calibration"
+        assert isinstance(metric.description, str) and len(metric.description) > 0
+        assert isinstance(metric.rationale, str) and len(metric.rationale) > 50


### PR DESCRIPTION
Refs #251

## Summary

- Add `TriageCalibrationMetric` that scores how well triage complexity predictions (small/medium/large) match actual session costs
- Register in all three places: `ALL_OPERATIONAL`, `METRIC_METADATA`, `OPERATIONAL_METRICS`
- Include per-complexity breakdown in details dict

## Details

- Thresholds: small <= $8, medium <= $16, large = any cost (class-level constants)
- Score = fraction of sessions where predicted complexity matches cost range
- N/A when no sessions have both triage complexity and cost data
- 15 tests covering all complexity levels, mixed datasets, N/A cases, and per-complexity breakdown

## Test plan

- [x] `uv run pytest tests/test_triage_calibration.py -v` — 15 passed
- [x] `uv run pytest tests/ --ignore=tests/test_metrics_ragas.py -q` — 1342 passed, 3 skipped
- [x] `TestMetricMetadataSync` passes (metadata in sync)
- [x] Towncrier fragment added


🐝 Generated with Crush