### PR TITLE
docs(comparing-runs): document raki report --diff workflow

### DIFF
--- a/changes/258.doc
+++ b/changes/258.doc
@@ -1,0 +1,5 @@
+Document the ``raki report --diff`` workflow for comparing evaluation runs. The new
+``docs/comparing-runs.md`` guide covers the full before/after comparison workflow:
+manifest scoping, reading metric deltas and direction indicators, per-session verdict
+transitions, ``--fail-on-regression`` for CI gating, and when to use ``--diff`` vs
+``raki trends``.

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -69,6 +69,8 @@ uv run raki report \
 
 Regression direction respects each metric's `higher_is_better` setting. For example, an increase in `rework_cycles` (lower is better) is flagged as a regression.
 
+For the full before/after comparison workflow — including manifest scoping, reading the diff output, and the `--html` option for a self-contained diff report — see [Comparing Runs](comparing-runs.md).
+
 ## Exit codes
 
 | Code | Meaning |

--- a/docs/comparing-runs.md
+++ b/docs/comparing-runs.md
@@ -1,0 +1,237 @@
+# Comparing Runs
+
+Use `raki report --diff` to compare two evaluation runs side by side. This workflow answers the question "did this change improve things?" — quantified, with per-session detail.
+
+## Quick start
+
+This section walks through a complete before/after comparison in four commands.
+
+### Step 1: Evaluate pre-change sessions
+
+To evaluate the pre-change sessions, run the following command:
+
+```bash
+uv run raki run -m manifests/before.yaml -o results/ --include-sessions
+```
+
+RAKI writes `results/raki-report-<timestamp>.json`. Rename or copy it to a stable path so you can reference it later:
+
+```bash
+cp results/raki-report-*.json results/before.json
+```
+
+### Step 2: Evaluate post-change sessions
+
+To evaluate the post-change sessions, run the following command:
+
+```bash
+uv run raki run -m manifests/after.yaml -o results/ --include-sessions
+```
+
+Copy the new report to a stable path:
+
+```bash
+cp results/raki-report-*.json results/after.json
+```
+
+### Step 3: Compare the two reports
+
+To compare the two reports, run the following command:
+
+```bash
+uv run raki report --diff results/before.json results/after.json
+```
+
+Example output:
+
+```
+Comparing raki-20260501T100000 → raki-20260512T140000
+Matched: 12/14 sessions (2 new)
+
+  First-pass success rate  0.36 → 0.67  (+0.31)  ▲
+  Rework cycles            0.72 → 0.33  (-0.39)  ▲
+  Cost / session           $12.30 → $8.50  (-$3.80)  ▲
+  Severity score           0.45 → 0.22  (-0.23)  ▲
+
+Improvements: 4 sessions (fail→pass: 3, rework→pass: 1)
+Regressions:  1 session (pass→rework: 1)
+```
+
+### Step 4: Generate an HTML diff report
+
+To generate an HTML diff report, add `--html`:
+
+```bash
+uv run raki report --diff results/before.json results/after.json --html diff-report.html
+```
+
+The HTML report is a self-contained file with a dark theme. Open it in any browser.
+
+### Step 5: Gate CI on regressions
+
+To fail CI when metrics regress, add `--fail-on-regression`:
+
+```bash
+uv run raki report --diff results/baseline.json results/current.json --fail-on-regression
+```
+
+RAKI exits with code 3 when any metric regresses beyond the 2% noise margin. See [CI Integration](ci-integration.md) for exit code reference.
+
+## Reading the diff output
+
+### Header
+
+The first line identifies the two runs being compared:
+
+```
+Comparing raki-20260501T100000 → raki-20260512T140000
+```
+
+The run IDs come from the report timestamps. The left-hand run is the baseline; the right-hand run is the comparison target.
+
+### Judge config warnings
+
+When the two reports used different judge providers or models, RAKI prints a warning before the metric table:
+
+```
+Warning: judge config differs between runs
+  Baseline:  vertex-anthropic / claude-sonnet-4-6
+  Compare:   anthropic / claude-opus-4
+```
+
+Analytical metric deltas (faithfulness, answer relevancy, context precision, context recall) may not be meaningful when the judge changed. Operational metric deltas are unaffected.
+
+When only one report used a judge, RAKI warns that analytical metrics are missing from the other run and omits those metric rows from the diff.
+
+### Agent model warnings
+
+When the sessions in each report used different agent models, RAKI prints a warning noting that the model changed. This is informational — the diff proceeds, but metric differences may reflect model differences as much as prompt or config differences.
+
+### Coverage line
+
+The coverage line shows how many sessions were matched by `session_id`:
+
+```
+Matched: 12/14 sessions (2 new)
+```
+
+- **Matched**: sessions present in both reports, compared directly
+- **New**: sessions present only in the comparison report
+- **Dropped**: sessions present only in the baseline report
+
+Aggregate metric deltas are computed from matched sessions only. New and dropped sessions are counted but do not affect the deltas.
+
+### Metric deltas
+
+Each metric is shown with its baseline value, comparison value, numeric delta, and direction indicator:
+
+```
+  First-pass success rate  0.36 → 0.67  (+0.31)  ▲
+  Rework cycles            0.72 → 0.33  (-0.39)  ▲
+  Cost / session           $12.30 → $8.50  (-$3.80)  ▲
+  Severity score           0.45 → 0.22  (-0.23)  ▲
+```
+
+The direction indicator (`▲` / `▼` / `=`) respects each metric's `higher_is_better` setting:
+
+| Indicator | Meaning |
+|-----------|---------|
+| `▲` | Improvement (value moved in the desired direction) |
+| `▼` | Regression (value moved in the wrong direction) |
+| `=` | No change |
+
+For example, a decrease in `rework_cycles` is shown as `▲` because lower is better for that metric.
+
+### Session transitions
+
+When both reports were generated with `--include-sessions`, RAKI groups sessions by verdict change:
+
+```
+Improvements: 4 sessions (fail→pass: 3, rework→pass: 1)
+Regressions:  1 session (pass→rework: 1)
+```
+
+Sessions with unchanged verdicts are not listed. Each transition line names the session ID and the verdict change so you can investigate specific sessions.
+
+## Producing reports to compare
+
+### Manifest scoping
+
+Create one manifest per session set to scope each evaluation run to the correct sessions:
+
+```yaml
+# manifests/before.yaml — sessions from before the change
+sessions:
+  paths:
+    - sessions/2026-04-01/
+    - sessions/2026-04-15/
+```
+
+```yaml
+# manifests/after.yaml — sessions from after the change
+sessions:
+  paths:
+    - sessions/2026-05-01/
+    - sessions/2026-05-12/
+```
+
+Alternatively, use a single manifest that covers all sessions and run it twice — once pointing at the before session directories and once at the after directories.
+
+### The --include-sessions flag
+
+Pass `--include-sessions` to both evaluation runs to enable per-session verdict transitions in the diff output. Without it, RAKI still shows aggregate metric deltas but cannot report which individual sessions improved or regressed.
+
+To evaluate with per-session data, run the following command:
+
+```bash
+uv run raki run -m manifests/before.yaml -o results/ --include-sessions
+```
+
+### Consistent judge configuration
+
+Verify that both reports use the same judge configuration (provider and model) when comparing analytical metrics. RAKI warns when they differ, but does not block the comparison. To ensure consistency, pin the judge config in both manifests:
+
+```yaml
+judge:
+  provider: vertex-anthropic
+  model: claude-sonnet-4-6
+```
+
+## When to use --diff vs raki trends
+
+Both `raki report --diff` and `raki trends` help you understand whether evaluation quality is improving. They answer different questions.
+
+| Situation | Use |
+|-----------|-----|
+| Before/after a specific prompt change | `raki report --diff` |
+| Before/after a config or model change | `raki report --diff` |
+| Monitoring quality over many runs | `raki trends` |
+| Checking if a PR introduces a regression | `raki report --diff --fail-on-regression` |
+| Weekly or monthly trajectory review | `raki trends` |
+| Identifying a regression's first occurrence | `raki trends` |
+
+**`raki report --diff`** is a point-in-time comparison between two specific evaluation runs. Use it when you have a concrete before/after hypothesis and want to confirm that a change had the intended effect.
+
+**`raki trends`** shows metric trajectories over many runs. Use it for ongoing monitoring — for example, to verify that quality is improving sprint over sprint, or to spot a gradual degradation that no single diff would catch.
+
+See the `raki trends --help` output for trajectory options such as `--since`, `--last`, and `--metrics`.
+
+## Tips and caveats
+
+- **Reports without `--include-sessions`** still show aggregate metric deltas. Only per-session verdict transitions (improvements and regressions) require session data in both reports.
+
+- **New and dropped sessions** are displayed in the coverage line and counted separately. They do not affect aggregate metric deltas, which are computed from matched sessions only.
+
+- **Judge config mismatches** trigger a warning but do not block comparison. Operational metric deltas remain meaningful regardless of judge config. Analytical metric deltas may reflect judge differences rather than true quality changes when the judge changed between runs.
+
+- **Exit codes** from `raki report --diff`:
+
+  | Code | Meaning |
+  |------|---------|
+  | 0 | No regressions detected |
+  | 3 | Regression detected (`--fail-on-regression`) |
+  | 4 | Regression and threshold violation |
+
+  See [CI Integration](ci-integration.md) for the full exit code reference.
+
+- **Noise margin**: `--fail-on-regression` uses a 2% noise margin. Metric changes smaller than 2% are treated as flat and do not trigger a regression exit.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -198,11 +198,13 @@ uv run raki report results/raki-report-20260410T120000.json
 uv run raki report results/raki-report-20260410T120000.json --html report.html
 ```
 
-Compare two runs:
+To compare two runs and see metric deltas, direction indicators, and per-session verdict transitions, use the `--diff` subcommand:
 
 ```bash
-uv run raki report --diff results/baseline.json results/compare.json
+uv run raki report --diff results/before.json results/after.json
 ```
+
+For the full before/after comparison workflow — including how to scope manifests, what the diff output shows, and how to gate CI on regressions — see [Comparing Runs](comparing-runs.md).
 
 ## CI integration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,17 @@ Welcome to the RAKI documentation. These guides cover everything from first inst
 ## Guides
 
 - [Getting Started](getting-started.md) — install RAKI, run your first evaluation, and understand the output
-- [Interpretation Reference](interpretation-reference.md) — what each metric measures, threshold guidance, and common patterns
+- [Interpreting Results](interpreting-results.md) — how to read the HTML report and understand metric output
+- [Results Interpretation Reference](interpretation-reference.md) — what each metric measures, threshold guidance, and common patterns
+- [Comparing Runs](comparing-runs.md) — use `raki report --diff` to compare two evaluation runs and detect regressions
+- [CI Integration](ci-integration.md) — quality gates, regression detection, exit codes, and CI examples
 - [Ground Truth Curation Guide](curation-guide.md) — how to write effective ground truth entries for retrieval evaluation
 - [Adapter Guide](adapter-guide.md) — integrate a custom session format with the adapter protocol
 - [Session Schema Reference](session-schema.md) — field definitions for meta.json, phase files, review.json, and events.jsonl
+
+## Metric References
+
+- [Operational Metrics](metrics/operational.md) — cost, rework cycles, first-pass success rate, and more
+- [Knowledge Metrics](metrics/knowledge.md) — knowledge gap rate and knowledge miss rate
+- [Analytical Metrics](metrics/analytical.md) — Ragas-backed retrieval quality metrics
+- [Rationale and Interpretation](metrics/rationale-and-interpretation.md) — why these metrics, and how to act on them


### PR DESCRIPTION
## Summary

Add `docs/comparing-runs.md` — a new 237-line guide that documents the full `raki report --diff` before/after comparison workflow. Update the docs index, getting-started guide, and CI integration guide with cross-references.

## Files Changed

| File | Action | Description |
|------|--------|-------------|
| `docs/comparing-runs.md` | Created | New guide (237 lines) covering the complete diff workflow |
| `docs/index.md` | Modified | Restructured into Guides / Metric References groups; added Comparing Runs entry |
| `docs/getting-started.md` | Modified | Expanded bare 3-line `--diff` mention into a paragraph with link |
| `docs/ci-integration.md` | Modified | Added cross-reference from regression detection section |
| `changes/258.doc` | Created | Towncrier changelog fragment |

## What `docs/comparing-runs.md` Covers

1. **Quick start** — five steps with lead-in sentences and code blocks (no inline `# comments` per Red Hat conventions), plus realistic synthetic CLI output
2. **Reading the diff output** — header, judge config warnings, agent model warnings, coverage line, metric deltas with `▲`/`▼`/`=` direction indicators, session transitions
3. **Producing reports to compare** — manifest scoping patterns, `--include-sessions` requirement, consistent judge configuration
4. **When to use `--diff` vs `raki trends`** — decision table (six situations) plus prose on point-in-time vs trajectory distinction
5. **Tips and caveats** — reports without `--include-sessions`, new/dropped session handling, judge config mismatches, exit codes, 2% noise margin

## Acceptance Criteria

- [x] `docs/comparing-runs.md` created with five ordered sections (procedure first, concept last)
- [x] Quick start: ≥ 3 steps from two `raki report` invocations to reading output
- [x] Reading the output: covers header, metric deltas with direction indicators, session transitions
- [x] Producing reports: manifest scoping, `--include-sessions`, judge config consistency
- [x] When to use `--diff` vs `raki trends`: decision table with ≥ 4 situations
- [x] Tips and caveats: noise margin, new/dropped sessions, exit codes
- [x] `docs/index.md` updated with Comparing Runs entry
- [x] `docs/getting-started.md` `--diff` mention expanded with link
- [x] `docs/ci-integration.md` cross-reference added
- [x] Towncrier fragment `changes/258.doc` created

## Review Results

All specialist reviews passed. Documentation follows Red Hat conventions (no inline `#` comments in code blocks, lead-in sentences before each code block, imperative headings).

Refs #258

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko