### PR TITLE
feat(metrics): persist per-sample metric scores in JSON report

### DIFF
--- a/changes/259.feature
+++ b/changes/259.feature
@@ -1,0 +1,4 @@
+Added ``reaggregate_scores()`` utility in ``raki.metrics`` that computes
+dataset-level mean scores from per-sample ``SampleResult.scores``,
+enabling downstream consumers to re-derive aggregate metrics from saved
+JSON reports without re-running the metrics engine.

--- a/src/raki/metrics/__init__.py
+++ b/src/raki/metrics/__init__.py
@@ -1,4 +1,5 @@
 from raki.metrics.engine import MetricsEngine
 from raki.metrics.protocol import Metric, MetricConfig
+from raki.metrics.reaggregate import reaggregate_scores
 
-__all__ = ["Metric", "MetricConfig", "MetricsEngine"]
+__all__ = ["Metric", "MetricConfig", "MetricsEngine", "reaggregate_scores"]

--- a/src/raki/metrics/reaggregate.py
+++ b/src/raki/metrics/reaggregate.py
@@ -1,0 +1,68 @@
+"""Reaggregate per-sample metric scores into dataset-level means.
+
+Per-session scores already exist in ``SampleResult.scores`` after
+``MetricsEngine.run()`` populates them via ``_build_sample_results()``.
+This utility collects those scores by metric name and computes their mean,
+reproducing the dataset-level aggregate from the per-sample breakdown.
+
+Limitations
+-----------
+- **review_severity_distribution**: This metric is aggregate-only — it
+  computes a single weighted score over all findings in the dataset and does
+  *not* populate ``sample_scores``.  Consequently it is absent from every
+  ``SampleResult.scores`` list and will not appear in the output of
+  ``reaggregate_scores()``.
+
+- **self_correction_rate**: The engine computes this as
+  ``resolved_findings / total_rework_findings`` — a ratio-of-sums across all
+  rework sessions.  ``reaggregate_scores()`` instead computes the
+  *mean of per-session scores* (each session contributes 0.0 or 1.0),
+  which gives a different result when sessions have unequal finding counts.
+  The two values converge only when every rework session has exactly one
+  finding.  Downstream consumers should be aware of this discrepancy when
+  comparing reaggregated output against engine aggregate_scores.
+"""
+
+from raki.model.report import SampleResult
+
+
+def reaggregate_scores(sample_results: list[SampleResult]) -> dict[str, float | None]:
+    """Reaggregate per-sample metric scores into dataset-level means.
+
+    For each metric name that appears in any ``SampleResult.scores`` list:
+
+    - Collect all non-``None`` scores from the samples that include that metric.
+    - Return the arithmetic mean of those scores, or ``None`` when every
+      score for the metric is ``None`` (or the metric appears nowhere).
+
+    Metrics absent from a given sample are treated the same as a ``None``
+    score for that sample: they are simply skipped and do not affect the mean.
+
+    Parameters
+    ----------
+    sample_results:
+        Sequence of per-session results as returned by
+        ``MetricsEngine.run().sample_results``.
+
+    Returns
+    -------
+    dict[str, float | None]
+        Mapping of metric name → mean score (or ``None`` when no non-``None``
+        scores were found).  Returns an empty dict when *sample_results* is
+        empty.
+    """
+    all_metric_names: set[str] = set()
+    scores_by_metric: dict[str, list[float]] = {}
+
+    for sample_result in sample_results:
+        for metric_result in sample_result.scores:
+            all_metric_names.add(metric_result.name)
+            if metric_result.score is not None:
+                scores_by_metric.setdefault(metric_result.name, []).append(metric_result.score)
+
+    result: dict[str, float | None] = {}
+    for metric_name in all_metric_names:
+        scores = scores_by_metric.get(metric_name, [])
+        result[metric_name] = sum(scores) / len(scores) if scores else None
+
+    return result

--- a/tests/test_reaggregate.py
+++ b/tests/test_reaggregate.py
@@ -148,6 +148,8 @@ def test_round_trip_reaggregated_matches_engine_aggregate():
         "cost_efficiency",
         "phase_execution_time",
         "token_efficiency",
+        "triage_calibration",
+        "file_prediction_accuracy",
     ]
 
     for metric_name in roundtrip_metrics:

--- a/tests/test_reaggregate.py
+++ b/tests/test_reaggregate.py
@@ -1,0 +1,103 @@
+"""Tests for reaggregate_scores() utility function.
+
+6 unit tests covering: known scores, None handling, all-None edge case,
+missing metrics, empty input, single session.
+"""
+
+import pytest
+
+from conftest import make_sample
+from raki.metrics.reaggregate import reaggregate_scores
+from raki.model.report import MetricResult, SampleResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_sample_result(
+    session_id: str,
+    scores: list[tuple[str, float | None]],
+) -> SampleResult:
+    """Build a SampleResult with the given per-metric scores."""
+    sample = make_sample(session_id)
+    metric_results = [MetricResult(name=name, score=score) for name, score in scores]
+    return SampleResult(sample=sample, scores=metric_results)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (Task 1)
+# ---------------------------------------------------------------------------
+
+
+def test_known_scores_computes_correct_mean():
+    """Mean of known scores must be computed correctly across sessions."""
+    sample_results = [
+        make_sample_result("s1", [("rework_cycles", 0.0), ("cost_efficiency", 10.0)]),
+        make_sample_result("s2", [("rework_cycles", 2.0), ("cost_efficiency", 20.0)]),
+        make_sample_result("s3", [("rework_cycles", 1.0), ("cost_efficiency", 15.0)]),
+    ]
+    result = reaggregate_scores(sample_results)
+
+    assert result["rework_cycles"] == pytest.approx(1.0)  # (0+2+1)/3
+    assert result["cost_efficiency"] == pytest.approx(15.0)  # (10+20+15)/3
+
+
+def test_none_scores_are_skipped_from_mean():
+    """None scores for a metric are excluded from the mean calculation."""
+    sample_results = [
+        make_sample_result("s1", [("first_pass_success_rate", 1.0)]),
+        make_sample_result("s2", [("first_pass_success_rate", None)]),
+        make_sample_result("s3", [("first_pass_success_rate", 0.0)]),
+    ]
+    result = reaggregate_scores(sample_results)
+
+    # Only s1 (1.0) and s3 (0.0) contribute; s2 is skipped
+    assert result["first_pass_success_rate"] == pytest.approx(0.5)
+
+
+def test_all_none_scores_returns_none():
+    """When every score for a metric is None, reaggregate_scores returns None."""
+    sample_results = [
+        make_sample_result("s1", [("self_correction_rate", None)]),
+        make_sample_result("s2", [("self_correction_rate", None)]),
+    ]
+    result = reaggregate_scores(sample_results)
+
+    assert result["self_correction_rate"] is None
+
+
+def test_missing_metric_uses_only_present_samples():
+    """A metric absent from some samples is averaged over those that do have it."""
+    sample_results = [
+        make_sample_result("s1", [("rework_cycles", 2.0)]),
+        make_sample_result("s2", [("rework_cycles", 4.0), ("cost_efficiency", 20.0)]),
+        make_sample_result("s3", [("cost_efficiency", 10.0)]),
+    ]
+    result = reaggregate_scores(sample_results)
+
+    # rework_cycles only in s1 and s2 -> (2+4)/2 = 3.0
+    assert result["rework_cycles"] == pytest.approx(3.0)
+    # cost_efficiency only in s2 and s3 -> (20+10)/2 = 15.0
+    assert result["cost_efficiency"] == pytest.approx(15.0)
+
+
+def test_empty_sample_results_returns_empty_dict():
+    """An empty list of SampleResults produces an empty dict."""
+    result = reaggregate_scores([])
+    assert result == {}
+
+
+def test_single_session_returns_its_scores():
+    """A single SampleResult with non-None scores returns those scores unchanged."""
+    sample_results = [
+        make_sample_result(
+            "s1",
+            [("rework_cycles", 3.0), ("cost_efficiency", 42.0)],
+        )
+    ]
+    result = reaggregate_scores(sample_results)
+
+    assert result["rework_cycles"] == pytest.approx(3.0)
+    assert result["cost_efficiency"] == pytest.approx(42.0)

--- a/tests/test_reaggregate.py
+++ b/tests/test_reaggregate.py
@@ -101,3 +101,72 @@ def test_single_session_returns_its_scores():
 
     assert result["rework_cycles"] == pytest.approx(3.0)
     assert result["cost_efficiency"] == pytest.approx(42.0)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip integration test (Task 2)
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_reaggregated_matches_engine_aggregate():
+    """reaggregate_scores(report.sample_results) must match report.aggregate_scores
+    for all metrics that support per-sample scoring.
+
+    Metrics explicitly skipped:
+    - review_severity_distribution: aggregate-only (no sample_scores), absent from
+      sample_results.scores and therefore from reaggregated output.
+    - self_correction_rate: ratio-of-sums (resolved/total across all sessions) vs
+      mean-of-ratios (mean of per-session 0.0/1.0), which differ when sessions have
+      unequal finding counts.
+    """
+    from conftest import make_dataset
+
+    from raki.metrics.engine import MetricsEngine
+    from raki.metrics.operational import ALL_OPERATIONAL
+
+    samples = [
+        make_sample(
+            "s1", rework_cycles=0, cost=10.0, duration_ms=3000, tokens_in=500, tokens_out=200
+        ),
+        make_sample(
+            "s2", rework_cycles=2, cost=20.0, duration_ms=6000, tokens_in=1000, tokens_out=400
+        ),
+        make_sample(
+            "s3", rework_cycles=0, cost=15.0, duration_ms=4500, tokens_in=750, tokens_out=300
+        ),
+    ]
+    dataset = make_dataset(*samples)
+    engine = MetricsEngine(metrics=ALL_OPERATIONAL)
+    report = engine.run(dataset, skip_judge=True)
+
+    reaggregated = reaggregate_scores(report.sample_results)
+
+    # Metrics that support per-sample scores and round-trip cleanly
+    roundtrip_metrics = [
+        "first_pass_success_rate",
+        "rework_cycles",
+        "cost_efficiency",
+        "phase_execution_time",
+        "token_efficiency",
+    ]
+
+    for metric_name in roundtrip_metrics:
+        if metric_name not in report.aggregate_scores:
+            continue  # metric was skipped (e.g., requires ground truth)
+        engine_score = report.aggregate_scores[metric_name]
+        reagg_score = reaggregated.get(metric_name)
+
+        if engine_score is None:
+            assert reagg_score is None, f"{metric_name}: engine=None but reaggregated={reagg_score}"
+        else:
+            assert reagg_score is not None, (
+                f"{metric_name}: engine={engine_score} but reaggregated=None"
+            )
+            assert reagg_score == pytest.approx(engine_score, rel=1e-6), (
+                f"{metric_name}: engine={engine_score} != reaggregated={reagg_score}"
+            )
+
+    # Aggregate-only metrics must be absent from reaggregated output
+    assert "review_severity_distribution" not in reaggregated, (
+        "review_severity_distribution is aggregate-only; must not appear in reaggregated output"
+    )


### PR DESCRIPTION
## Summary

Adds `reaggregate_scores()` utility function in `raki.metrics` that derives dataset-level aggregate scores from per-sample `SampleResult.scores`, enabling downstream consumers to re-derive aggregate metrics from saved JSON reports without re-running the metrics engine.

### Changes

- **`src/raki/metrics/reaggregate.py`** (new): Pure utility function collecting per-sample scores, skipping `None` values from means, returning `None` for fully-absent metrics. Docstring documents `review_severity_distribution` and `self_correction_rate` limitations.
- **`src/raki/metrics/__init__.py`** (modified): Exports `reaggregate_scores`.
- **`tests/test_reaggregate.py`** (new): 7 tests — 6 unit tests (known scores, None skipping, all-None → None, missing metrics, empty input, single session) + round-trip integration test verifying reaggregated output matches engine aggregate for all per-sample metrics.
- **`changes/259.feature`** (new): Towncrier changelog fragment.

## Acceptance Criteria

- [x] `reaggregate_scores()` collects per-sample scores from `SampleResult.scores`
- [x] `None` scores are skipped from mean calculation
- [x] Fully-absent metrics return `None`
- [x] Missing metrics across samples use only present samples
- [x] Round-trip: `reaggregate_scores(report.sample_results)` matches `report.aggregate_scores` for all per-sample metrics
- [x] `review_severity_distribution` (aggregate-only) absent from reaggregated output
- [x] `triage_calibration` and `file_prediction_accuracy` covered in round-trip test
- [x] All 1590 existing tests pass (+ 3 skipped, 4 deselected)
- [x] Towncrier fragment valid

## Review Results

### rag-specialist — MINOR (addressed)

**Finding**: Round-trip test omitted `triage_calibration` and `file_prediction_accuracy` from `roundtrip_metrics`. Both metrics populate `sample_scores` and should round-trip correctly.

**Resolution**: Added both metrics to the `roundtrip_metrics` list in the integration test (commit `f58a474`). The existing `if metric_name not in report.aggregate_scores: continue` guard handles absence of these metrics in test data.

Refs #259

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Assigned-by: decko