### PR TITLE
feat(report): structured drill-down sections in HTML report

### DIFF
--- a/changes/250.feature
+++ b/changes/250.feature
@@ -1,0 +1,5 @@
+Structured drill-down sections in the HTML report: the per-session expanded view now
+wraps **Phases**, **Findings**, and **Metrics** in individually collapsible
+``<details>`` blocks with counts in each summary label (e.g. "Phases (3)",
+"Findings (2)"). Each phase item also shows the count of tool calls used and
+a list of files modified (when ``PhaseResult.files_modified`` is populated).

--- a/changes/250.feature
+++ b/changes/250.feature
@@ -1,5 +1,5 @@
 Structured drill-down sections in the HTML report: the per-session expanded view now
 wraps **Phases**, **Findings**, and **Metrics** in individually collapsible
-``<details>`` blocks with counts in each summary label (e.g. "Phases (3)",
-"Findings (2)"). Each phase item also shows the count of tool calls used and
-a list of files modified (when ``PhaseResult.files_modified`` is populated).
+``<details>`` blocks with item counts in each summary label (e.g. "Phases (3)",
+"Findings (2)", "Metrics (4)"). Each phase item also shows the count of tool calls
+used and a list of files modified (when ``PhaseResult.files_modified`` is populated).

--- a/src/raki/report/templates/report.html.j2
+++ b/src/raki/report/templates/report.html.j2
@@ -1180,17 +1180,17 @@
       </details>
 
       {# Metrics — collapsible sub-section (closed by default) #}
-      {% if sample_result.scores and session_id in (sample_result.scores | map(attribute='sample_scores') | list | selectattr(session_id, 'defined') | list) or sample_result.scores | selectattr('sample_scores.' ~ session_id, 'defined') | list %}
-      {% endif %}
       {% set has_session_scores = namespace(value=false) %}
+      {% set session_metric_count = namespace(value=0) %}
       {% for metric_result in sample_result.scores %}
         {% if session_id in metric_result.sample_scores %}
           {% set has_session_scores.value = true %}
+          {% set session_metric_count.value = session_metric_count.value + 1 %}
         {% endif %}
       {% endfor %}
       {% if has_session_scores.value %}
       <details class="drill-down-section">
-        <summary>Metrics</summary>
+        <summary>Metrics ({{ session_metric_count.value }})</summary>
         <div class="drill-down-section-body">
         <div class="score-chips">
           {% for metric_result in sample_result.scores %}

--- a/src/raki/report/templates/report.html.j2
+++ b/src/raki/report/templates/report.html.j2
@@ -750,6 +750,74 @@
     font-style: italic;
     padding: 1rem 0;
   }
+
+  /* Drill-down sub-sections: individually collapsible sections within expanded session */
+  details.drill-down-section {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    margin: 0.5rem 0;
+    overflow: visible;
+  }
+
+  details.drill-down-section > summary {
+    padding: 0.45rem 0.75rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  details.drill-down-section > summary::before {
+    content: "▶";
+    font-size: 0.55rem;
+    margin-right: 0.2rem;
+    transition: transform 0.15s;
+    display: inline-block;
+  }
+
+  details.drill-down-section[open] > summary::before {
+    transform: rotate(90deg);
+  }
+
+  details.drill-down-section > .drill-down-section-body {
+    padding: 0.25rem 0.75rem 0.6rem;
+  }
+
+  /* Files modified within a phase item */
+  .phase-files {
+    margin: 0.2rem 0 0.2rem 1.4rem;
+    font-size: 0.8rem;
+  }
+
+  .phase-files-label {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    margin-bottom: 0.15rem;
+  }
+
+  .phase-file-item {
+    color: var(--text-secondary);
+    font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+    padding: 0.05rem 0;
+  }
+
+  /* Tool call count badge within a phase item */
+  .tool-call-count {
+    display: inline-block;
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    background: var(--bg-tertiary);
+    border-radius: 3px;
+    padding: 0.05rem 0.35rem;
+    margin-left: 0.4rem;
+    vertical-align: middle;
+  }
 </style>
 </head>
 <body>
@@ -1029,98 +1097,131 @@
         </div>
       </div>
 
-      {# Phase timeline #}
-      {% if sample.phases %}
-      <h3>Phases</h3>
-      <div class="phase-list">
-        {% for phase in sort_phases(sample.phases, sample.session.pipeline_phases) %}
-        {% set dot_class = 'rework' if phase.status == 'completed' and phase.generation > 1 else phase.status %}
-        <div class="phase-item">
-          <span class="phase-status phase-status-{{ dot_class }}"></span>
-          <span>{{ phase.name }} (gen {{ phase.generation }})</span>
-          <span style="color: var(--text-muted);">&mdash; {{ phase.status }}</span>
-          {% if phase.duration_ms is not none %}
-          <span class="phase-duration">{{ format_duration(phase.duration_ms // 1000) }}</span>
-          {% endif %}
-        </div>
-        {% if phase.output and phase.output != "<stripped>" %}
-        <details class="phase-transcript">
-          <summary>View transcript</summary>
-          <pre class="phase-transcript-content">{{ phase.output }}</pre>
-        </details>
-        {% endif %}
-        {% endfor %}
-      </div>
-      {% else %}
-      <p class="empty-state">Phase data unavailable</p>
-      {% endif %}
-
-      {# Findings #}
-      {% if sample.findings %}
-      {% set has_synthesized = sample.findings | selectattr("finding_source", "equalto", "synthesized") | list | length > 0 %}
-      <h3>Findings</h3>
-      <div class="findings-list">
-        {% for finding in sample.findings %}
-        <div class="finding-item finding-{{ finding.severity }}">
-          <div class="finding-header">
-            <span class="severity-badge severity-{{ finding.severity }}">{{ finding.severity }}</span>
-            {% if finding.finding_source == "synthesized" %}
-            <span class="severity-badge" style="background: rgba(100,100,100,0.2); color: var(--text-muted); font-size: 0.7rem;">synthesized</span>
+      {# Phase timeline — collapsible sub-section #}
+      {% set sorted_phases = sort_phases(sample.phases, sample.session.pipeline_phases) %}
+      <details class="drill-down-section" open>
+        <summary>Phases ({{ sample.phases | length }})</summary>
+        <div class="drill-down-section-body">
+        {% if sorted_phases %}
+        <div class="phase-list">
+          {% for phase in sorted_phases %}
+          {% set dot_class = 'rework' if phase.status == 'completed' and phase.generation > 1 else phase.status %}
+          <div class="phase-item">
+            <span class="phase-status phase-status-{{ dot_class }}"></span>
+            <span>{{ phase.name }} (gen {{ phase.generation }})</span>
+            <span style="color: var(--text-muted);">&mdash; {{ phase.status }}</span>
+            {% if phase.duration_ms is not none %}
+            <span class="phase-duration">{{ format_duration(phase.duration_ms // 1000) }}</span>
             {% endif %}
-            <span class="finding-issue">{{ finding.issue }}</span>
+            {% if phase.tool_calls %}
+            <span class="tool-call-count">{{ phase.tool_calls | length }} tool call{{ "s" if phase.tool_calls | length != 1 else "" }}</span>
+            {% endif %}
           </div>
-          {% if finding.file %}
-          <div class="finding-location">{{ finding.file }}{% if finding.line %}:{{ finding.line }}{% endif %}</div>
+          {% if phase.files_modified %}
+          <div class="phase-files">
+            <div class="phase-files-label">{{ phase.files_modified | length }} file{{ "s" if phase.files_modified | length != 1 else "" }} changed</div>
+            {% for fname in phase.files_modified %}
+            <div class="phase-file-item">{{ fname }}</div>
+            {% endfor %}
+          </div>
           {% endif %}
-          {% if finding.reviewer and finding.finding_source != "synthesized" %}
-          <div class="finding-reviewer">Reviewer: {{ finding.reviewer }}</div>
+          {% if phase.output and phase.output != "<stripped>" %}
+          <details class="phase-transcript">
+            <summary>View transcript</summary>
+            <pre class="phase-transcript-content">{{ phase.output }}</pre>
+          </details>
           {% endif %}
-          {% if finding.suggestion %}
-          <div class="finding-suggestion">{{ finding.suggestion }}</div>
+          {% endfor %}
+        </div>
+        {% else %}
+        <p class="empty-state">Phase data unavailable</p>
+        {% endif %}
+        </div>
+      </details>
+
+      {# Findings — collapsible sub-section #}
+      <details class="drill-down-section" open>
+        <summary>Findings ({{ sample.findings | length }})</summary>
+        <div class="drill-down-section-body">
+        {% if sample.findings %}
+        {% set has_synthesized = sample.findings | selectattr("finding_source", "equalto", "synthesized") | list | length > 0 %}
+        <div class="findings-list">
+          {% for finding in sample.findings %}
+          <div class="finding-item finding-{{ finding.severity }}">
+            <div class="finding-header">
+              <span class="severity-badge severity-{{ finding.severity }}">{{ finding.severity }}</span>
+              {% if finding.finding_source == "synthesized" %}
+              <span class="severity-badge" style="background: rgba(100,100,100,0.2); color: var(--text-muted); font-size: 0.7rem;">synthesized</span>
+              {% endif %}
+              <span class="finding-issue">{{ finding.issue }}</span>
+            </div>
+            {% if finding.file %}
+            <div class="finding-location">{{ finding.file }}{% if finding.line %}:{{ finding.line }}{% endif %}</div>
+            {% endif %}
+            {% if finding.reviewer and finding.finding_source != "synthesized" %}
+            <div class="finding-reviewer">Reviewer: {{ finding.reviewer }}</div>
+            {% endif %}
+            {% if finding.suggestion %}
+            <div class="finding-suggestion">{{ finding.suggestion }}</div>
+            {% endif %}
+          </div>
+          {% endfor %}
+        </div>
+        {% if has_synthesized %}
+        <p style="font-size: 0.8rem; color: var(--text-muted); margin-top: 0.5rem;">
+          † Synthesized findings are inferred from test/lint tool failures in the transcript.
+          They count toward severity score but are excluded from knowledge gap/miss rate and self-correction rate.
+        </p>
+        {% endif %}
+        {% else %}
+        <p class="empty-state">No review findings in this session</p>
+        {% endif %}
+        </div>
+      </details>
+
+      {# Metrics — collapsible sub-section (closed by default) #}
+      {% if sample_result.scores and session_id in (sample_result.scores | map(attribute='sample_scores') | list | selectattr(session_id, 'defined') | list) or sample_result.scores | selectattr('sample_scores.' ~ session_id, 'defined') | list %}
+      {% endif %}
+      {% set has_session_scores = namespace(value=false) %}
+      {% for metric_result in sample_result.scores %}
+        {% if session_id in metric_result.sample_scores %}
+          {% set has_session_scores.value = true %}
+        {% endif %}
+      {% endfor %}
+      {% if has_session_scores.value %}
+      <details class="drill-down-section">
+        <summary>Metrics</summary>
+        <div class="drill-down-section-body">
+        <div class="score-chips">
+          {% for metric_result in sample_result.scores %}
+          {% if session_id in metric_result.sample_scores %}
+          {% set session_score = metric_result.sample_scores[session_id] %}
+          <span class="score-chip">
+            <span class="chip-name">{{ metric_result.name }}</span>
+            <span class="chip-value {{ color_class(session_score, metric_result.name) }}">{{ "%.2f"|format(session_score) }}</span>
+          </span>
+          {% endif %}
+          {% endfor %}
+        </div>
+
+        {# Faithfulness breakdown #}
+        {% for metric_result in sample_result.scores %}
+        {% if metric_result.name == "faithfulness" and metric_result.details %}
+        <div class="faithfulness-detail">
+          <span class="claims-label">Faithfulness Claims:</span>
+          {% if "claims_verified" in metric_result.details and "claims_total" in metric_result.details %}
+          {{ metric_result.details["claims_verified"] }} / {{ metric_result.details["claims_total"] }} claims verified
+          {% else %}
+          {% for detail_key, detail_val in metric_result.details.items() %}
+          {{ detail_key }}: {{ detail_val }}{% if not loop.last %}, {% endif %}
+          {% endfor %}
           {% endif %}
         </div>
-        {% endfor %}
-      </div>
-      {% if has_synthesized %}
-      <p style="font-size: 0.8rem; color: var(--text-muted); margin-top: 0.5rem;">
-        † Synthesized findings are inferred from test/lint tool failures in the transcript.
-        They count toward severity score but are excluded from knowledge gap/miss rate and self-correction rate.
-      </p>
-      {% endif %}
-      {% else %}
-      <p class="empty-state">No review findings in this session</p>
-      {% endif %}
-
-      {# Score chips #}
-      {% if sample_result.scores %}
-      <div class="score-chips">
-        {% for metric_result in sample_result.scores %}
-        {% if session_id in metric_result.sample_scores %}
-        {% set session_score = metric_result.sample_scores[session_id] %}
-        <span class="score-chip">
-          <span class="chip-name">{{ metric_result.name }}</span>
-          <span class="chip-value {{ color_class(session_score, metric_result.name) }}">{{ "%.2f"|format(session_score) }}</span>
-        </span>
         {% endif %}
         {% endfor %}
-      </div>
+        </div>
+      </details>
       {% endif %}
-
-      {# Faithfulness breakdown #}
-      {% for metric_result in sample_result.scores %}
-      {% if metric_result.name == "faithfulness" and metric_result.details %}
-      <div class="faithfulness-detail">
-        <span class="claims-label">Faithfulness Claims:</span>
-        {% if "claims_verified" in metric_result.details and "claims_total" in metric_result.details %}
-        {{ metric_result.details["claims_verified"] }} / {{ metric_result.details["claims_total"] }} claims verified
-        {% else %}
-        {% for detail_key, detail_val in metric_result.details.items() %}
-        {{ detail_key }}: {{ detail_val }}{% if not loop.last %}, {% endif %}
-        {% endfor %}
-        {% endif %}
-      </div>
-      {% endif %}
-      {% endfor %}
     </div>
   </details>
   {% endmacro %}

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -2618,3 +2618,290 @@ class TestPhaseTimelineDotColoring:
         write_html_report(report, output, include_sessions=True)
         content = output.read_text()
         assert 'class="phase-status phase-status-skipped"' in content
+
+
+# --- Ticket #250: Structured drill-down sections ---
+
+
+class TestDrillDownSubSections:
+    """Drill-down expanded view wraps Phases, Findings, and Metrics in collapsible <details>."""
+
+    def test_drill_down_section_class_present(self, tmp_path: Path) -> None:
+        """Expanded drill-down should use drill-down-section class for sub-sections."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "drill-down-section" in content
+
+    def test_phases_subsection_is_collapsible(self, tmp_path: Path) -> None:
+        """The Phases sub-section in the drill-down should use a <details> element."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # There should be a details.drill-down-section element containing phase info
+        assert "drill-down-section" in content
+        # The phases sub-section should have a summary label containing "Phases"
+        assert "Phases" in content
+
+    def test_findings_subsection_is_collapsible(self, tmp_path: Path) -> None:
+        """The Findings sub-section in the drill-down should use a <details> element."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # The findings sub-section should have a summary label containing "Findings"
+        assert "Findings" in content
+        assert "drill-down-section" in content
+
+    def test_phases_count_in_summary_label(self, tmp_path: Path) -> None:
+        """Phase sub-section summary should include the phase count like 'Phases (2)'."""
+        from raki.model.phases import PhaseResult
+        from raki.model.report import EvalReport, SampleResult
+        from raki.report.html_report import write_html_report
+
+        meta = _make_session_meta_helper("session-phasecount")
+        phases = [
+            PhaseResult(name="implement", generation=1, status="completed", output="done"),
+            PhaseResult(name="verify", generation=1, status="completed", output="PASS"),
+        ]
+        sample = EvalSample(session=meta, phases=phases, findings=[], events=[])
+        report = EvalReport(
+            run_id="phase-count-test",
+            aggregate_scores={},
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # The Phases sub-section summary should include the count (2)
+        assert "Phases (2)" in content
+
+    def test_findings_count_in_summary_label(self, tmp_path: Path) -> None:
+        """Findings sub-section summary should include the finding count like 'Findings (2)'."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # session-alpha has 2 findings
+        assert "Findings (2)" in content
+
+    def test_metrics_subsection_present_when_scores_exist(self, tmp_path: Path) -> None:
+        """When sample_result has scores, a Metrics sub-section should be present."""
+        from raki.report.html_report import write_html_report
+
+        report = _make_report_with_samples()
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # There should be a Metrics section with score chips
+        assert "Metrics" in content
+
+    def test_no_findings_section_when_empty(self, tmp_path: Path) -> None:
+        """When a session has no findings, the Findings sub-section should show empty state."""
+        from raki.report.html_report import write_html_report
+
+        clean_sample = make_sample("s-no-findings", rework_cycles=0, cost=5.0)
+        report = EvalReport(
+            run_id="no-findings-test",
+            aggregate_scores={},
+            sample_results=[SampleResult(sample=clean_sample, scores=[])],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "No review findings" in content
+
+
+class TestDrillDownFilesModified:
+    """Files-modified section appears in each phase item when PhaseResult.files_modified is set."""
+
+    def _make_report_with_files(
+        self,
+        session_id: str,
+        files: list[str],
+    ) -> EvalReport:
+        """Build a report with a phase that has files_modified populated."""
+        from raki.model.phases import PhaseResult
+        from raki.model.report import EvalReport, SampleResult
+
+        meta = _make_session_meta_helper(session_id)
+        phases = [
+            PhaseResult(
+                name="implement",
+                generation=1,
+                status="completed",
+                output="done",
+                files_modified=files,
+            ),
+        ]
+        sample = EvalSample(session=meta, phases=phases, findings=[], events=[])
+        return EvalReport(
+            run_id="files-test",
+            aggregate_scores={},
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+
+    def test_files_modified_shown_when_present(self, tmp_path: Path) -> None:
+        """When phase has files_modified, the file names should appear in the HTML drill-down."""
+        from raki.report.html_report import write_html_report
+
+        report = self._make_report_with_files(
+            "session-files-01",
+            ["src/raki/cli.py", "tests/test_cli.py"],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "src/raki/cli.py" in content
+        assert "tests/test_cli.py" in content
+
+    def test_no_files_section_when_empty(self, tmp_path: Path) -> None:
+        """When phase has no files_modified, no files list should appear in the drill-down."""
+        from raki.model.phases import PhaseResult
+        from raki.model.report import EvalReport, SampleResult
+        from raki.report.html_report import write_html_report
+
+        meta = _make_session_meta_helper("session-no-files")
+        phases = [
+            PhaseResult(
+                name="implement",
+                generation=1,
+                status="completed",
+                output="done",
+                files_modified=[],
+            ),
+        ]
+        sample = EvalSample(session=meta, phases=phases, findings=[], events=[])
+        report = EvalReport(
+            run_id="no-files-test",
+            aggregate_scores={},
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # The phase-file-item element should not appear when files_modified is empty
+        # (the CSS class definition may still be in the <style> block, so check for the element)
+        assert 'class="phase-file-item"' not in content
+
+    def test_files_use_phase_files_class(self, tmp_path: Path) -> None:
+        """Files modified list should use the phase-files CSS class."""
+        from raki.report.html_report import write_html_report
+
+        report = self._make_report_with_files(
+            "session-files-css",
+            ["main.py"],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "phase-files" in content
+
+    def test_files_count_in_label(self, tmp_path: Path) -> None:
+        """The files-modified section label should include the file count."""
+        from raki.report.html_report import write_html_report
+
+        report = self._make_report_with_files(
+            "session-files-count",
+            ["a.py", "b.py", "c.py"],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Should show count "3 files" or "Files (3)"
+        assert "3 file" in content or "files (3)" in content.lower()
+
+
+class TestDrillDownToolCallCount:
+    """Tool-call count badge appears on phase items when PhaseResult.tool_calls is non-empty."""
+
+    def _make_report_with_tool_calls(
+        self,
+        session_id: str,
+        tool_call_count: int,
+    ) -> EvalReport:
+        """Build a report with a phase that has tool_calls populated."""
+        from raki.model.phases import PhaseResult, ToolCall
+        from raki.model.report import EvalReport, SampleResult
+
+        meta = _make_session_meta_helper(session_id)
+        tool_calls = [
+            ToolCall(name=f"tool_{idx}", arguments={"arg": idx}) for idx in range(tool_call_count)
+        ]
+        phases = [
+            PhaseResult(
+                name="implement",
+                generation=1,
+                status="completed",
+                output="done",
+                tool_calls=tool_calls,
+            ),
+        ]
+        sample = EvalSample(session=meta, phases=phases, findings=[], events=[])
+        return EvalReport(
+            run_id="tool-call-test",
+            aggregate_scores={},
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+
+    def test_tool_call_count_shown_when_present(self, tmp_path: Path) -> None:
+        """When phase has tool_calls, the count should appear in the phase item."""
+        from raki.report.html_report import write_html_report
+
+        report = self._make_report_with_tool_calls("session-tools-01", tool_call_count=5)
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # Should show "5 tool calls" or "5 calls" or similar
+        assert "5" in content
+        assert "tool" in content.lower() or "call" in content.lower()
+
+    def test_no_tool_count_when_empty(self, tmp_path: Path) -> None:
+        """When phase has no tool_calls, no tool count badge should appear."""
+        from raki.model.phases import PhaseResult
+        from raki.model.report import EvalReport, SampleResult
+        from raki.report.html_report import write_html_report
+
+        meta = _make_session_meta_helper("session-no-tools")
+        phases = [
+            PhaseResult(
+                name="implement",
+                generation=1,
+                status="completed",
+                output="done",
+                tool_calls=[],
+            ),
+        ]
+        sample = EvalSample(session=meta, phases=phases, findings=[], events=[])
+        report = EvalReport(
+            run_id="no-tools-test",
+            aggregate_scores={},
+            sample_results=[SampleResult(sample=sample, scores=[])],
+        )
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        # The tool-call-count element should not appear when tool_calls is empty.
+        # The CSS class definition may be present in the <style> block, so check
+        # that no actual HTML element uses the class.
+        assert 'class="tool-call-count"' not in content
+
+    def test_tool_call_count_uses_css_class(self, tmp_path: Path) -> None:
+        """Tool call count badge should use the tool-call-count CSS class."""
+        from raki.report.html_report import write_html_report
+
+        report = self._make_report_with_tool_calls("session-tools-css", tool_call_count=3)
+        output = tmp_path / "report.html"
+        write_html_report(report, output)
+        content = output.read_text()
+        assert "tool-call-count" in content

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -2862,9 +2862,9 @@ class TestDrillDownToolCallCount:
         output = tmp_path / "report.html"
         write_html_report(report, output)
         content = output.read_text()
-        # Should show "5 tool calls" or "5 calls" or similar
-        assert "5" in content
-        assert "tool" in content.lower() or "call" in content.lower()
+        # Should show "5 tool calls" — match the exact rendered phrase for precision
+        assert "5 tool calls" in content
+        assert 'class="tool-call-count"' in content
 
     def test_no_tool_count_when_empty(self, tmp_path: Path) -> None:
         """When phase has no tool_calls, no tool count badge should appear."""


### PR DESCRIPTION
## Summary

Adds structured collapsible sub-sections within the per-session drill-down expanded view in the HTML report. Each section is wrapped in a `<details class="drill-down-section">` element with a count in the summary label:

- **Phases (n)**: wraps the phase timeline, open by default
- **Findings (n)**: wraps the findings list, open by default
- **Metrics (n)**: wraps per-session score chips, closed by default

Phase items are enhanced with:
- **Tool call count badge** (`.tool-call-count`) shown when `PhaseResult.tool_calls` is non-empty
- **Files-modified list** (`.phase-files`) with file count label when `PhaseResult.files_modified` is populated

## Acceptance Criteria

- [x] Phases, Findings, and Metrics sections are individually collapsible via `<details>`
- [x] Each summary label includes a count (e.g. `Phases (3)`, `Findings (2)`, `Metrics (4)`)
- [x] Phases and Findings are open by default; Metrics is closed by default
- [x] Tool call count badge appears when `PhaseResult.tool_calls` is non-empty
- [x] Files-modified list appears when `PhaseResult.files_modified` is populated
- [x] 14 new tests added, all passing (1569 total, no regressions)

## Review Results

### python-specialist

| # | Severity | Finding | Resolution |
|---|----------|---------|------------|
| 1 | IMPORTANT | Dead no-op Jinja2 block (empty `{% if %}{% endif %}` with broken `selectattr` expression) at line 1183 | ✅ Fixed — removed dead block entirely |
| 2 | MINOR | Weak assertion in `test_tool_call_count_shown_when_present`: `'5' in content` can match unrelated numbers | ✅ Fixed — now asserts `'5 tool calls' in content` and `'class="tool-call-count"' in content` |
| 3 | MINOR | Changelog says 'counts in each summary label' but Metrics rendered as plain 'Metrics' without a count | ✅ Fixed — Metrics summary now renders as `Metrics (n)` |

### rag-specialist

| # | Severity | Finding | Resolution |
|---|----------|---------|------------|
| 4 | MINOR | Same dead no-op block as Finding 1 | ✅ Fixed (same fix as #1) |
| 5 | MINOR | Inconsistent summary label: Metrics had no count unlike Phases/Findings | ✅ Fixed (same fix as #3) |

## Files Changed

| File | Action |
|------|--------|
| `src/raki/report/templates/report.html.j2` | Modified — CSS + drill-down macros; removed dead block; added metric count to Metrics summary |
| `tests/test_report_html.py` | Modified — 14 new tests; strengthened `tool_call_count` assertion |
| `changes/250.feature` | Created — towncrier changelog fragment |

Refs #250

---
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko