### PR TITLE
fix(html-report): phase timeline ordering and rework dot coloring

### DIFF
--- a/changes/249.fix
+++ b/changes/249.fix
@@ -1,0 +1,5 @@
+Fix phase timeline ordering in the HTML report — phases are now sorted by their
+canonical pipeline position (triage → plan → implement → verify → review → submit
+→ monitor) using the new ``sort_phases()`` helper.  Rework phases (generation > 1)
+are highlighted with an amber dot instead of green, making it visually obvious
+which pipeline steps were repeated.

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from raki.model.dataset import EvalSample
+from raki.model.phases import PhaseResult
 from raki.model.report import EvalReport, SampleResult
 from raki.report.cli_summary import (
     EXPERIMENTAL_METRICS,
@@ -180,6 +181,39 @@ METRIC_METADATA: dict[str, dict[str, str | bool]] = {
 
 # GitHub base URL for metric documentation links
 DOCS_BASE_URL = "https://github.com/decko/raki/blob/main/docs/interpreting-results.md"
+
+# Canonical pipeline phase order — used to sort phases in the HTML phase timeline.
+# Phases not listed here are placed after all known phases, in their original order.
+PHASE_ORDER: list[str] = [
+    "triage",
+    "plan",
+    "implement",
+    "verify",
+    "review",
+    "submit",
+    "monitor",
+]
+
+
+def sort_phases(
+    phases: list[PhaseResult],
+    pipeline_phases: list[str] | None = None,
+) -> list[PhaseResult]:
+    """Sort phases by canonical pipeline order, then by generation.
+
+    Uses ``pipeline_phases`` from ``SessionMeta`` when available (the actual
+    ordered list recorded by the orchestrator); otherwise falls back to
+    ``PHASE_ORDER``.  Unknown phase names sort to the end.  Within the same
+    phase name the secondary key is ``generation``, which places rework
+    repetitions in ascending order.
+    """
+    order_list = pipeline_phases if pipeline_phases else PHASE_ORDER
+    order_index: dict[str, int] = {name: idx for idx, name in enumerate(order_list)}
+    fallback = len(order_list)
+    return sorted(
+        phases,
+        key=lambda phase: (order_index.get(phase.name, fallback), phase.generation),
+    )
 
 
 def _get_metric_meta(name: str) -> dict[str, str | bool]:

--- a/src/raki/report/html_report.py
+++ b/src/raki/report/html_report.py
@@ -703,6 +703,7 @@ def write_html_report(
         needs_attention_rows=needs_attention_rows,
         needs_attention_count=needs_attention_count,
         format_duration=_format_duration,
+        sort_phases=sort_phases,
         no_data_metrics=no_data_metrics,
         agent_models=agent_models,
         judge_cost=judge_cost,

--- a/src/raki/report/templates/report.html.j2
+++ b/src/raki/report/templates/report.html.j2
@@ -594,8 +594,9 @@
   }
 
   .phase-status-completed { background: var(--green); }
-  .phase-status-failed { background: var(--red); }
-  .phase-status-skipped { background: var(--text-muted); }
+  .phase-status-rework    { background: var(--yellow); }
+  .phase-status-failed    { background: var(--red); }
+  .phase-status-skipped   { background: var(--text-muted); }
 
   .phase-duration {
     color: var(--text-muted);
@@ -1032,9 +1033,10 @@
       {% if sample.phases %}
       <h3>Phases</h3>
       <div class="phase-list">
-        {% for phase in sample.phases %}
+        {% for phase in sort_phases(sample.phases, sample.session.pipeline_phases) %}
+        {% set dot_class = 'rework' if phase.status == 'completed' and phase.generation > 1 else phase.status %}
         <div class="phase-item">
-          <span class="phase-status phase-status-{{ phase.status }}"></span>
+          <span class="phase-status phase-status-{{ dot_class }}"></span>
           <span>{{ phase.name }} (gen {{ phase.generation }})</span>
           <span style="color: var(--text-muted);">&mdash; {{ phase.status }}</span>
           {% if phase.duration_ms is not none %}

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -2471,3 +2471,133 @@ class TestHtmlReportHeaderEnrichment:
         content = output.read_text()
         assert output.exists()
         assert "RAKI Evaluation Report" in content
+
+
+# --- Ticket #249: Phase timeline ordering and dot coloring ---
+
+
+class TestSortPhases:
+    """sort_phases orders phases by (PHASE_ORDER index, generation)."""
+
+    def _make_phase(
+        self,
+        name: str,
+        generation: int = 1,
+        status: str = "completed",
+    ):
+        from raki.model.phases import PhaseResult
+
+        return PhaseResult(
+            name=name,
+            generation=generation,
+            status=status,  # type: ignore[arg-type]
+            output="done",
+        )
+
+    def test_sorts_by_phase_order(self) -> None:
+        """Phases should be returned in PHASE_ORDER order regardless of input order."""
+        from raki.report.html_report import sort_phases
+
+        verify = self._make_phase("verify")
+        implement = self._make_phase("implement")
+        triage = self._make_phase("triage")
+        sorted_phases = sort_phases([verify, implement, triage])
+        assert [ph.name for ph in sorted_phases] == ["triage", "implement", "verify"]
+
+    def test_sorts_generation_within_same_phase(self) -> None:
+        """Multiple generations of same phase should be ordered by generation number."""
+        from raki.report.html_report import sort_phases
+
+        impl_gen2 = self._make_phase("implement", generation=2)
+        impl_gen1 = self._make_phase("implement", generation=1)
+        sorted_phases = sort_phases([impl_gen2, impl_gen1])
+        assert sorted_phases[0].generation == 1
+        assert sorted_phases[1].generation == 2
+
+    def test_unknown_phase_goes_to_end(self) -> None:
+        """Phases not in PHASE_ORDER should be sorted after all known phases."""
+        from raki.report.html_report import sort_phases
+
+        implement = self._make_phase("implement")
+        custom = self._make_phase("custom-phase")
+        sorted_phases = sort_phases([custom, implement])
+        assert sorted_phases[0].name == "implement"
+        assert sorted_phases[1].name == "custom-phase"
+
+    def test_pipeline_phases_overrides_phase_order(self) -> None:
+        """When pipeline_phases is provided it takes priority over PHASE_ORDER."""
+        from raki.report.html_report import sort_phases
+
+        implement = self._make_phase("implement")
+        verify = self._make_phase("verify")
+        # Custom order: verify before implement
+        sorted_phases = sort_phases([implement, verify], pipeline_phases=["verify", "implement"])
+        assert sorted_phases[0].name == "verify"
+        assert sorted_phases[1].name == "implement"
+
+    def test_empty_list_returns_empty(self) -> None:
+        """sort_phases on an empty list should return an empty list."""
+        from raki.report.html_report import sort_phases
+
+        assert sort_phases([]) == []
+
+
+class TestPhaseTimelineDotColoring:
+    """Phase status dots use correct colors: green gen-1, yellow rework (gen>1), red failed."""
+
+    def _make_report_with_phases(self, phases: list):
+        from raki.model.phases import PhaseResult
+        from raki.model.report import EvalReport, SampleResult
+
+        meta = _make_session_meta_helper("session-dots")
+        phase_results = [
+            PhaseResult(
+                name=ph["name"],
+                generation=ph["generation"],
+                status=ph["status"],
+                output="done",
+            )
+            for ph in phases
+        ]
+        sample = EvalSample(session=meta, phases=phase_results, findings=[], events=[])
+        return EvalReport(
+            run_id="dot-color-test",
+            aggregate_scores={},
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+
+    def test_completed_gen1_phase_has_green_dot(self, tmp_path: Path) -> None:
+        """Completed generation-1 phases should use the green status dot."""
+        from raki.report.html_report import write_html_report
+
+        report = self._make_report_with_phases(
+            [{"name": "implement", "generation": 1, "status": "completed"}]
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output, include_sessions=True)
+        content = output.read_text()
+        assert "phase-status-completed" in content
+
+    def test_rework_phase_gen2_has_rework_dot(self, tmp_path: Path) -> None:
+        """A completed phase with generation > 1 should have the rework status dot class."""
+        from raki.report.html_report import write_html_report
+
+        report = self._make_report_with_phases(
+            [{"name": "implement", "generation": 2, "status": "completed"}]
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output, include_sessions=True)
+        content = output.read_text()
+        assert "phase-status-rework" in content
+
+    def test_failed_phase_has_failed_dot(self, tmp_path: Path) -> None:
+        """Failed phases should use the red failed status dot regardless of generation."""
+        from raki.report.html_report import write_html_report
+
+        report = self._make_report_with_phases(
+            [{"name": "verify", "generation": 1, "status": "failed"}]
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output, include_sessions=True)
+        content = output.read_text()
+        assert "phase-status-failed" in content

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -2576,7 +2576,10 @@ class TestPhaseTimelineDotColoring:
         output = tmp_path / "report.html"
         write_html_report(report, output, include_sessions=True)
         content = output.read_text()
-        assert "phase-status-completed" in content
+        # Assert on the specific class attribute in the rendered <span> element, not
+        # the CSS definition (which uses a leading dot: `.phase-status-completed`).
+        assert 'class="phase-status phase-status-completed"' in content
+        assert 'class="phase-status phase-status-rework"' not in content
 
     def test_rework_phase_gen2_has_rework_dot(self, tmp_path: Path) -> None:
         """A completed phase with generation > 1 should have the rework status dot class."""
@@ -2588,7 +2591,9 @@ class TestPhaseTimelineDotColoring:
         output = tmp_path / "report.html"
         write_html_report(report, output, include_sessions=True)
         content = output.read_text()
-        assert "phase-status-rework" in content
+        # Rework dot uses phase-status-rework class, not phase-status-completed.
+        assert 'class="phase-status phase-status-rework"' in content
+        assert 'class="phase-status phase-status-completed"' not in content
 
     def test_failed_phase_has_failed_dot(self, tmp_path: Path) -> None:
         """Failed phases should use the red failed status dot regardless of generation."""
@@ -2600,4 +2605,16 @@ class TestPhaseTimelineDotColoring:
         output = tmp_path / "report.html"
         write_html_report(report, output, include_sessions=True)
         content = output.read_text()
-        assert "phase-status-failed" in content
+        assert 'class="phase-status phase-status-failed"' in content
+
+    def test_skipped_phase_has_skipped_dot(self, tmp_path: Path) -> None:
+        """Skipped phases should use the muted skipped status dot."""
+        from raki.report.html_report import write_html_report
+
+        report = self._make_report_with_phases(
+            [{"name": "monitor", "generation": 1, "status": "skipped"}]
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output, include_sessions=True)
+        content = output.read_text()
+        assert 'class="phase-status phase-status-skipped"' in content


### PR DESCRIPTION
## Summary

Fixes two issues in the HTML report's phase timeline visualization:

1. **Phase ordering** — Phases in the timeline were not sorted by their canonical pipeline position. A new `PHASE_ORDER` constant and `sort_phases()` helper ensure phases always appear in the order: triage → plan → implement → verify → review → submit → monitor. A `pipeline_phases` override from `SessionMeta` is respected when available. Unknown phases sort to the end.

2. **Rework dot coloring** — Phases that were repeated (generation > 1 and status `completed`) previously showed the same green dot as first-run completions. They now render with an amber (`#ffc107`) dot using the new `.phase-status-rework` CSS class, making rework visually distinct at a glance.

## Acceptance Criteria

- [x] `PHASE_ORDER` constant defined in `html_report.py` with canonical pipeline order
- [x] `sort_phases(phases, pipeline_phases=None)` helper sorts by position, then generation
- [x] Unknown phase names sort to end of timeline
- [x] `pipeline_phases` arg from `SessionMeta` overrides default order when provided
- [x] Jinja2 template uses `sort_phases()` when iterating phase dots
- [x] Completed gen-1 phases → green dot (`phase-status-completed`)
- [x] Completed gen>1 phases → amber dot (`phase-status-rework`, `#ffc107`)
- [x] Failed phases → red dot (`phase-status-failed`)
- [x] Skipped phases → muted dot (`phase-status-skipped`)
- [x] 9 new tests: 5 `TestSortPhases` + 4 `TestPhaseTimelineDotColoring`
- [x] All 153 `test_report_html.py` tests pass; zero existing tests modified

## Review Results

### python-specialist (IMPORTANT — fixed)
Assertions in `TestPhaseTimelineDotColoring` were vacuous: `assert "phase-status-rework" in content` matched the CSS `<style>` block (which defines `.phase-status-rework`) even when no phase dot was rendered. Fixed by asserting on the full class attribute string `class="phase-status phase-status-rework"`, which only appears in rendered `<span>` elements, not in CSS selectors. Added negative assertions to guard against future false-positives.

### rag-specialist (MINOR — addressed)
No test for skipped phase dot coloring. Added `test_skipped_phase_has_skipped_dot` to `TestPhaseTimelineDotColoring`.

---

Refs #249

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko